### PR TITLE
Drop generics from Protocol class

### DIFF
--- a/src/main/kotlin/io/modelcontextprotocol/kotlin/sdk/client/Client.kt
+++ b/src/main/kotlin/io/modelcontextprotocol/kotlin/sdk/client/Client.kt
@@ -1,42 +1,7 @@
 package io.modelcontextprotocol.kotlin.sdk.client
 
-import io.modelcontextprotocol.kotlin.sdk.CallToolRequest
-import io.modelcontextprotocol.kotlin.sdk.CallToolResult
-import io.modelcontextprotocol.kotlin.sdk.CallToolResultBase
-import io.modelcontextprotocol.kotlin.sdk.ClientCapabilities
-import io.modelcontextprotocol.kotlin.sdk.ClientNotification
-import io.modelcontextprotocol.kotlin.sdk.ClientRequest
-import io.modelcontextprotocol.kotlin.sdk.ClientResult
-import io.modelcontextprotocol.kotlin.sdk.CompatibilityCallToolResult
-import io.modelcontextprotocol.kotlin.sdk.CompleteRequest
-import io.modelcontextprotocol.kotlin.sdk.CompleteResult
-import io.modelcontextprotocol.kotlin.sdk.EmptyRequestResult
-import io.modelcontextprotocol.kotlin.sdk.GetPromptRequest
-import io.modelcontextprotocol.kotlin.sdk.GetPromptResult
-import io.modelcontextprotocol.kotlin.sdk.Implementation
-import io.modelcontextprotocol.kotlin.sdk.InitializeRequest
-import io.modelcontextprotocol.kotlin.sdk.InitializeResult
-import io.modelcontextprotocol.kotlin.sdk.InitializedNotification
-import io.modelcontextprotocol.kotlin.sdk.LATEST_PROTOCOL_VERSION
-import io.modelcontextprotocol.kotlin.sdk.ListPromptsRequest
-import io.modelcontextprotocol.kotlin.sdk.ListPromptsResult
-import io.modelcontextprotocol.kotlin.sdk.ListResourceTemplatesRequest
-import io.modelcontextprotocol.kotlin.sdk.ListResourceTemplatesResult
-import io.modelcontextprotocol.kotlin.sdk.ListResourcesRequest
-import io.modelcontextprotocol.kotlin.sdk.ListResourcesResult
-import io.modelcontextprotocol.kotlin.sdk.ListToolsRequest
-import io.modelcontextprotocol.kotlin.sdk.ListToolsResult
-import io.modelcontextprotocol.kotlin.sdk.LoggingLevel
+import io.modelcontextprotocol.kotlin.sdk.*
 import io.modelcontextprotocol.kotlin.sdk.LoggingMessageNotification.SetLevelRequest
-import io.modelcontextprotocol.kotlin.sdk.Method
-import io.modelcontextprotocol.kotlin.sdk.PingRequest
-import io.modelcontextprotocol.kotlin.sdk.ReadResourceRequest
-import io.modelcontextprotocol.kotlin.sdk.ReadResourceResult
-import io.modelcontextprotocol.kotlin.sdk.RootsListChangedNotification
-import io.modelcontextprotocol.kotlin.sdk.SUPPORTED_PROTOCOL_VERSIONS
-import io.modelcontextprotocol.kotlin.sdk.ServerCapabilities
-import io.modelcontextprotocol.kotlin.sdk.SubscribeRequest
-import io.modelcontextprotocol.kotlin.sdk.UnsubscribeRequest
 import io.modelcontextprotocol.kotlin.sdk.shared.Protocol
 import io.modelcontextprotocol.kotlin.sdk.shared.ProtocolOptions
 import io.modelcontextprotocol.kotlin.sdk.shared.RequestOptions
@@ -45,6 +10,7 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+
 /**
  * Options for configuring the MCP client.
  *
@@ -70,7 +36,7 @@ public class ClientOptions(
 public open class Client(
     private val clientInfo: Implementation,
     options: ClientOptions = ClientOptions(),
-) : Protocol<ClientRequest, ClientNotification, ClientResult>(options) {
+) : Protocol(options) {
 
     private var serverCapabilities: ServerCapabilities? = null
     private var serverVersion: Implementation? = null

--- a/src/main/kotlin/io/modelcontextprotocol/kotlin/sdk/server/Server.kt
+++ b/src/main/kotlin/io/modelcontextprotocol/kotlin/sdk/server/Server.kt
@@ -1,13 +1,12 @@
 package io.modelcontextprotocol.kotlin.sdk.server
 
 import io.github.oshai.kotlinlogging.KotlinLogging
-import io.modelcontextprotocol.kotlin.sdk.ServerCapabilities
-import kotlinx.coroutines.CompletableDeferred
-import kotlinx.serialization.json.JsonObject
 import io.modelcontextprotocol.kotlin.sdk.*
 import io.modelcontextprotocol.kotlin.sdk.shared.Protocol
 import io.modelcontextprotocol.kotlin.sdk.shared.ProtocolOptions
 import io.modelcontextprotocol.kotlin.sdk.shared.RequestOptions
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.serialization.json.JsonObject
 
 private val logger = KotlinLogging.logger {}
 
@@ -37,7 +36,7 @@ public open class Server(
     private val serverInfo: Implementation,
     options: ServerOptions,
     public var onCloseCallback: (() -> Unit)? = null
-) : Protocol<ServerRequest, ServerNotification, ServerResult>(options) {
+) : Protocol(options) {
 
     /**
      * The client's reported capabilities after initialization.


### PR DESCRIPTION
The generic types in the Protocol class were not providing significant value and made the code more complex. This change simplifies the API by removing these generic parameters while maintaining the same functionality.

another breaking change