### PR TITLE
remove the mention of `onCloseCallback` and replace it  to `onClose`

### DIFF
--- a/samples/weather-stdio-server/src/main/kotlin/io/modelcontextprotocol/sample/server/McpWeatherServer.kt
+++ b/samples/weather-stdio-server/src/main/kotlin/io/modelcontextprotocol/sample/server/McpWeatherServer.kt
@@ -121,7 +121,7 @@ fun `run mcp server`() {
     runBlocking {
         server.connect(transport)
         val done = Job()
-        server.onCloseCallback = {
+        server.onClose {
             done.complete()
         }
         done.join()

--- a/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/Server.kt
+++ b/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/Server.kt
@@ -30,7 +30,6 @@ public class ServerOptions(
  *
  * @param serverInfo Information about this server implementation (name, version).
  * @param options Configuration options for the server.
- * @param onCloseCallback A callback invoked when the server connection closes.
  */
 public open class Server(
     private val serverInfo: Implementation,
@@ -127,7 +126,6 @@ public open class Server(
 
     /**
      * Called when the server connection is closing.
-     * Invokes [onCloseCallback] if set.
      */
     override fun onClose() {
         logger.info { "Server connection closing" }

--- a/src/jvmTest/kotlin/InMemoryTransport.kt
+++ b/src/jvmTest/kotlin/InMemoryTransport.kt
@@ -1,6 +1,5 @@
 import io.modelcontextprotocol.kotlin.sdk.JSONRPCMessage
 import io.modelcontextprotocol.kotlin.sdk.shared.AbstractTransport
-import io.modelcontextprotocol.kotlin.sdk.shared.Transport
 
 /**
  * In-memory transport for creating clients and servers that talk to each other within the same process.

--- a/src/jvmTest/kotlin/client/InMemoryTransportTest.kt
+++ b/src/jvmTest/kotlin/client/InMemoryTransportTest.kt
@@ -96,11 +96,9 @@ class InMemoryTransportTest {
             clientTransport.close()
 
             assertThrows<IllegalStateException> {
-                runBlocking {
-                    clientTransport.send(
-                        InitializedNotification().toJSON()
-                    )
-                }
+                clientTransport.send(
+                    InitializedNotification().toJSON()
+                )
             }
         }
     }


### PR DESCRIPTION
Removed the mention of `onCloseCallback`, and replaced all uses of `onCloseCallback` to `onClose`.
Refactor the code to the 0.4.0 version of sdk

## How Has This Been Tested?
Tested locally:
- ran all tests
- ran projects in samples

## Breaking Changes
No breaking changes

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
