### PR TITLE
Accept requestID as a string, fix #25

### DIFF
--- a/src/main/kotlin/io/modelcontextprotocol/kotlin/sdk/shared/Protocol.kt
+++ b/src/main/kotlin/io/modelcontextprotocol/kotlin/sdk/shared/Protocol.kt
@@ -15,6 +15,7 @@ import io.modelcontextprotocol.kotlin.sdk.PingRequest
 import io.modelcontextprotocol.kotlin.sdk.Progress
 import io.modelcontextprotocol.kotlin.sdk.ProgressNotification
 import io.modelcontextprotocol.kotlin.sdk.Request
+import io.modelcontextprotocol.kotlin.sdk.RequestId
 import io.modelcontextprotocol.kotlin.sdk.RequestResult
 import io.modelcontextprotocol.kotlin.sdk.fromJSON
 import io.modelcontextprotocol.kotlin.sdk.toJSON
@@ -119,11 +120,11 @@ public abstract class Protocol<SendRequestT : Request, SendNotificationT : Notif
         mutableMapOf()
 
     @PublishedApi
-    internal val responseHandlers: MutableMap<Long, (response: JSONRPCResponse?, error: Exception?) -> Unit> =
+    internal val responseHandlers: MutableMap<RequestId, (response: JSONRPCResponse?, error: Exception?) -> Unit> =
         mutableMapOf()
 
     @PublishedApi
-    internal val progressHandlers: MutableMap<Long, ProgressCallback> = mutableMapOf()
+    internal val progressHandlers: MutableMap<RequestId, ProgressCallback> = mutableMapOf()
 
     /**
      * Callback for when the connection is closed for any reason.

--- a/src/main/kotlin/io/modelcontextprotocol/kotlin/sdk/types.kt
+++ b/src/main/kotlin/io/modelcontextprotocol/kotlin/sdk/types.kt
@@ -25,7 +25,7 @@ private val REQUEST_MESSAGE_ID = AtomicLong(0L)
  * A progress token, used to associate progress notifications with the original request.
  * Stores message ID.
  */
-public typealias ProgressToken = Long
+public typealias ProgressToken = RequestId
 
 /**
  * An opaque token used to represent a cursor for pagination.
@@ -191,7 +191,14 @@ public data class EmptyRequestResult(
 /**
  * A uniquely identifying ID for a request in JSON-RPC.
  */
-public typealias RequestId = Long
+@Serializable(with = RequestIdSerializer::class)
+public sealed interface RequestId {
+    @Serializable
+    public data class StringId(val value: String) : RequestId
+
+    @Serializable
+    public data class NumberId(val value: Long) : RequestId
+}
 
 /**
  * Represents a JSON-RPC message in the protocol.
@@ -204,7 +211,7 @@ public sealed interface JSONRPCMessage
  */
 @Serializable
 public data class JSONRPCRequest(
-    val id: RequestId = REQUEST_MESSAGE_ID.incrementAndGet(),
+    val id: RequestId = RequestId.NumberId(REQUEST_MESSAGE_ID.incrementAndGet()),
     val method: String,
     val params: JsonElement? = null,
     val jsonrpc: String = JSONRPC_VERSION,

--- a/src/test/kotlin/client/TypesTest.kt
+++ b/src/test/kotlin/client/TypesTest.kt
@@ -24,4 +24,24 @@ class TypesTest {
         val line = "{\"result\":{\"content\":[{\"type\":\"text\"}],\"isError\":false},\"jsonrpc\":\"2.0\",\"id\":4}"
         McpJson.decodeFromString<JSONRPCMessage>(line)
     }
+
+    @Test
+    fun testJSONRPCMessageWithStringId() {
+        val line = """
+            {
+              "jsonrpc": "2.0",
+              "method": "initialize",
+              "id": "ebf9f64a-0",
+              "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {
+                  "name": "mcp-java-client",
+                  "version": "0.2.0"
+                }
+              }
+            }
+        """.trimIndent()
+        McpJson.decodeFromString<JSONRPCMessage>(line)
+    }
 }


### PR DESCRIPTION
This change updates the handling of `requestID` by accepting it as a string. This ensures greater flexibility and compatibility with varying input formats.

## Motivation and Context
This change solves inconsistencies with the data type handling of `requestID` across different implementations, improving system robustness.

## How Has This Been Tested?
The change was tested in a controlled environment with various string inputs to verify compatibility and correctness. Scenarios with incorrect formats were tested to ensure proper error handling.

## Breaking Changes
~No breaking changes are introduced.~

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
No additional context.