### PR TITLE
Change sample to work with Claude Desktop

### DIFF
--- a/samples/kotlin-mcp-server/src/main/kotlin/Main.kt
+++ b/samples/kotlin-mcp-server/src/main/kotlin/Main.kt
@@ -91,7 +91,7 @@ fun configureServer(): Server {
 
     // Add a tool
     server.addTool(
-        name = "Test io.modelcontextprotocol.kotlin.sdk.Tool",
+        name = "kotlin-sdk-tool",
         description = "A test tool",
         inputSchema = Tool.Input()
     ) { request ->
@@ -128,7 +128,6 @@ fun runMcpServerUsingStdio() {
 
     runBlocking {
         server.connect(transport)
-        println("Server running on stdio")
         val done = Job()
         server.onCloseCallback = {
             done.complete()


### PR DESCRIPTION
Claude Desktop expects the following:

- No stdout emissions before the actual JSON interactions (removed the `Server running...` text)
- Tool name to conform to a regex:


<img width="584" alt="Screenshot 2025-03-07 at 11 56 22" src="https://github.com/user-attachments/assets/93c82e27-06c8-4935-9c27-751ff13bf71d" />

This PR makes the required changes to the example project.

After these changes, both MCP inspector and Claude Desktop behave correctly:

<img width="1112" alt="Screenshot 2025-03-07 at 11 58 35" src="https://github.com/user-attachments/assets/5460f362-f5b6-4c1a-8906-d9f7e944b6ee" />
