### PR TITLE
sse server does not process endpoint correctly when sse path is not a directory

### DIFF
--- a/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/client/SSEClientTransport.kt
+++ b/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/client/SSEClientTransport.kt
@@ -12,6 +12,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.Url
 import io.ktor.http.append
 import io.ktor.http.isSuccess
+import io.ktor.http.protocolWithAuthority
 import io.modelcontextprotocol.kotlin.sdk.JSONRPCMessage
 import io.modelcontextprotocol.kotlin.sdk.shared.AbstractTransport
 import io.modelcontextprotocol.kotlin.sdk.shared.McpJson
@@ -24,7 +25,6 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
-import kotlinx.serialization.encodeToString
 import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.properties.Delegates

--- a/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/client/SseTransportTest.kt
+++ b/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/client/SseTransportTest.kt
@@ -119,4 +119,31 @@ class SseTransportTest : BaseTransportTest() {
         testClientRead(client)
         server.stop()
     }
+
+    @Test
+    fun `test sse path not root path`() = runTest {
+        val server = embeddedServer(CIO, port = PORT) {
+            install(io.ktor.server.sse.SSE)
+            routing {
+                mcpSseTransport(path = "/sse", incomingPath = "/messages") {
+                    onMessage = {
+                        send(it)
+                    }
+                }
+            }
+        }.start(wait = false)
+
+        val client = HttpClient {
+            install(SSE)
+        }.mcpSseTransport {
+            url {
+                host = "localhost"
+                port = PORT
+                pathSegments = listOf("sse")
+            }
+        }
+
+        testClientRead(client)
+        server.stop()
+    }
 }


### PR DESCRIPTION
issue is : https://github.com/modelcontextprotocol/kotlin-sdk/issues/41

mcp sse server does not remove last path when join endpoint url.
for example: baseUrl is http://localhost/sse, and server return sse data:

event:endpoint data:mesages?sessionId=a7f13c57-3ebe-4676-8079-bab962990583

sdk return endpoint http://localhost/sse/mesages?sessionId=a7f13c57-3ebe-4676-8079-bab962990583

the correct endpoint should be http://localhost/mesages?sessionId=a7f13c57-3ebe-4676-8079-bab962990583

python-sdk can correctly return the endpoint
