### PR TITLE
Update to Kotlin 2.1.20 and minor refactoring

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,6 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.dokka)
     alias(libs.plugins.jreleaser)
-    alias(libs.plugins.atomicfu)
     `maven-publish`
     alias(libs.plugins.kotlinx.binary.compatibility.validator)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,7 @@
 [versions]
 # plugins version
-kotlin = "2.0.21"
+kotlin = "2.1.20"
 dokka = "2.0.0"
-atomicfu = "0.26.1"
 
 # libraries version
 serialization = "1.7.3"
@@ -40,5 +39,4 @@ kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref 
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 jreleaser = { id = "org.jreleaser", version.ref = "jreleaser"}
-atomicfu = { id = "org.jetbrains.kotlinx.atomicfu", version.ref = "atomicfu" }
 kotlinx-binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "binaryCompatibilityValidatorPlugin" }

--- a/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/StdioServerTransport.kt
+++ b/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/StdioServerTransport.kt
@@ -115,7 +115,10 @@ public class StdioServerTransport(
 
         // Cancel reading job and close channel
         readingJob?.cancel() // ToDO("was cancel and join")
+        sendingJob?.cancel()
+
         readChannel.close()
+        writeChannel.close()
         readBuffer.clear()
 
         _onClose.invoke()

--- a/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/StdioServerTransport.kt
+++ b/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/StdioServerTransport.kt
@@ -5,10 +5,6 @@ import io.modelcontextprotocol.kotlin.sdk.JSONRPCMessage
 import io.modelcontextprotocol.kotlin.sdk.shared.AbstractTransport
 import io.modelcontextprotocol.kotlin.sdk.shared.ReadBuffer
 import io.modelcontextprotocol.kotlin.sdk.shared.serializeMessage
-import kotlinx.atomicfu.AtomicBoolean
-import kotlinx.atomicfu.atomic
-import kotlinx.atomicfu.locks.ReentrantLock
-import kotlinx.atomicfu.locks.withLock
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import kotlinx.io.*
@@ -31,12 +27,13 @@ public class StdioServerTransport(
     private val readBuffer = ReadBuffer()
     private val initialized: AtomicBoolean = AtomicBoolean(false)
     private var readingJob: Job? = null
+    private var sendingJob: Job? = null
 
     private val coroutineContext: CoroutineContext = Dispatchers.IO + SupervisorJob()
     private val scope = CoroutineScope(coroutineContext)
     private val readChannel = Channel<ByteArray>(Channel.UNLIMITED)
+    private val writeChannel = Channel<JSONRPCMessage>(Channel.UNLIMITED)
     private val outputWriter = outputStream.buffered()
-    private val lock = ReentrantLock()
 
     override suspend fun start() {
         if (!initialized.compareAndSet(expectedValue = false, newValue = true)) {
@@ -78,6 +75,20 @@ public class StdioServerTransport(
                 _onError.invoke(e)
             }
         }
+
+        // Launch a coroutine to handle message sending
+        sendingJob = scope.launch {
+            try {
+                for (message in writeChannel) {
+                    val json = serializeMessage(message)
+                    outputWriter.writeString(json)
+                    outputWriter.flush()
+                }
+            } catch (e: Throwable) {
+                logger.error(e) { "Error writing to stdout" }
+                _onError.invoke(e)
+            }
+        }
     }
 
     private suspend fun processReadBuffer() {
@@ -111,11 +122,6 @@ public class StdioServerTransport(
     }
 
     override suspend fun send(message: JSONRPCMessage) {
-        val json = serializeMessage(message)
-        lock.withLock {
-            // You may need to add Content-Length headers before the message if using the LSP framing protocol
-            outputWriter.writeString(json)
-            outputWriter.flush()
-        }
+        writeChannel.send(message)
     }
 }


### PR DESCRIPTION
- update Kotlin version to 2.1.20
- use atomics from `kotlin.concurrent`
- refactor lock in `StrdioServerTransport`, using `Channel`
- remove the `atomicfu` plugin

## How Has This Been Tested?
- unit test
- run a custom mcp server with Claude via stdio

## Breaking Changes
No breaking changes


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
default atomics: https://kotlinlang.org/docs/whatsnew2120.html#common-atomic-types
