### PR TITLE
Move samples deps to version catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,9 +33,20 @@ mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 slf4j-simple = { group = "org.slf4j", name = "slf4j-simple", version.ref = "slf4j" }
 kotest-assertions-json = { group = "io.kotest", name = "kotest-assertions-json", version.ref = "kotest" }
 
+# Samples
+mcp-kotlin = { group = "io.modelcontextprotocol", name = "kotlin-sdk", version = "0.5.0" }
+slf4j-nop = { group = "org.slf4j", name = "slf4j-nop", version.ref = "slf4j" }
+anthropic-jvm = { group = "com.anthropic", name = "anthropic-java", version = "0.8.0" }
+ktor-client-negotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-serialization-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
+
 [plugins]
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 jreleaser = { id = "org.jreleaser", version.ref = "jreleaser"}
 kotlinx-binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "binaryCompatibilityValidatorPlugin" }
+
+# Samples
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+shadow = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }

--- a/samples/kotlin-mcp-client/build.gradle.kts
+++ b/samples/kotlin-mcp-client/build.gradle.kts
@@ -1,25 +1,20 @@
 plugins {
-    kotlin("jvm") version "2.1.10"
+    alias(libs.plugins.kotlin.jvm)
     application
-    id("com.github.johnrengelman.shadow") version "8.1.1"
+    alias(libs.plugins.shadow)
 }
 
 application {
     mainClass.set("io.modelcontextprotocol.sample.client.MainKt")
 }
 
-
 group = "org.example"
 version = "0.1.0"
 
-val mcpVersion = "0.5.0"
-val slf4jVersion = "2.0.9"
-val anthropicVersion = "0.8.0"
-
 dependencies {
-    implementation("io.modelcontextprotocol:kotlin-sdk:$mcpVersion")
-    implementation("org.slf4j:slf4j-nop:$slf4jVersion")
-    implementation("com.anthropic:anthropic-java:$anthropicVersion")
+    implementation(libs.mcp.kotlin)
+    implementation(libs.slf4j.nop)
+    implementation(libs.anthropic.jvm)
 }
 
 tasks.test {

--- a/samples/kotlin-mcp-client/settings.gradle.kts
+++ b/samples/kotlin-mcp-client/settings.gradle.kts
@@ -5,6 +5,11 @@ plugins {
 }
 
 dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../../gradle/libs.versions.toml"))
+        }
+    }
     repositories {
         mavenCentral()
     }

--- a/samples/kotlin-mcp-server/build.gradle.kts
+++ b/samples/kotlin-mcp-server/build.gradle.kts
@@ -4,16 +4,12 @@ import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 
 plugins {
-    kotlin("multiplatform") version "2.1.20"
-    kotlin("plugin.serialization") version "2.1.20"
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 group = "org.example"
 version = "0.1.0"
-
-repositories {
-    mavenCentral()
-}
 
 val jvmMainClass = "Main_jvmKt"
 
@@ -43,10 +39,10 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            implementation("io.modelcontextprotocol:kotlin-sdk:0.5.0")
+            implementation(libs.mcp.kotlin)
         }
         jvmMain.dependencies {
-            implementation("org.slf4j:slf4j-nop:2.0.9")
+            implementation(libs.slf4j.nop)
         }
         wasmJsMain.dependencies {}
     }

--- a/samples/kotlin-mcp-server/settings.gradle.kts
+++ b/samples/kotlin-mcp-server/settings.gradle.kts
@@ -1,4 +1,17 @@
+rootProject.name = "kotlin-mcp-server"
+
 plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
 }
-rootProject.name = "kotlin-mcp-server"
+
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../../gradle/libs.versions.toml"))
+        }
+    }
+    repositories {
+        mavenCentral()
+    }
+}

--- a/samples/weather-stdio-server/build.gradle.kts
+++ b/samples/weather-stdio-server/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-    kotlin("jvm") version "2.1.10"
-    kotlin("plugin.serialization") version "2.1.10"
-    id("com.github.johnrengelman.shadow") version "8.1.1"
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.shadow)
     application
 }
 
@@ -9,21 +9,16 @@ application {
     mainClass.set("io.modelcontextprotocol.sample.server.MainKt")
 }
 
-
 group = "org.example"
 version = "0.1.0"
 
-val mcpVersion = "0.5.0"
-val slf4jVersion = "2.0.9"
-val ktorVersion = "3.1.1"
-
 dependencies {
-    implementation("io.modelcontextprotocol:kotlin-sdk:$mcpVersion")
-    implementation("org.slf4j:slf4j-nop:$slf4jVersion")
-    implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
+    implementation(libs.mcp.kotlin)
+    implementation(libs.slf4j.nop)
+    implementation(libs.ktor.client.negotiation)
+    implementation(libs.ktor.serialization.json)
     testImplementation(kotlin("test"))
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.1")
+    testImplementation(libs.kotlinx.coroutines.test)
 }
 
 tasks.test {

--- a/samples/weather-stdio-server/settings.gradle.kts
+++ b/samples/weather-stdio-server/settings.gradle.kts
@@ -5,6 +5,11 @@ plugins {
 }
 
 dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../../gradle/libs.versions.toml"))
+        }
+    }
     repositories {
         mavenCentral()
     }


### PR DESCRIPTION
This PR moves the dependencies of the samples to a single source - the root version catalog

Its a solution between a fully integregation of the samples (#119) into the project, while maintaining a single file for all dependencies.
With that, dependabot (see #121) is also able to update dependencies from the samples.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
**I haven't tested the samples ❗**
Because of the dependency bumps (might happen), it might be the case that they don't work anymore.
I just run `./gradlew help` in the root project and the samples to make sure that dependency resolution works correctly.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No breaking changes for consumers of the library itself.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
