### PR TITLE
Fix Dokka Gradle task call in API docs workflow.

### DIFF
--- a/.github/workflows/apidocs.yaml
+++ b/.github/workflows/apidocs.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Generate Dokka Site
         run: |-
-          ./gradlew :docs:clean :docs:dokkaGenerate
+          ./gradlew clean dokkaGenerate
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4


### PR DESCRIPTION
Fix Dokka Gradle task call in API docs workflow.

## Motivation and Context

Wrong gradle goal is called in apidocs workflow

## How Has This Been Tested?

`./gradlew clean dokkaGenerate`

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
