### PR TITLE
Update `mcp` functions to use `ServerSSESession` with lambda receiver

### DIFF
--- a/api/kotlin-sdk.api
+++ b/api/kotlin-sdk.api
@@ -2990,10 +2990,10 @@ public final class io/modelcontextprotocol/kotlin/sdk/client/WebSocketMcpKtorCli
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/server/KtorServerKt {
-	public static final fun MCP (Lio/ktor/server/application/Application;Lkotlin/jvm/functions/Function0;)V
-	public static final fun mcp (Lio/ktor/server/application/Application;Lkotlin/jvm/functions/Function0;)V
-	public static final fun mcp (Lio/ktor/server/routing/Routing;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
-	public static final fun mcp (Lio/ktor/server/routing/Routing;Lkotlin/jvm/functions/Function0;)V
+	public static final fun MCP (Lio/ktor/server/application/Application;Lkotlin/jvm/functions/Function1;)V
+	public static final fun mcp (Lio/ktor/server/application/Application;Lkotlin/jvm/functions/Function1;)V
+	public static final fun mcp (Lio/ktor/server/routing/Routing;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public static final fun mcp (Lio/ktor/server/routing/Routing;Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/server/RegisteredPrompt {

--- a/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/KtorServer.kt
+++ b/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/KtorServer.kt
@@ -19,7 +19,7 @@ import io.ktor.utils.io.KtorDsl
 private val logger = KotlinLogging.logger {}
 
 @KtorDsl
-public fun Routing.mcp(path: String, block: () -> Server) {
+public fun Routing.mcp(path: String, block: ServerSSESession.() -> Server) {
     route(path) {
         mcp(block)
     }
@@ -29,7 +29,7 @@ public fun Routing.mcp(path: String, block: () -> Server) {
  * Configures the Ktor Application to handle Model Context Protocol (MCP) over Server-Sent Events (SSE).
  */
 @KtorDsl
-public fun Routing.mcp(block: () -> Server) {
+public fun Routing.mcp(block: ServerSSESession.() -> Server) {
     val transports = ConcurrentMap<String, SseServerTransport>()
 
     sse {
@@ -43,12 +43,12 @@ public fun Routing.mcp(block: () -> Server) {
 
 @Suppress("FunctionName")
 @Deprecated("Use mcp() instead", ReplaceWith("mcp(block)"), DeprecationLevel.WARNING)
-public fun Application.MCP(block: () -> Server) {
+public fun Application.MCP(block: ServerSSESession.() -> Server) {
     mcp(block)
 }
 
 @KtorDsl
-public fun Application.mcp(block: () -> Server) {
+public fun Application.mcp(block: ServerSSESession.() -> Server) {
     val transports = ConcurrentMap<String, SseServerTransport>()
 
     install(SSE)
@@ -67,7 +67,7 @@ public fun Application.mcp(block: () -> Server) {
 private suspend fun ServerSSESession.mcpSseEndpoint(
     postEndpoint: String,
     transports: ConcurrentMap<String, SseServerTransport>,
-    block: () -> Server,
+    block: ServerSSESession.() -> Server,
 ) {
     val transport =  mcpSseTransport(postEndpoint, transports)
 


### PR DESCRIPTION
Provide `ServeSSESession` as a context receiver.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
locally

## Breaking Changes
Yes, changed signature for `mcp` server extensions

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

