### PR TITLE
feat: add tool annotations according to 2025-03-26 spec

### DIFF
--- a/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/Server.kt
+++ b/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/Server.kt
@@ -145,6 +145,7 @@ public open class Server(
         name: String,
         description: String,
         inputSchema: Tool.Input = Tool.Input(),
+        toolAnnotations: ToolAnnotations? = null,
         handler: suspend (CallToolRequest) -> CallToolResult
     ) {
         if (capabilities.tools == null) {
@@ -152,7 +153,7 @@ public open class Server(
             throw IllegalStateException("Server does not support tools capability. Enable it in ServerOptions.")
         }
         logger.info { "Registering tool: $name" }
-        tools[name] = RegisteredTool(Tool(name, description, inputSchema), handler)
+        tools[name] = RegisteredTool(Tool(name, description, inputSchema, toolAnnotations), handler)
     }
 
     /**

--- a/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types.kt
+++ b/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types.kt
@@ -992,6 +992,58 @@ public class PromptListChangedNotification : ServerNotification {
 
 /* Tools */
 /**
+ * Additional properties describing a Tool to clients.
+ *
+ * NOTE: all properties in ToolAnnotations are **hints**.
+ * They are not guaranteed to provide a faithful description of
+ * tool behavior (including descriptive properties like `title`).
+ *
+ * Clients should never make tool use decisions based on ToolAnnotations
+ * received from untrusted servers.
+ */
+@Serializable
+public data class ToolAnnotations(
+    /**
+     * A human-readable title for the tool.
+     */
+    val title: String?,
+    /**
+     * If true, the tool does not modify its environment.
+     *
+     * Default: false
+     */
+    val readOnlyHint: Boolean? = false,
+    /**
+     * If true, the tool may perform destructive updates to its environment.
+     * If false, the tool performs only additive updates.
+     *
+     * (This property is meaningful only when `readOnlyHint == false`)
+     *
+     * Default: true
+     */
+    val destructiveHint: Boolean? = true,
+    /**
+     * If true, calling the tool repeatedly with the same arguments
+     * will have no additional effect on the its environment.
+     *
+     * (This property is meaningful only when `readOnlyHint == false`)
+     *
+     * Default: false
+     */
+    val idempotentHint: Boolean? = false,
+    /**
+     * If true, this tool may interact with an "open world" of external
+     * entities. If false, the tool's domain of interaction is closed.
+     * For example, the world of a web search tool is open, whereas that
+     * of a memory tool is not.
+     *
+     * Default: true
+     */
+    val openWorldHint: Boolean? = true,
+)
+
+
+/**
  * Definition for a tool the client can call.
  */
 @Serializable
@@ -1008,6 +1060,11 @@ public data class Tool(
      * A JSON object defining the expected parameters for the tool.
      */
     val inputSchema: Input,
+
+    /**
+     * Optional additional tool information.
+     */
+    val annotations: ToolAnnotations?,
 ) {
     @Serializable
     public data class Input(

--- a/src/commonTest/kotlin/ToolSerializationTest.kt
+++ b/src/commonTest/kotlin/ToolSerializationTest.kt
@@ -2,6 +2,7 @@ package io.modelcontextprotocol.kotlin.sdk
 
 import io.kotest.assertions.json.shouldEqualJson
 import io.modelcontextprotocol.kotlin.sdk.shared.McpJson
+import kotlinx.atomicfu.atomicArrayOfNulls
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
@@ -32,6 +33,7 @@ class ToolSerializationTest {
     val getWeatherTool = Tool(
         name = "get_weather",
         description = "Get the current weather in a given location",
+        annotations = null,
         inputSchema = Tool.Input(
             properties = buildJsonObject {
                 put("location", buildJsonObject {

--- a/src/jvmTest/kotlin/client/ClientTest.kt
+++ b/src/jvmTest/kotlin/client/ClientTest.kt
@@ -523,6 +523,7 @@ class ClientTest {
                 Tool(
                     name = "testTool",
                     description = "testTool description",
+                    annotations = null,
                     inputSchema = Tool.Input()
                 )
             ), nextCursor = null


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
Add tool annotations to provide additional properties describing a Tool to clients.

## How Has This Been Tested?
NA

## Breaking Changes
NA

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
References: 
https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/schema/2025-03-26/schema.ts#L737