### PR TITLE
Downgrade Kotlin to 2.1.21

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,8 @@ See [How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/
 
 * To build MCP Kotlin SDK, JDK version 21 or higher is required. Make sure this is your default JDK (`JAVA_HOME` is set
   accordingly)
+* To build for MacOS/iOS targets, Xcode/Command Line Tools should be installed. See Apple Developer [documentation](https://developer.apple.com/documentation/xcode/downloading-and-installing-additional-xcode-components) for details.
+* To build JS/Wasm targets, [Node.js](https://nodejs.org/) must be installed.
 * The project can be opened in IntelliJ IDEA without additional prerequisites.
 
 ### Building MCP Kotlin SDK from source

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # MCP Kotlin SDK
 
+[![Kotlin](https://img.shields.io/badge/kotlin-2.1-blue.svg?logo=kotlin)](http://kotlinlang.org)
 [![Kotlin Multiplatform](https://img.shields.io/badge/Kotlin-Multiplatform-blueviolet?logo=kotlin)](https://kotlinlang.org/docs/multiplatform.html)
-[![Platforms](https://img.shields.io/badge/Platforms-JVM%20%7C%20Wasm%2FJS%20%7C%20Native%20(iOS%2FiOS%20Simulator)-blue)](https://kotlinlang.org/docs/multiplatform.html)
+[![Platforms](https://img.shields.io/badge/Platforms-JVM%20%7C%20Wasm%2FJS%20%7C%20Native-blue)](https://kotlinlang.org/docs/multiplatform.html)
 [![Maven Central](https://img.shields.io/maven-central/v/io.modelcontextprotocol/kotlin-sdk.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:io.modelcontextprotocol%20a:kotlin-sdk)
 [![License](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 

--- a/buildSrc/src/main/kotlin/mcp.multiplatform.gradle.kts
+++ b/buildSrc/src/main/kotlin/mcp.multiplatform.gradle.kts
@@ -3,6 +3,7 @@
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_1
 
 plugins {
     kotlin("multiplatform")
@@ -24,18 +25,40 @@ val generateLibVersion by tasks.registering {
 
             public const val LIB_VERSION: String = "${project.version}"
             
-            """.trimIndent()
+            """.trimIndent(),
         )
     }
 }
 
 kotlin {
-    jvm {
-        compilerOptions.jvmTarget = JvmTarget.JVM_1_8
+
+    compilerOptions {
+        languageVersion = KOTLIN_2_1
+        apiVersion = KOTLIN_2_1
+        // TODO: allWarningsAsErrors = true
+        extraWarnings = true
+        freeCompilerArgs =
+            listOf(
+                "-Xwhen-guards",
+            )
     }
-    macosX64(); macosArm64()
-    linuxX64(); linuxArm64()
+    coreLibrariesVersion = "2.1.21"
+
+    jvm {
+        compilerOptions {
+            jvmTarget = JvmTarget.JVM_1_8
+            javaParameters = true
+        }
+    }
+
+    macosX64()
+    macosArm64()
+
+    linuxX64()
+    linuxArm64()
+
     mingwX64()
+
     js { nodejs() }
     wasmJs { nodejs() }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,9 @@ org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
 # Kotlin
 kotlin.code.style=official
 kotlin.daemon.jvmargs=-Xmx4G
+kotlin.native.ignoreDisabledTargets=true
 # MPP
 kotlin.mpp.enableCInteropCommonization=true
+
+# Build JS targets using npm package manager https://kotlinlang.org/docs/js-project-setup.html#npm-dependencies
+kotlin.js.yarn=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,21 +1,22 @@
 [versions]
 # plugins version
-kotlin = "2.2.0"
+kotlin = "2.1.21"
 dokka = "2.0.0"
-atomicfu = "0.29.0"
+atomicfu = "0.28.0"
 ktlint = "13.0.0"
 
 # libraries version
-serialization = "1.9.0"
+binaryCompatibilityValidatorPlugin = "0.18.1"
 collections-immutable = "0.4.0"
 coroutines = "1.10.2"
-kotlinx-io = "0.8.0"
+jreleaser = "1.19.0"
+kotest = "5.9.1"
+kotlinx-datetime = "0.6.2"
+kotlinx-io = "0.7.0"
 ktor = "3.2.3"
 logging = "7.0.7"
-jreleaser = "1.19.0"
-binaryCompatibilityValidatorPlugin = "0.18.1"
+serialization = "1.8.1"
 slf4j = "2.0.17"
-kotest = "5.9.1"
 
 # Samples
 mcp-kotlin = "0.6.0"
@@ -31,11 +32,13 @@ dokka-gradle = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref
 jreleaser-gradle = { module = "org.jreleaser:jreleaser-gradle-plugin", version.ref = "jreleaser" }
 
 # Kotlinx libraries
-kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "serialization" }
-kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
-kotlinx-io-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-io-core", version.ref = "kotlinx-io" }
-kotlinx-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "collections-immutable" }
 kotlin-logging = { group = "io.github.oshai", name = "kotlin-logging", version.ref = "logging" }
+kotlinx-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "collections-immutable" }
+kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
+kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
+kotlinx-io-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-io-core", version.ref = "kotlinx-io" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "serialization" }
+
 
 # Ktor
 ktor-client-cio = { group = "io.ktor", name = "ktor-client-cio", version.ref = "ktor" }

--- a/kotlin-sdk-core/api/kotlin-sdk-core.api
+++ b/kotlin-sdk-core/api/kotlin-sdk-core.api
@@ -1,20 +1,20 @@
 public final class io/modelcontextprotocol/kotlin/sdk/Annotations {
 	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/Annotations$Companion;
-	public fun <init> (Ljava/util/List;Lkotlin/time/Instant;Ljava/lang/Double;)V
+	public fun <init> (Ljava/util/List;Lkotlinx/datetime/Instant;Ljava/lang/Double;)V
 	public final fun component1 ()Ljava/util/List;
-	public final fun component2 ()Lkotlin/time/Instant;
+	public final fun component2 ()Lkotlinx/datetime/Instant;
 	public final fun component3 ()Ljava/lang/Double;
-	public final fun copy (Ljava/util/List;Lkotlin/time/Instant;Ljava/lang/Double;)Lio/modelcontextprotocol/kotlin/sdk/Annotations;
-	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/Annotations;Ljava/util/List;Lkotlin/time/Instant;Ljava/lang/Double;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/Annotations;
+	public final fun copy (Ljava/util/List;Lkotlinx/datetime/Instant;Ljava/lang/Double;)Lio/modelcontextprotocol/kotlin/sdk/Annotations;
+	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/Annotations;Ljava/util/List;Lkotlinx/datetime/Instant;Ljava/lang/Double;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/Annotations;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAudience ()Ljava/util/List;
-	public final fun getLastModified ()Lkotlin/time/Instant;
+	public final fun getLastModified ()Lkotlinx/datetime/Instant;
 	public final fun getPriority ()Ljava/lang/Double;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/Annotations$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/Annotations$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/Annotations$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/Annotations;
@@ -22,7 +22,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/Annotations$$ser
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/Annotations;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/Annotations$Companion {
@@ -48,7 +47,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/AudioContent : io/modelcon
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/AudioContent$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/AudioContent$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/AudioContent$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/AudioContent;
@@ -56,7 +55,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/AudioContent$$se
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/AudioContent;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/AudioContent$Companion {
@@ -79,7 +77,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/BlobResourceContents : io/
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/BlobResourceContents$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/BlobResourceContents$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/BlobResourceContents$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/BlobResourceContents;
@@ -87,7 +85,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/BlobResourceCont
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/BlobResourceContents;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/BlobResourceContents$Companion {
@@ -112,7 +109,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/CallToolRequest : io/model
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/CallToolRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/CallToolRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/CallToolRequest$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/CallToolRequest;
@@ -120,7 +117,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/CallToolRequest$
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/CallToolRequest;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/CallToolRequest$Companion {
@@ -137,7 +133,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/CallToolResult : io/modelc
 	public fun isError ()Ljava/lang/Boolean;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/CallToolResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/CallToolResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/CallToolResult$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/CallToolResult;
@@ -145,7 +141,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/CallToolResult$$
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/CallToolResult;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/CallToolResult$Companion {
@@ -156,7 +151,7 @@ public abstract interface class io/modelcontextprotocol/kotlin/sdk/CallToolResul
 	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/CallToolResultBase$Companion;
 	public abstract fun getContent ()Ljava/util/List;
 	public abstract fun getStructuredContent ()Lkotlinx/serialization/json/JsonObject;
-	public fun isError ()Ljava/lang/Boolean;
+	public abstract fun isError ()Ljava/lang/Boolean;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/CallToolResultBase$Companion {
@@ -181,7 +176,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/CancelledNotification : io
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/CancelledNotification$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/CancelledNotification$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/CancelledNotification$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/CancelledNotification;
@@ -189,7 +184,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/CancelledNotific
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/CancelledNotification;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/CancelledNotification$Companion {
@@ -213,7 +207,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/CancelledNotification$Para
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/CancelledNotification$Params$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/CancelledNotification$Params$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/CancelledNotification$Params$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/CancelledNotification$Params;
@@ -221,7 +215,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/CancelledNotific
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/CancelledNotification$Params;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/CancelledNotification$Params$Companion {
@@ -248,7 +241,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/ClientCapabilities {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/ClientCapabilities$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/ClientCapabilities$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/ClientCapabilities$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/ClientCapabilities;
@@ -256,7 +249,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/ClientCapabiliti
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/ClientCapabilities;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/ClientCapabilities$Companion {
@@ -275,7 +267,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/ClientCapabilities$Roots {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/ClientCapabilities$Roots$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/ClientCapabilities$Roots$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/ClientCapabilities$Roots$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/ClientCapabilities$Roots;
@@ -283,7 +275,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/ClientCapabiliti
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/ClientCapabilities$Roots;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/ClientCapabilities$Roots$Companion {
@@ -320,7 +311,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/CompatibilityCallToolResul
 	public fun isError ()Ljava/lang/Boolean;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/CompatibilityCallToolResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/CompatibilityCallToolResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/CompatibilityCallToolResult$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/CompatibilityCallToolResult;
@@ -328,7 +319,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/CompatibilityCal
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/CompatibilityCallToolResult;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/CompatibilityCallToolResult$Companion {
@@ -353,7 +343,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/CompleteRequest : io/model
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/CompleteRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/CompleteRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/CompleteRequest$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/CompleteRequest;
@@ -361,7 +351,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/CompleteRequest$
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/CompleteRequest;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/CompleteRequest$Argument {
@@ -378,7 +367,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/CompleteRequest$Argument {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/CompleteRequest$Argument$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/CompleteRequest$Argument$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/CompleteRequest$Argument$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/CompleteRequest$Argument;
@@ -386,7 +375,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/CompleteRequest$
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/CompleteRequest$Argument;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/CompleteRequest$Argument$Companion {
@@ -412,7 +400,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/CompleteResult : io/modelc
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/CompleteResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/CompleteResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/CompleteResult$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/CompleteResult;
@@ -420,7 +408,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/CompleteResult$$
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/CompleteResult;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/CompleteResult$Companion {
@@ -435,7 +422,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/CompleteResult$Completion 
 	public final fun getValues ()Ljava/util/List;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/CompleteResult$Completion$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/CompleteResult$Completion$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/CompleteResult$Completion$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/CompleteResult$Completion;
@@ -443,7 +430,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/CompleteResult$C
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/CompleteResult$Completion;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/CompleteResult$Completion$Companion {
@@ -468,7 +454,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/CreateElicitationRequest :
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/CreateElicitationRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/CreateElicitationRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/CreateElicitationRequest$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/CreateElicitationRequest;
@@ -476,7 +462,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/CreateElicitatio
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/CreateElicitationRequest;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/CreateElicitationRequest$Companion {
@@ -500,7 +485,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/CreateElicitationRequest$R
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/CreateElicitationRequest$RequestedSchema$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/CreateElicitationRequest$RequestedSchema$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/CreateElicitationRequest$RequestedSchema$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/CreateElicitationRequest$RequestedSchema;
@@ -508,7 +493,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/CreateElicitatio
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/CreateElicitationRequest$RequestedSchema;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/CreateElicitationRequest$RequestedSchema$Companion {
@@ -532,7 +516,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/CreateElicitationResult : 
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/CreateElicitationResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/CreateElicitationResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/CreateElicitationResult$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/CreateElicitationResult;
@@ -540,7 +524,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/CreateElicitatio
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/CreateElicitationResult;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/CreateElicitationResult$Action : java/lang/Enum {
@@ -591,7 +574,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/CreateMessageRequest : io/
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/CreateMessageRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/CreateMessageRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/CreateMessageRequest$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/CreateMessageRequest;
@@ -599,7 +582,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/CreateMessageReq
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/CreateMessageRequest;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/CreateMessageRequest$Companion {
@@ -641,7 +623,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/CreateMessageResult : io/m
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/CreateMessageResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/CreateMessageResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/CreateMessageResult$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/CreateMessageResult;
@@ -649,7 +631,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/CreateMessageRes
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/CreateMessageResult;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/CreateMessageResult$Companion {
@@ -664,7 +645,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/CustomMeta : io/modelconte
 	public fun get_meta ()Lkotlinx/serialization/json/JsonObject;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/CustomMeta$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/CustomMeta$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/CustomMeta$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/CustomMeta;
@@ -672,7 +653,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/CustomMeta$$seri
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/CustomMeta;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/CustomMeta$Companion {
@@ -687,7 +667,7 @@ public class io/modelcontextprotocol/kotlin/sdk/CustomRequest : io/modelcontextp
 	public static final synthetic fun write$Self (Lio/modelcontextprotocol/kotlin/sdk/CustomRequest;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/CustomRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/CustomRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/CustomRequest$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/CustomRequest;
@@ -695,7 +675,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/CustomRequest$$s
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/CustomRequest;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/CustomRequest$Companion {
@@ -719,7 +698,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/EmbeddedResource : io/mode
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/EmbeddedResource$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/EmbeddedResource$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/EmbeddedResource$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/EmbeddedResource;
@@ -727,7 +706,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/EmbeddedResource
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/EmbeddedResource;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/EmbeddedResource$Companion {
@@ -748,7 +726,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/EmptyRequestResult : io/mo
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/EmptyRequestResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/EmptyRequestResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/EmptyRequestResult$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/EmptyRequestResult;
@@ -756,7 +734,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/EmptyRequestResu
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/EmptyRequestResult;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/EmptyRequestResult$Companion {
@@ -803,7 +780,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/ErrorCode$Unknown : io/mod
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/ErrorCode$Unknown$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/ErrorCode$Unknown$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/ErrorCode$Unknown$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/ErrorCode$Unknown;
@@ -811,7 +788,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/ErrorCode$Unknow
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/ErrorCode$Unknown;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/ErrorCode$Unknown$Companion {
@@ -836,7 +812,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/GetPromptRequest : io/mode
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/GetPromptRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/GetPromptRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/GetPromptRequest$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/GetPromptRequest;
@@ -844,7 +820,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/GetPromptRequest
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/GetPromptRequest;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/GetPromptRequest$Companion {
@@ -860,7 +835,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/GetPromptResult : io/model
 	public fun get_meta ()Lkotlinx/serialization/json/JsonObject;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/GetPromptResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/GetPromptResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/GetPromptResult$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/GetPromptResult;
@@ -868,7 +843,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/GetPromptResult$
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/GetPromptResult;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/GetPromptResult$Companion {
@@ -894,7 +868,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/ImageContent : io/modelcon
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/ImageContent$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/ImageContent$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/ImageContent$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/ImageContent;
@@ -902,7 +876,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/ImageContent$$se
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/ImageContent;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/ImageContent$Companion {
@@ -923,7 +896,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/Implementation {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/Implementation$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/Implementation$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/Implementation$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/Implementation;
@@ -931,7 +904,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/Implementation$$
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/Implementation;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/Implementation$Companion {
@@ -958,7 +930,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/InitializeRequest : io/mod
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/InitializeRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/InitializeRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/InitializeRequest$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/InitializeRequest;
@@ -966,7 +938,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/InitializeReques
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/InitializeRequest;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/InitializeRequest$Companion {
@@ -992,7 +963,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/InitializeResult : io/mode
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/InitializeResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/InitializeResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/InitializeResult$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/InitializeResult;
@@ -1000,7 +971,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/InitializeResult
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/InitializeResult;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/InitializeResult$Companion {
@@ -1023,7 +993,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/InitializedNotification : 
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/InitializedNotification$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/InitializedNotification$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/InitializedNotification$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/InitializedNotification;
@@ -1031,7 +1001,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/InitializedNotif
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/InitializedNotification;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/InitializedNotification$Companion {
@@ -1052,7 +1021,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/InitializedNotification$Pa
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/InitializedNotification$Params$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/InitializedNotification$Params$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/InitializedNotification$Params$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/InitializedNotification$Params;
@@ -1060,7 +1029,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/InitializedNotif
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/InitializedNotification$Params;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/InitializedNotification$Params$Companion {
@@ -1084,7 +1052,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/JSONRPCError : io/modelcon
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/JSONRPCError$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/JSONRPCError$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/JSONRPCError$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/JSONRPCError;
@@ -1092,7 +1060,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/JSONRPCError$$se
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/JSONRPCError;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/JSONRPCError$Companion {
@@ -1124,7 +1091,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/JSONRPCNotification : io/m
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/JSONRPCNotification$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/JSONRPCNotification$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/JSONRPCNotification$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/JSONRPCNotification;
@@ -1132,7 +1099,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/JSONRPCNotificat
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/JSONRPCNotification;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/JSONRPCNotification$Companion {
@@ -1158,7 +1124,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/JSONRPCRequest : io/modelc
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/JSONRPCRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/JSONRPCRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/JSONRPCRequest$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/JSONRPCRequest;
@@ -1166,7 +1132,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/JSONRPCRequest$$
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/JSONRPCRequest;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/JSONRPCRequest$Companion {
@@ -1185,7 +1150,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/JSONRPCResponse : io/model
 	public final fun getResult ()Lio/modelcontextprotocol/kotlin/sdk/RequestResult;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/JSONRPCResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/JSONRPCResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/JSONRPCResponse$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/JSONRPCResponse;
@@ -1193,7 +1158,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/JSONRPCResponse$
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/JSONRPCResponse;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/JSONRPCResponse$Companion {
@@ -1221,7 +1185,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/ListPromptsRequest : io/mo
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/ListPromptsRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/ListPromptsRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/ListPromptsRequest$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/ListPromptsRequest;
@@ -1229,7 +1193,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/ListPromptsReque
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/ListPromptsRequest;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/ListPromptsRequest$Companion {
@@ -1245,7 +1208,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/ListPromptsResult : io/mod
 	public fun get_meta ()Lkotlinx/serialization/json/JsonObject;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/ListPromptsResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/ListPromptsResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/ListPromptsResult$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/ListPromptsResult;
@@ -1253,7 +1216,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/ListPromptsResul
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/ListPromptsResult;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/ListPromptsResult$Companion {
@@ -1276,7 +1238,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/ListResourceTemplatesReque
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/ListResourceTemplatesRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/ListResourceTemplatesRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/ListResourceTemplatesRequest$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/ListResourceTemplatesRequest;
@@ -1284,7 +1246,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/ListResourceTemp
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/ListResourceTemplatesRequest;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/ListResourceTemplatesRequest$Companion {
@@ -1300,7 +1261,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/ListResourceTemplatesResul
 	public fun get_meta ()Lkotlinx/serialization/json/JsonObject;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/ListResourceTemplatesResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/ListResourceTemplatesResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/ListResourceTemplatesResult$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/ListResourceTemplatesResult;
@@ -1308,7 +1269,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/ListResourceTemp
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/ListResourceTemplatesResult;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/ListResourceTemplatesResult$Companion {
@@ -1332,7 +1292,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/ListResourcesRequest : io/
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/ListResourcesRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/ListResourcesRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/ListResourcesRequest$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/ListResourcesRequest;
@@ -1340,7 +1300,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/ListResourcesReq
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/ListResourcesRequest;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/ListResourcesRequest$Companion {
@@ -1356,7 +1315,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/ListResourcesResult : io/m
 	public fun get_meta ()Lkotlinx/serialization/json/JsonObject;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/ListResourcesResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/ListResourcesResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/ListResourcesResult$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/ListResourcesResult;
@@ -1364,7 +1323,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/ListResourcesRes
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/ListResourcesResult;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/ListResourcesResult$Companion {
@@ -1380,7 +1338,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/ListRootsRequest : io/mode
 	public fun get_meta ()Lkotlinx/serialization/json/JsonObject;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/ListRootsRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/ListRootsRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/ListRootsRequest$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/ListRootsRequest;
@@ -1388,7 +1346,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/ListRootsRequest
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/ListRootsRequest;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/ListRootsRequest$Companion {
@@ -1403,7 +1360,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/ListRootsResult : io/model
 	public fun get_meta ()Lkotlinx/serialization/json/JsonObject;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/ListRootsResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/ListRootsResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/ListRootsResult$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/ListRootsResult;
@@ -1411,7 +1368,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/ListRootsResult$
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/ListRootsResult;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/ListRootsResult$Companion {
@@ -1435,7 +1391,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/ListToolsRequest : io/mode
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/ListToolsRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/ListToolsRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/ListToolsRequest$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/ListToolsRequest;
@@ -1443,7 +1399,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/ListToolsRequest
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/ListToolsRequest;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/ListToolsRequest$Companion {
@@ -1459,7 +1414,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/ListToolsResult : io/model
 	public fun get_meta ()Lkotlinx/serialization/json/JsonObject;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/ListToolsResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/ListToolsResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/ListToolsResult$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/ListToolsResult;
@@ -1467,7 +1422,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/ListToolsResult$
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/ListToolsResult;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/ListToolsResult$Companion {
@@ -1507,7 +1461,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/LoggingMessageNotification
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/LoggingMessageNotification$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/LoggingMessageNotification$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/LoggingMessageNotification$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/LoggingMessageNotification;
@@ -1515,7 +1469,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/LoggingMessageNo
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/LoggingMessageNotification;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/LoggingMessageNotification$Companion {
@@ -1541,7 +1494,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/LoggingMessageNotification
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/LoggingMessageNotification$Params$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/LoggingMessageNotification$Params$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/LoggingMessageNotification$Params$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/LoggingMessageNotification$Params;
@@ -1549,7 +1502,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/LoggingMessageNo
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/LoggingMessageNotification$Params;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/LoggingMessageNotification$Params$Companion {
@@ -1572,7 +1524,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/LoggingMessageNotification
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/LoggingMessageNotification$SetLevelRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/LoggingMessageNotification$SetLevelRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/LoggingMessageNotification$SetLevelRequest$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/LoggingMessageNotification$SetLevelRequest;
@@ -1580,7 +1532,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/LoggingMessageNo
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/LoggingMessageNotification$SetLevelRequest;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/LoggingMessageNotification$SetLevelRequest$Companion {
@@ -1616,7 +1567,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/Method$Custom : io/modelco
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/Method$Custom$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/Method$Custom$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/Method$Custom$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/Method$Custom;
@@ -1624,7 +1575,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/Method$Custom$$s
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/Method$Custom;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/Method$Custom$Companion {
@@ -1680,7 +1630,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/ModelHint {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/ModelHint$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/ModelHint$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/ModelHint$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/ModelHint;
@@ -1688,7 +1638,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/ModelHint$$seria
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/ModelHint;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/ModelHint$Companion {
@@ -1704,7 +1653,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/ModelPreferences {
 	public final fun getSpeedPriority ()Ljava/lang/Double;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/ModelPreferences$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/ModelPreferences$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/ModelPreferences$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/ModelPreferences;
@@ -1712,7 +1661,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/ModelPreferences
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/ModelPreferences;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/ModelPreferences$Companion {
@@ -1762,7 +1710,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/PingRequest : io/modelcont
 	public fun getMethod ()Lio/modelcontextprotocol/kotlin/sdk/Method;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/PingRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/PingRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/PingRequest$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/PingRequest;
@@ -1770,7 +1718,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/PingRequest$$ser
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/PingRequest;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/PingRequest$Companion {
@@ -1787,7 +1734,7 @@ public class io/modelcontextprotocol/kotlin/sdk/Progress : io/modelcontextprotoc
 	public static final synthetic fun write$Self (Lio/modelcontextprotocol/kotlin/sdk/Progress;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/Progress$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/Progress$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/Progress$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/Progress;
@@ -1795,7 +1742,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/Progress$$serial
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/Progress;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/Progress$Companion {
@@ -1827,7 +1773,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/ProgressNotification : io/
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/ProgressNotification$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/ProgressNotification$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/ProgressNotification$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/ProgressNotification;
@@ -1835,7 +1781,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/ProgressNotifica
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/ProgressNotification;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/ProgressNotification$Companion {
@@ -1863,7 +1808,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/ProgressNotification$Param
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/ProgressNotification$Params$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/ProgressNotification$Params$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/ProgressNotification$Params$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/ProgressNotification$Params;
@@ -1871,7 +1816,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/ProgressNotifica
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/ProgressNotification$Params;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/ProgressNotification$Params$Companion {
@@ -1886,7 +1830,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/Prompt {
 	public final fun getName ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/Prompt$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/Prompt$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/Prompt$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/Prompt;
@@ -1894,7 +1838,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/Prompt$$serializ
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/Prompt;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/Prompt$Companion {
@@ -1917,7 +1860,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/PromptArgument {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/PromptArgument$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/PromptArgument$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/PromptArgument$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/PromptArgument;
@@ -1925,7 +1868,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/PromptArgument$$
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/PromptArgument;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/PromptArgument$Companion {
@@ -1948,7 +1890,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/PromptListChangedNotificat
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/PromptListChangedNotification$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/PromptListChangedNotification$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/PromptListChangedNotification$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/PromptListChangedNotification;
@@ -1956,7 +1898,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/PromptListChange
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/PromptListChangedNotification;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/PromptListChangedNotification$Companion {
@@ -1977,7 +1918,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/PromptListChangedNotificat
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/PromptListChangedNotification$Params$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/PromptListChangedNotification$Params$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/PromptListChangedNotification$Params$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/PromptListChangedNotification$Params;
@@ -1985,7 +1926,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/PromptListChange
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/PromptListChangedNotification$Params;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/PromptListChangedNotification$Params$Companion {
@@ -2006,7 +1946,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/PromptMessage {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/PromptMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/PromptMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/PromptMessage$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/PromptMessage;
@@ -2014,7 +1954,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/PromptMessage$$s
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/PromptMessage;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/PromptMessage$Companion {
@@ -2052,7 +1991,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/PromptReference : io/model
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/PromptReference$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/PromptReference$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/PromptReference$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/PromptReference;
@@ -2060,7 +1999,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/PromptReference$
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/PromptReference;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/PromptReference$Companion {
@@ -2083,7 +2021,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/ReadResourceRequest : io/m
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/ReadResourceRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/ReadResourceRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/ReadResourceRequest$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/ReadResourceRequest;
@@ -2091,7 +2029,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/ReadResourceRequ
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/ReadResourceRequest;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/ReadResourceRequest$Companion {
@@ -2106,7 +2043,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/ReadResourceResult : io/mo
 	public fun get_meta ()Lkotlinx/serialization/json/JsonObject;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/ReadResourceResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/ReadResourceResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/ReadResourceResult$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/ReadResourceResult;
@@ -2114,7 +2051,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/ReadResourceResu
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/ReadResourceResult;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/ReadResourceResult$Companion {
@@ -2159,7 +2095,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/RequestId$NumberId : io/mo
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/RequestId$NumberId$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/RequestId$NumberId$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/RequestId$NumberId$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/RequestId$NumberId;
@@ -2167,7 +2103,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/RequestId$Number
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/RequestId$NumberId;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/RequestId$NumberId$Companion {
@@ -2186,7 +2121,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/RequestId$StringId : io/mo
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/RequestId$StringId$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/RequestId$StringId$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/RequestId$StringId$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/RequestId$StringId;
@@ -2194,7 +2129,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/RequestId$String
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/RequestId$StringId;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/RequestId$StringId$Companion {
@@ -2243,7 +2177,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/Resource {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/Resource$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/Resource$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/Resource$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/Resource;
@@ -2251,7 +2185,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/Resource$$serial
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/Resource;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/Resource$Companion {
@@ -2284,7 +2217,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/ResourceListChangedNotific
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/ResourceListChangedNotification$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/ResourceListChangedNotification$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/ResourceListChangedNotification$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/ResourceListChangedNotification;
@@ -2292,7 +2225,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/ResourceListChan
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/ResourceListChangedNotification;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/ResourceListChangedNotification$Companion {
@@ -2313,7 +2245,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/ResourceListChangedNotific
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/ResourceListChangedNotification$Params$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/ResourceListChangedNotification$Params$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/ResourceListChangedNotification$Params$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/ResourceListChangedNotification$Params;
@@ -2321,7 +2253,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/ResourceListChan
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/ResourceListChangedNotification$Params;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/ResourceListChangedNotification$Params$Companion {
@@ -2351,7 +2282,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/ResourceTemplate {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/ResourceTemplate$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/ResourceTemplate$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/ResourceTemplate$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/ResourceTemplate;
@@ -2359,7 +2290,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/ResourceTemplate
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/ResourceTemplate;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/ResourceTemplate$Companion {
@@ -2380,7 +2310,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/ResourceTemplateReference 
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/ResourceTemplateReference$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/ResourceTemplateReference$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/ResourceTemplateReference$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/ResourceTemplateReference;
@@ -2388,7 +2318,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/ResourceTemplate
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/ResourceTemplateReference;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/ResourceTemplateReference$Companion {
@@ -2409,7 +2338,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/ResourceUpdatedNotificatio
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/ResourceUpdatedNotification$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/ResourceUpdatedNotification$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/ResourceUpdatedNotification$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/ResourceUpdatedNotification;
@@ -2417,7 +2346,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/ResourceUpdatedN
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/ResourceUpdatedNotification;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/ResourceUpdatedNotification$Companion {
@@ -2439,7 +2367,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/ResourceUpdatedNotificatio
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/ResourceUpdatedNotification$Params$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/ResourceUpdatedNotification$Params$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/ResourceUpdatedNotification$Params$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/ResourceUpdatedNotification$Params;
@@ -2447,7 +2375,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/ResourceUpdatedN
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/ResourceUpdatedNotification$Params;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/ResourceUpdatedNotification$Params$Companion {
@@ -2481,7 +2408,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/Root {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/Root$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/Root$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/Root$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/Root;
@@ -2489,7 +2416,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/Root$$serializer
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/Root;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/Root$Companion {
@@ -2512,7 +2438,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/RootsListChangedNotificati
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/RootsListChangedNotification$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/RootsListChangedNotification$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/RootsListChangedNotification$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/RootsListChangedNotification;
@@ -2520,7 +2446,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/RootsListChanged
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/RootsListChangedNotification;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/RootsListChangedNotification$Companion {
@@ -2541,7 +2466,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/RootsListChangedNotificati
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/RootsListChangedNotification$Params$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/RootsListChangedNotification$Params$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/RootsListChangedNotification$Params$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/RootsListChangedNotification$Params;
@@ -2549,7 +2474,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/RootsListChanged
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/RootsListChangedNotification$Params;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/RootsListChangedNotification$Params$Companion {
@@ -2570,7 +2494,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/SamplingMessage {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/SamplingMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/SamplingMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/SamplingMessage$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/SamplingMessage;
@@ -2578,7 +2502,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/SamplingMessage$
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/SamplingMessage;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/SamplingMessage$Companion {
@@ -2609,7 +2532,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/ServerCapabilities {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/ServerCapabilities$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/ServerCapabilities$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/ServerCapabilities$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/ServerCapabilities;
@@ -2617,7 +2540,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/ServerCapabiliti
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/ServerCapabilities;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/ServerCapabilities$Companion {
@@ -2636,7 +2558,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/ServerCapabilities$Prompts
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/ServerCapabilities$Prompts$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/ServerCapabilities$Prompts$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/ServerCapabilities$Prompts$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/ServerCapabilities$Prompts;
@@ -2644,7 +2566,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/ServerCapabiliti
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/ServerCapabilities$Prompts;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/ServerCapabilities$Prompts$Companion {
@@ -2665,7 +2586,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/ServerCapabilities$Resourc
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/ServerCapabilities$Resources$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/ServerCapabilities$Resources$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/ServerCapabilities$Resources$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/ServerCapabilities$Resources;
@@ -2673,7 +2594,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/ServerCapabiliti
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/ServerCapabilities$Resources;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/ServerCapabilities$Resources$Companion {
@@ -2692,7 +2612,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/ServerCapabilities$Tools {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/ServerCapabilities$Tools$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/ServerCapabilities$Tools$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/ServerCapabilities$Tools$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/ServerCapabilities$Tools;
@@ -2700,7 +2620,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/ServerCapabiliti
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/ServerCapabilities$Tools;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/ServerCapabilities$Tools$Companion {
@@ -2768,7 +2687,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/StopReason$Other : io/mode
 	public final synthetic fun unbox-impl ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/StopReason$Other$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/StopReason$Other$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/StopReason$Other$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
@@ -2776,7 +2695,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/StopReason$Other
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
 	public final fun serialize-AuY3eX0 (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/String;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/StopReason$Other$Companion {
@@ -2808,7 +2726,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/SubscribeRequest : io/mode
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/SubscribeRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/SubscribeRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/SubscribeRequest$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/SubscribeRequest;
@@ -2816,7 +2734,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/SubscribeRequest
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/SubscribeRequest;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/SubscribeRequest$Companion {
@@ -2841,7 +2758,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/TextContent : io/modelcont
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/TextContent$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/TextContent$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/TextContent$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/TextContent;
@@ -2849,7 +2766,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/TextContent$$ser
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/TextContent;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/TextContent$Companion {
@@ -2872,7 +2788,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/TextResourceContents : io/
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/TextResourceContents$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/TextResourceContents$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/TextResourceContents$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/TextResourceContents;
@@ -2880,7 +2796,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/TextResourceCont
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/TextResourceContents;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/TextResourceContents$Companion {
@@ -2909,7 +2824,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/Tool {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/Tool$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/Tool$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/Tool$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/Tool;
@@ -2917,7 +2832,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/Tool$$serializer
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/Tool;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/Tool$Companion {
@@ -2941,7 +2855,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/Tool$Input {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/Tool$Input$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/Tool$Input$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/Tool$Input$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/Tool$Input;
@@ -2949,7 +2863,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/Tool$Input$$seri
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/Tool$Input;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/Tool$Input$Companion {
@@ -2973,7 +2886,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/Tool$Output {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/Tool$Output$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/Tool$Output$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/Tool$Output$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/Tool$Output;
@@ -2981,7 +2894,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/Tool$Output$$ser
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/Tool$Output;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/Tool$Output$Companion {
@@ -3009,7 +2921,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/ToolAnnotations {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/ToolAnnotations$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/ToolAnnotations$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/ToolAnnotations$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/ToolAnnotations;
@@ -3017,7 +2929,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/ToolAnnotations$
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/ToolAnnotations;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/ToolAnnotations$Companion {
@@ -3040,7 +2951,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/ToolListChangedNotificatio
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/ToolListChangedNotification$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/ToolListChangedNotification$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/ToolListChangedNotification$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/ToolListChangedNotification;
@@ -3048,7 +2959,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/ToolListChangedN
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/ToolListChangedNotification;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/ToolListChangedNotification$Companion {
@@ -3069,7 +2979,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/ToolListChangedNotificatio
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/ToolListChangedNotification$Params$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/ToolListChangedNotification$Params$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/ToolListChangedNotification$Params$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/ToolListChangedNotification$Params;
@@ -3077,7 +2987,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/ToolListChangedN
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/ToolListChangedNotification$Params;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/ToolListChangedNotification$Params$Companion {
@@ -3112,7 +3021,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/UnknownContent : io/modelc
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/UnknownContent$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/UnknownContent$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/UnknownContent$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/UnknownContent;
@@ -3120,7 +3029,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/UnknownContent$$
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/UnknownContent;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/UnknownContent$Companion {
@@ -3142,7 +3050,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/UnknownMethodRequestOrNoti
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/UnknownMethodRequestOrNotification$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/UnknownMethodRequestOrNotification$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/UnknownMethodRequestOrNotification$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/UnknownMethodRequestOrNotification;
@@ -3150,7 +3058,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/UnknownMethodReq
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/UnknownMethodRequestOrNotification;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/UnknownMethodRequestOrNotification$Companion {
@@ -3169,7 +3076,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/UnknownReference : io/mode
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/UnknownReference$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/UnknownReference$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/UnknownReference$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/UnknownReference;
@@ -3177,7 +3084,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/UnknownReference
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/UnknownReference;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/UnknownReference$Companion {
@@ -3198,7 +3104,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/UnknownResourceContents : 
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/UnknownResourceContents$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/UnknownResourceContents$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/UnknownResourceContents$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/UnknownResourceContents;
@@ -3206,7 +3112,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/UnknownResourceC
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/UnknownResourceContents;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/UnknownResourceContents$Companion {
@@ -3229,7 +3134,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/UnsubscribeRequest : io/mo
 	public fun toString ()Ljava/lang/String;
 }
 
-public final synthetic class io/modelcontextprotocol/kotlin/sdk/UnsubscribeRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public synthetic class io/modelcontextprotocol/kotlin/sdk/UnsubscribeRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/UnsubscribeRequest$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/UnsubscribeRequest;
@@ -3237,7 +3142,6 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/UnsubscribeReque
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/UnsubscribeRequest;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/UnsubscribeRequest$Companion {

--- a/kotlin-sdk-core/build.gradle.kts
+++ b/kotlin-sdk-core/build.gradle.kts
@@ -34,6 +34,7 @@ kotlin {
             dependencies {
                 api(libs.kotlinx.serialization.json)
                 api(libs.kotlinx.coroutines.core)
+                api(libs.kotlinx.datetime)
                 api(libs.kotlinx.io.core)
                 api(libs.ktor.server.websockets)
                 api(libs.kotlinx.collections.immutable)

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types.kt
@@ -1,8 +1,7 @@
-@file:Suppress("unused", "EnumEntryName")
-
 package io.modelcontextprotocol.kotlin.sdk
 
 import io.modelcontextprotocol.kotlin.sdk.shared.McpJson
+import kotlinx.datetime.Instant
 import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
@@ -17,8 +16,6 @@ import kotlin.concurrent.atomics.AtomicLong
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.jvm.JvmInline
-import kotlin.time.ExperimentalTime
-import kotlin.time.Instant
 
 public const val LATEST_PROTOCOL_VERSION: String = "2025-03-26"
 
@@ -302,6 +299,7 @@ public data class JSONRPCError(val code: ErrorCode, val message: String, val dat
 public sealed interface NotificationParams : WithMeta
 
 /* Cancellation */
+
 /**
  * This notification can be sent by either side to indicate that it is cancelling a previously issued request.
  *
@@ -334,6 +332,7 @@ public data class CancelledNotification(override val params: Params) :
 }
 
 /* Initialization */
+
 /**
  * Describes the name and version of an MCP implementation.
  */
@@ -527,6 +526,7 @@ public data class InitializedNotification(override val params: Params = Params()
 }
 
 /* Ping */
+
 /**
  * A ping, issued by either the server or the client, to check that the other party is still alive.
  * The receiver must promptly respond, or else it may be disconnected.
@@ -560,6 +560,7 @@ public sealed interface ProgressBase {
 }
 
 /* Progress notifications */
+
 /**
  * Represents a progress notification.
  *
@@ -619,6 +620,7 @@ public data class ProgressNotification(override val params: Params) :
 }
 
 /* Pagination */
+
 /**
  * Represents a request supporting pagination.
  */
@@ -646,6 +648,7 @@ public sealed interface PaginatedResult : RequestResult {
 }
 
 /* Resources */
+
 /**
  * The contents of a specific resource or sub-resource.
  */
@@ -888,6 +891,7 @@ public data class ResourceUpdatedNotification(override val params: Params) : Ser
 }
 
 /* Prompts */
+
 /**
  * Describes an argument that a prompt can accept.
  */
@@ -1111,7 +1115,6 @@ public data class Annotations(
     /**
      * The moment the resource was last modified.
      */
-    @OptIn(ExperimentalTime::class)
     val lastModified: Instant?,
     /**
      * Describes how important this data is for operating the server.
@@ -1158,6 +1161,7 @@ public data class PromptListChangedNotification(override val params: Params = Pa
 }
 
 /* Tools */
+
 /**
  * Additional properties describing a Tool to clients.
  *
@@ -1336,6 +1340,7 @@ public data class ToolListChangedNotification(override val params: Params = Para
 }
 
 /* Logging */
+
 /**
  * The severity of a log message.
  */
@@ -1395,6 +1400,7 @@ public data class LoggingMessageNotification(override val params: Params) : Serv
 }
 
 /* Sampling */
+
 /**
  * Hints to use for model selection.
  */
@@ -1486,8 +1492,13 @@ public data class CreateMessageRequest(
     WithMeta {
     override val method: Method = Method.Defined.SamplingCreateMessage
 
+    @Suppress("EnumEntryName")
     @Serializable
-    public enum class IncludeContext { none, thisServer, allServers }
+    public enum class IncludeContext {
+        none,
+        thisServer,
+        allServers,
+    }
 }
 
 @Serializable(with = StopReasonSerializer::class)
@@ -1614,7 +1625,6 @@ public data class CompleteRequest(
 @Serializable
 public data class CompleteResult(val completion: Completion, override val _meta: JsonObject = EmptyJsonObject) :
     ServerResult {
-    @Suppress("CanBeParameter")
     @Serializable
     public class Completion(
         /**
@@ -1639,6 +1649,7 @@ public data class CompleteResult(val completion: Completion, override val _meta:
 }
 
 /* Roots */
+
 /**
  * Represents a root directory or file that the server can operate on.
  */
@@ -1729,6 +1740,7 @@ public data class CreateElicitationResult(
     }
 
     @Serializable
+    @Suppress("EnumEntryName")
     public enum class Action { accept, decline, cancel }
 }
 

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/TypesTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/TypesTest.kt
@@ -1,13 +1,13 @@
 package io.modelcontextprotocol.kotlin.sdk
 
 import io.modelcontextprotocol.kotlin.sdk.shared.McpJson
+import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 import kotlin.time.ExperimentalTime
-import kotlin.time.Instant
 
 class TypesTest {
 


### PR DESCRIPTION
# Downgrade Kotlin to 2.1.21

## Motivation and Context

Compiled iOS client is not compatible with frameworks, which are using older version of Kotlin.
- [Slack thread](https://kotlinlang.slack.com/archives/C08SLB97W23/p1757126633769069)
- [KG-380](https://youtrack.jetbrains.com/issue/KG-380) Make agents-mcp support KMP targets
- This PR is blocked: https://github.com/JetBrains/koog/pull/756
 
Kotlin version should be downgraded 2.2.0->2.1.21 to make possible use native artifacts in other projects, e.g. [Koog](https://github.com/JetBrains/koog)

## Changes

- Downgrade Kotlin 2.2.0->2.1.21 to make broader adoption possible. Update Kotlin compiler configuration
- **Breaking change:** Add [kotlinx-datetime](https://github.com/Kotlin/kotlinx-datetime) dependency. Switch from `kotlin.time.Instant` to `kotlinx.datetime.Instant`.
- Downgrade atomicfu 0.29.0->0.28.0
- Downgrade kotlinx-serialization 1.9.0->1.8.1

## Breaking Changes
- Switch to kotlinx-datetime is causing signature changes: `kotlin.time.Instant` to `kotlinx.datetime.Instant`.

## How Has This Been Tested?
- Build project locally
- [PR Validaiton](https://github.com/kpavlov/mcp-kotlin-sdk/actions/runs/17543215382)


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
