### PR TITLE
feat: add message field to ProgressNotification according to 2025-03-26 spec

### DIFF
--- a/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/shared/Protocol.kt
+++ b/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/shared/Protocol.kt
@@ -260,6 +260,7 @@ public abstract class Protocol(
         LOGGER.trace { "Received progress notification: token=${notification.progressToken}, progress=${notification.progress}/${notification.total}" }
         val progress = notification.progress
         val total = notification.total
+        val message = notification.message
         val progressToken = notification.progressToken
 
         val handler = progressHandlers[progressToken]
@@ -272,7 +273,7 @@ public abstract class Protocol(
             return
         }
 
-        handler.invoke(Progress(progress, total))
+        handler.invoke(Progress(progress, total, message))
     }
 
     private fun onResponse(response: JSONRPCResponse?, error: JSONRPCError?) {

--- a/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types.kt
+++ b/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types.kt
@@ -510,6 +510,11 @@ public sealed interface ProgressBase {
      * Total number of items to a process (or total progress required), if known.
      */
     public val total: Double?
+
+    /**
+     * An optional message describing the current progress.
+     */
+    public val message: String?
 }
 
 /* Progress notifications */
@@ -530,6 +535,11 @@ public open class Progress(
      * Total number of items to a process (or total progress required), if known.
      */
     override val total: Double?,
+
+    /**
+     * An optional message describing the current progress.
+     */
+    override val message: String?,
 ) : ProgressBase
 
 /**
@@ -546,6 +556,7 @@ public data class ProgressNotification(
     public val progressToken: ProgressToken,
     @Suppress("PropertyName") val _meta: JsonObject = EmptyJsonObject,
     override val total: Double?,
+    override val message: String?,
 ) : ClientNotification, ServerNotification, ProgressBase {
     override val method: Method = Method.Defined.NotificationsProgress
 }


### PR DESCRIPTION
## Motivation and Context
This PR adds message field to ProgressNotification to provide descriptive status updates

## How Has This Been Tested?
NA

## Breaking Changes
NA

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
References: https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/schema/2025-03-26/schema.ts#L294
