### PR TITLE
Skip empty lines

### DIFF
--- a/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/shared/ReadBuffer.kt
+++ b/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/shared/ReadBuffer.kt
@@ -24,7 +24,7 @@ public class ReadBuffer {
             -1L -> return null
             0L -> {
                 buffer.skip(1)
-                ""
+                return null
             }
 
             else -> {

--- a/src/jvmTest/kotlin/shared/ReadBufferTest.kt
+++ b/src/jvmTest/kotlin/shared/ReadBufferTest.kt
@@ -42,6 +42,13 @@ class ReadBufferTest {
     }
 
     @Test
+    fun `skip empty line`() {
+        val readBuffer = ReadBuffer()
+        readBuffer.append("\n".toByteArray(StandardCharsets.UTF_8))
+        assertNull(readBuffer.readMessage())
+    }
+
+    @Test
     fun `should be reusable after clearing`() {
         val readBuffer = ReadBuffer()
 


### PR DESCRIPTION
## Motivation and Context
This pull request fixes an issue with the `ReadBuffer` functionality by ensuring that empty lines are properly skipped during input processing. A new test case has been added to validate this behavior.

## How Has This Been Tested?
The `ReadBuffer` threw exception on empty message which leaded to connection closing.


## Breaking Changes
no

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
