### PR TITLE
fix: apply `requestBuilder` headers when sending rpc messages

### DIFF
--- a/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/client/SSEClientTransport.kt
+++ b/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/client/SSEClientTransport.kt
@@ -113,6 +113,7 @@ public class SseClientTransport(
 
         try {
             val response = client.post(endpoint.getCompleted()) {
+                requestBuilder()
                 headers.append(HttpHeaders.ContentType, ContentType.Application.Json)
                 setBody(McpJson.encodeToString(message))
             }


### PR DESCRIPTION
fixes: #63

<!-- Provide a brief summary of your changes -->
Adds the missing `requestBuilder` call to `send` function

## Motivation and Context
Client doesn't send `Auth` headers when sending a rpc message

## How Has This Been Tested?
logs:
```sh
2025-05-05 01:07:32.569 12997-13028            V  REQUEST: https://[REDACTED]/sse/message?sessionId=c28e21031144b7b85616b23d6caf8c7feb1f88e88ad1beefb533b68060d3e236
                                                  METHOD: POST
                                                  COMMON HEADERS
                                                  -> Accept: application/json
                                                  -> Accept-Charset: UTF-8
                                                  -> Authorization: Bearer e41ef9271332d4732fb4f[REDACTED]
                                                  CONTENT HEADERS
                                                  -> Content-Length: 230
                                                  -> Content-Type: application/json
2025-05-05 01:07:32.594 12997-13028            D  tagSocket(114) with statsTag=0xffffffff, statsUid=-1
2025-05-05 01:07:33.097 12997-13055            V  RESPONSE: 202 Accepted
                                                  METHOD: POST
                                                  FROM: https://[REDACTED]/sse/message?sessionId=c28e21031144b7b85616b23d6caf8c7feb1f88e88ad1beefb533b68060d3e236
                                                  COMMON HEADERS
                                                  -> Access-Control-Allow-Origin: *
                                                  -> CF-RAY: 93aa74118ec0938b-BBI
                                                  -> Cache-Control: no-cache
                                                  -> Connection: keep-alive
                                                  -> Content-Length: 8
                                                  -> Content-Type: text/event-stream
                                                  -> Date: Sun, 04 May 2025 19:37:34 GMT
```

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
