### PR TITLE
Remove docs command from workflow

### DIFF
--- a/.github/workflows/apidocs.yaml
+++ b/.github/workflows/apidocs.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Generate Dokka Site
         run: |-
-          ./gradlew :docs:clean :docs:dokkaGenerate
+          ./gradlew clean dokkaGenerate
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4


### PR DESCRIPTION
Remove `docs:clean` and `docs:dokkaGenerate` from apidocs workflow

## Motivation and Context
fix build and deploy docs to github pages 

## Breaking Changes
no

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

