### PR TITLE
Update build workflow to use larger macOS runner and set Java options

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   validate-pr:
-    runs-on: macos-latest
+    runs-on: macos-latest-xlarge
     name: Validate PR
     steps:
       - uses: actions/checkout@v5
@@ -33,6 +33,8 @@ jobs:
 
       - name: Build with Gradle
         run: ./gradlew clean ktlintCheck build koverLog koverHtmlReport
+        env:
+          JAVA_OPTS: "-Xmx8g -Dfile.encoding=UTF-8 -Djava.awt.headless=true -Dkotlin.daemon.jvm.options=-Xmx6g"
 
       - name: Upload Reports
         if: always()


### PR DESCRIPTION
## Motivation and Context

To speed-up CI:

- Switch `runs-on` to `macos-latest-xlarge` for additional resources.
- Add `JAVA_OPTS` environment variable for optimized memory and encoding settings during Gradle builds.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Build improvement

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
