### PR TITLE
Process JSONRPCRequest with default param (#42)

### DIFF
--- a/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/shared/Protocol.kt
+++ b/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/shared/Protocol.kt
@@ -440,7 +440,7 @@ public abstract class Protocol(
         val serializer = McpJson.serializersModule.serializer(requestType)
 
         requestHandlers[method.value] = { request, extraHandler ->
-            val result = request.params?.let { McpJson.decodeFromJsonElement(serializer, it) }
+            val result = McpJson.decodeFromJsonElement(serializer, request.params)
             val response = if (result != null) {
                 @Suppress("UNCHECKED_CAST")
                 block(result as T, extraHandler)

--- a/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types.kt
+++ b/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types.kt
@@ -215,7 +215,7 @@ public sealed interface JSONRPCMessage
 public data class JSONRPCRequest(
     val id: RequestId = RequestId.NumberId(REQUEST_MESSAGE_ID.incrementAndGet()),
     val method: String,
-    val params: JsonElement? = null,
+    val params: JsonElement = EmptyJsonObject,
     val jsonrpc: String = JSONRPC_VERSION,
 ) : JSONRPCMessage
 


### PR DESCRIPTION
Fixes issue #42 by setting the default to `JSONRPTCRequest.params` from null to `EmptyJsonObject`. This makes it so that the absence of params in a request is treated as an empty array which is what the Python sdk also does.

## Motivation and Context
This makes it so that these two request bodies are treated similarly where previously not including params would result in an empty response.

`{"jsonrpc": "2.0", "method": "tools/list","params": {}, "id": 1}`
and 
`{"jsonrpc": "2.0", "method": "tools/list", "id": 1}`

## How Has This Been Tested?
I tested this with the sample Kotlin server project (with a bit of modification to update sample to use more up to date code) and a basic python SSE client.

I would use the python client to get the sessionId and then I would run

```
curl -v -X POST "http://localhost:3001/message?sessionId=9799477a-945f-4498-ac8e-fc9156d5898f" \
     -H "Accept: text/event-stream" \
     -H "Content-Type: application/json" \
     -d '{"jsonrpc": "2.0", "method": "tools/list","params": {}, "id": 1}'
```
with `"params": {},` I would get the listed tools and without it I would get an empty response(`EmptyRequestResult`).

I also added a unit test that would fail before my changes (would be EmptyRequestResult) and pass after my changes
 

## Breaking Changes
No

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ?] Breaking change (fix or feature that would cause existing functionality to change)
    * this will technically change behavior from certain requests getting empty results to those requests getting correct results
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x ] I have added or updated documentation as needed
