### PR TITLE
Add `--rerun-tasks` flag to CodeQL workflow compilation

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,7 +59,7 @@ jobs:
             :kotlin-sdk:compileKotlinJvm \
             :kotlin-sdk-test:compileKotlinJvm \
             -Pkotlin.incremental=false \
-            --no-daemon --stacktrace
+            --no-daemon --stacktrace --rerun-tasks
 
       - name: Analyze
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
CodeQL doesn’t see tasks on already opened PRs because they are up-to-date. To use the cache while still allowing CodeQL to run, I added the `--rerun-tasks`

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
