### PR TITLE
use SSEClientExcpetion instead of ClientRequestClient

### DIFF
--- a/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/client/StreamableHttpClientTransport.kt
+++ b/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/client/StreamableHttpClientTransport.kt
@@ -4,6 +4,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.ClientRequestException
 import io.ktor.client.plugins.sse.ClientSSESession
+import io.ktor.client.plugins.sse.SSEClientException
 import io.ktor.client.plugins.sse.sseSession
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.accept
@@ -229,8 +230,8 @@ public class StreamableHttpClientTransport(
                 requestBuilder()
             }
             logger.debug { "Client SSE session started successfully." }
-        } catch (e: ClientRequestException) {
-            if (e.response.status == HttpStatusCode.MethodNotAllowed) {
+        } catch (e: SSEClientException) {
+            if (e.response?.status == HttpStatusCode.MethodNotAllowed) {
                 logger.info { "Server returned 405 for GET/SSE, stream disabled." }
                 return
             }


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

`Client.sseSession` doesn't throw `ClientRequestException`, it throws `SSEClientException`  

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Without this fix, `StreamableHTTPTransport` crashes for stateless request 

## How Has This Been Tested?
Manually tested
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
No
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
