### PR TITLE
Implement logging disable feature in MCP server

### DIFF
--- a/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/Server.kt
+++ b/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/Server.kt
@@ -1,6 +1,10 @@
 package io.modelcontextprotocol.kotlin.sdk.server
 
+import io.github.oshai.kotlinlogging.KLogger
+import io.github.oshai.kotlinlogging.KLoggingEventBuilder
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.github.oshai.kotlinlogging.Level
+import io.github.oshai.kotlinlogging.Marker
 import io.modelcontextprotocol.kotlin.sdk.CallToolRequest
 import io.modelcontextprotocol.kotlin.sdk.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.ClientCapabilities
@@ -56,7 +60,7 @@ import kotlinx.collections.immutable.toPersistentSet
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.serialization.json.JsonObject
 
-private val logger = KotlinLogging.logger {}
+private var logger = KotlinLogging.logger{}
 
 /**
  * Configuration options for the MCP server.
@@ -109,6 +113,7 @@ public open class Server(private val serverInfo: Implementation, options: Server
         get() = _resources.value
 
     init {
+
         logger.debug { "Initializing MCP server with capabilities: $capabilities" }
 
         // Core protocol handlers
@@ -804,6 +809,21 @@ public open class Server(private val serverInfo: Implementation, options: Server
 
             "ping", "initialize" -> {
                 // No capability required
+            }
+        }
+    }
+    companion object{
+        fun disableLogging(){
+            logger = object : KLogger {
+                override val name: String
+                    get() = "no"
+
+                override fun at(level: Level, marker: Marker?, block: KLoggingEventBuilder.() -> Unit) {
+                }
+
+                override fun isLoggingEnabledFor(level: Level, marker: Marker?): Boolean {
+                    return false
+                }
             }
         }
     }


### PR DESCRIPTION
Added a method to disable logging in the MCP server.

Add a function to disable the logger. 

## Motivation and Context
This is needed because prints are causing errors on my nodejs stdio implementation

## How Has This Been Tested?
Compiles and works in my environment

## Breaking Changes
no

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
