### PR TITLE
Make McpJson public to allow flexible protocol development

### DIFF
--- a/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/shared/Protocol.kt
+++ b/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/shared/Protocol.kt
@@ -25,8 +25,7 @@ internal const val IMPLEMENTATION_NAME = "mcp-ktor"
 public typealias ProgressCallback = (Progress) -> Unit
 
 @OptIn(ExperimentalSerializationApi::class)
-@PublishedApi
-internal val McpJson: Json by lazy {
+public val McpJson: Json by lazy {
     Json {
         ignoreUnknownKeys = true
         encodeDefaults = true


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
This MCP repo allows to create new transport from public `AbstractTransport` but `McpJson` which is main part for parsing ([example](https://github.com/modelcontextprotocol/kotlin-sdk/blob/main/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/SSEServerTransport.kt#L102)) instead being private and not visible to use and block the development of new Transport.

## Motivation and Context
I am trying to create a new transport but got blocked on not being able to encode or decode JSONRPCMessage as McpJSON is not public.

## How Has This Been Tested?
Open Intellij project and run tests as per this repo guideline.

## Breaking Changes
N/A

## Types of changes
- [ X ] New feature (non-breaking change which adds functionality)

## Checklist
- [ X ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ X ] My code follows the repository's style guidelines
- [ X ] New and existing tests pass locally
- [ N/A ] I have added appropriate error handling
- [ N/A ] I have added or updated documentation as needed