### PR TITLE
Fixe for #56 - missing method attribute from client RPC message

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
 }
 
 group = "io.modelcontextprotocol"
-version = "0.3.0"
+version = "0.3.1"
 
 val mainSourcesJar = tasks.register<Jar>("mainSourcesJar") {
     archiveClassifier = "sources"


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
Per #56 Cursor (and apparently some other MCP clients) don't send the `method` attribute in the `params` map in their notification messages, whereas this server requires it to be present, throwing an NPE when it's not and thus preventing successful initialisation.

## How Has This Been Tested?
Tested manually with the latest version of Cursor - 0.46.8

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
Draft at present, as automating a test will require modifying the client code (or pulling in an alternative client) to behave like Cursor and others.
