### PR TITLE
Add support for testing JSON serialization of the mcp API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -219,6 +219,7 @@ kotlin {
                 implementation(libs.ktor.server.test.host)
                 implementation(libs.kotlinx.coroutines.test)
                 implementation(libs.kotlinx.coroutines.debug)
+                implementation(libs.kotest.assertions.json)
             }
         }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ logging = "7.0.0"
 jreleaser = "1.15.0"
 binaryCompatibilityValidatorPlugin = "0.17.0"
 slf4j = "2.0.16"
+kotest = "5.9.1"
 
 [libraries]
 # Kotlinx libraries
@@ -32,8 +33,7 @@ kotlinx-coroutines-debug = { group = "org.jetbrains.kotlinx", name = "kotlinx-co
 ktor-server-test-host = { group = "io.ktor", name = "ktor-server-test-host", version.ref = "ktor" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 slf4j-simple = { group = "org.slf4j", name = "slf4j-simple", version.ref = "slf4j" }
-
-
+kotest-assertions-json = { group = "io.kotest", name = "kotest-assertions-json", version.ref = "kotest" }
 
 [plugins]
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }

--- a/src/commonTest/kotlin/ToolSerializationTest.kt
+++ b/src/commonTest/kotlin/ToolSerializationTest.kt
@@ -1,0 +1,47 @@
+package io.modelcontextprotocol.kotlin.sdk
+
+import io.kotest.assertions.json.shouldEqualJson
+import io.modelcontextprotocol.kotlin.sdk.shared.McpJson
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlin.test.Test
+
+class ToolSerializationTest {
+
+    @Test
+    fun `should serialize GetWeather tool`() {
+        val tool = Tool(
+            name = "get_weather",
+            description = "Get the current weather in a given location",
+            inputSchema = Tool.Input(
+                properties = buildJsonObject {
+                    put("location", buildJsonObject {
+                        put("type", JsonPrimitive("string"))
+                        put("description", JsonPrimitive("The city and state, e.g. San Francisco, CA"))
+                    })
+                },
+                required = listOf("location")
+            )
+        )
+
+        // see https://docs.anthropic.com/en/docs/build-with-claude/tool-use
+        McpJson.encodeToString(tool) shouldEqualJson /* language=json */ """
+            {
+              "name": "get_weather",
+              "description": "Get the current weather in a given location",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "location": {
+                    "type": "string",
+                    "description": "The city and state, e.g. San Francisco, CA"
+                  }
+                },
+                "required": ["location"]
+              }
+            }
+        """
+    }
+
+}

--- a/src/commonTest/kotlin/ToolSerializationTest.kt
+++ b/src/commonTest/kotlin/ToolSerializationTest.kt
@@ -6,42 +6,52 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class ToolSerializationTest {
 
-    @Test
-    fun `should serialize GetWeather tool`() {
-        val tool = Tool(
-            name = "get_weather",
-            description = "Get the current weather in a given location",
-            inputSchema = Tool.Input(
-                properties = buildJsonObject {
-                    put("location", buildJsonObject {
-                        put("type", JsonPrimitive("string"))
-                        put("description", JsonPrimitive("The city and state, e.g. San Francisco, CA"))
-                    })
-                },
-                required = listOf("location")
-            )
-        )
-
-        // see https://docs.anthropic.com/en/docs/build-with-claude/tool-use
-        McpJson.encodeToString(tool) shouldEqualJson /* language=json */ """
-            {
-              "name": "get_weather",
-              "description": "Get the current weather in a given location",
-              "inputSchema": {
-                "type": "object",
-                "properties": {
-                  "location": {
-                    "type": "string",
-                    "description": "The city and state, e.g. San Francisco, CA"
-                  }
-                },
-                "required": ["location"]
+    // see https://docs.anthropic.com/en/docs/build-with-claude/tool-use
+    /* language=json */
+    private val getWeatherToolJson = """
+        {
+          "name": "get_weather",
+          "description": "Get the current weather in a given location",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "location": {
+                "type": "string",
+                "description": "The city and state, e.g. San Francisco, CA"
               }
-            }
-        """
+            },
+            "required": ["location"]
+          }
+        }
+    """.trimIndent()
+
+    val getWeatherTool = Tool(
+        name = "get_weather",
+        description = "Get the current weather in a given location",
+        inputSchema = Tool.Input(
+            properties = buildJsonObject {
+                put("location", buildJsonObject {
+                    put("type", JsonPrimitive("string"))
+                    put("description", JsonPrimitive("The city and state, e.g. San Francisco, CA"))
+                })
+            },
+            required = listOf("location")
+        )
+    )
+
+    @Test
+    fun `should serialize get_weather tool`() {
+        McpJson.encodeToString(getWeatherTool) shouldEqualJson getWeatherToolJson
+    }
+
+    @Test
+    fun `should deserialize get_weather tool`() {
+        val tool = McpJson.decodeFromString<Tool>(getWeatherToolJson)
+        assertEquals(expected = getWeatherTool, actual = tool)
     }
 
 }


### PR DESCRIPTION
I added:
- `kotest-assertions-json` dependency
- `ToolSerializationTest` to verify correctness of tool serialization

## Motivation and Context
This change does not provide any feature, except for improving test coverage. It paves the way for my subsequent PRs presenting JSON schema inputs which are valid and might appear in MCP, but cannot be expressed by the current `Tool.Input`.

See also:
* https://github.com/modelcontextprotocol/specification/issues/156
* #32 

## How Has This Been Tested?
It comes with the test itself.

## Breaking Changes
No

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
