### PR TITLE
Add required field to tool input

### DIFF
--- a/src/main/kotlin/io/modelcontextprotocol/kotlin/sdk/types.kt
+++ b/src/main/kotlin/io/modelcontextprotocol/kotlin/sdk/types.kt
@@ -1003,6 +1003,7 @@ public data class Tool(
     @Serializable
     public data class Input(
         val properties: JsonObject = EmptyJsonObject,
+        val required: List<String>? = null,
     ) {
         val type: String = "object"
     }


### PR DESCRIPTION
According to the schema https://github.com/modelcontextprotocol/specification/blob/main/schema/schema.json, tool's inputSchema should have 'required' field with a list of required property names.