### PR TITLE
Fix the difference in error handling between Kotlin and Typescript implementations in onClose

### DIFF
--- a/src/main/kotlin/io/modelcontextprotocol/kotlin/sdk/shared/Protocol.kt
+++ b/src/main/kotlin/io/modelcontextprotocol/kotlin/sdk/shared/Protocol.kt
@@ -191,15 +191,15 @@ public abstract class Protocol<SendRequestT : Request, SendNotificationT : Notif
     }
 
     private fun onClose() {
-        val error = McpError(ErrorCode.Defined.ConnectionClosed.code, "Connection closed")
-        for (handler in responseHandlers.values) {
-            handler(null, error)
-        }
-
         responseHandlers.clear()
         progressHandlers.clear()
         transport = null
         onclose()
+
+        val error = McpError(ErrorCode.Defined.ConnectionClosed.code, "Connection closed")
+        for (handler in responseHandlers.values) {
+            handler(null, error)
+        }
     }
 
     private fun onError(error: Throwable) {


### PR DESCRIPTION
Makes the error handling behavior consistent between Kotlin and TypeScript implementations when handling connection closure events.