### PR TITLE
fix(client) add encodeDefault for field with non spec default value

### DIFF
--- a/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types.kt
+++ b/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types.kt
@@ -1046,7 +1046,6 @@ public data class Tool(
     /**
      * A JSON object defining the expected parameters for the tool.
      */
-    @SerialName("input_schema")
     val inputSchema: Input,
 ) {
     @Serializable

--- a/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types.kt
+++ b/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types.kt
@@ -1046,6 +1046,7 @@ public data class Tool(
     /**
      * A JSON object defining the expected parameters for the tool.
      */
+    @SerialName("input_schema")
     val inputSchema: Input,
 ) {
     @Serializable
@@ -1053,6 +1054,8 @@ public data class Tool(
         val properties: JsonObject = EmptyJsonObject,
         val required: List<String>? = null,
     ) {
+        @OptIn(ExperimentalSerializationApi::class)
+        @EncodeDefault
         val type: String = "object"
     }
 }

--- a/src/commonTest/kotlin/ToolSerializationTest.kt
+++ b/src/commonTest/kotlin/ToolSerializationTest.kt
@@ -3,6 +3,7 @@ package io.modelcontextprotocol.kotlin.sdk
 import io.kotest.assertions.json.shouldEqualJson
 import io.modelcontextprotocol.kotlin.sdk.shared.McpJson
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlin.test.Test
@@ -54,4 +55,11 @@ class ToolSerializationTest {
         assertEquals(expected = getWeatherTool, actual = tool)
     }
 
+    @Test
+    fun `should always serialize default value`() {
+        val json = Json(from = McpJson) {
+            encodeDefaults = false
+        }
+        json.encodeToString(getWeatherTool) shouldEqualJson getWeatherToolJson
+    }
 }


### PR DESCRIPTION

`type` in `Tool.Input` has a default value, but the spec doesn't treat it as default value, therefore serailizer  should always write it. 

## Motivation and Context
Serialized `Tool` can be used directly in calling anthropic api (without SDK).

## How Has This Been Tested?
Passing all existing tests

## Breaking Changes
It is a breaking change if code depends on "missing" `type` behavior

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
