### PR TITLE
Remove fixed suffix /sse

### DIFF
--- a/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/client/SSEClientTransport.kt
+++ b/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/client/SSEClientTransport.kt
@@ -68,7 +68,7 @@ public class SseClientTransport(
 
         session = urlString?.let {
             client.sseSession(
-                urlString = "$it/sse",
+                urlString = it,
                 reconnectionTime = reconnectionTime,
                 block = requestBuilder,
             )

--- a/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/SseIntegrationTest.kt
+++ b/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/SseIntegrationTest.kt
@@ -2,9 +2,11 @@ package io.modelcontextprotocol.kotlin.sdk.integration
 
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.sse.SSE
+import io.ktor.server.application.install
 import io.ktor.server.cio.CIOApplicationEngine
 import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.engine.embeddedServer
+import io.ktor.server.routing.routing
 import io.modelcontextprotocol.kotlin.sdk.Implementation
 import io.modelcontextprotocol.kotlin.sdk.ServerCapabilities
 import io.modelcontextprotocol.kotlin.sdk.client.Client
@@ -52,7 +54,12 @@ class SseIntegrationTest {
             ServerOptions(capabilities = ServerCapabilities()),
         )
 
-        return embeddedServer(ServerCIO, host = URL, port = PORT) { mcp { server } }.startSuspend(wait = false)
+        return embeddedServer(ServerCIO, host = URL, port = PORT) { 
+            install(io.ktor.server.sse.SSE)
+            routing { 
+                mcp { server } 
+            } 
+        }.startSuspend(wait = false)
     }
 
     companion object {


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Remove the hardcoded /sse string in the sse client transport, which forcibly adds /sse to the path, making it very crude. 

When using all sse mcp servers, it's almost always in the format like `http://localhost:3000/sse`, and the forced addition of /sse leads to errors. In (npx @modelcontextprotocol/inspector), users also need to manually add the /sse suffix.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
If this PR is merged, consumers must manually add the /sse suffix to their URL.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
