### PR TITLE
fix(client): serialize inputSchema as input_schema

### DIFF
--- a/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types.kt
+++ b/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types.kt
@@ -3,6 +3,9 @@
 package io.modelcontextprotocol.kotlin.sdk
 
 import io.modelcontextprotocol.kotlin.sdk.shared.McpJson
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -1043,6 +1046,7 @@ public data class Tool(
     /**
      * A JSON object defining the expected parameters for the tool.
      */
+    @SerialName("input_schema")
     val inputSchema: Input,
 ) {
     @Serializable

--- a/src/commonTest/kotlin/ToolSerializationTest.kt
+++ b/src/commonTest/kotlin/ToolSerializationTest.kt
@@ -16,7 +16,7 @@ class ToolSerializationTest {
         {
           "name": "get_weather",
           "description": "Get the current weather in a given location",
-          "inputSchema": {
+          "input_schema": {
             "type": "object",
             "properties": {
               "location": {


### PR DESCRIPTION
Snake case is expected in general in Anthropic and other LLM provider,  so serialize `Tool.inputSchema` as `input_schema` 

## Motivation and Context
Tool class can be used directly in message API, but it needs to be snake case

## How Has This Been Tested?
Tests are updated and passing, also according to https://docs.anthropic.com/en/api/messages#body-tools

## Breaking Changes
If code depends on camlCase, then this is a breaking change.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
