### PR TITLE
Capture version at configuration time to avoid configuration cache issue

### DIFF
--- a/kotlin-sdk-core/build.gradle.kts
+++ b/kotlin-sdk-core/build.gradle.kts
@@ -14,6 +14,9 @@ val generateLibVersion by tasks.registering {
     val outputDir = layout.buildDirectory.dir("generated-sources/libVersion")
     outputs.dir(outputDir)
 
+    // Capture version at configuration time to avoid configuration cache issues
+    val projectVersion = project.version.toString()
+
     doLast {
         val sourceFile = outputDir.get().file("io/modelcontextprotocol/kotlin/sdk/LibVersion.kt").asFile
         sourceFile.parentFile.mkdirs()
@@ -21,7 +24,7 @@ val generateLibVersion by tasks.registering {
             """
             package io.modelcontextprotocol.kotlin.sdk
 
-            public const val LIB_VERSION: String = "${project.version}"
+            public const val LIB_VERSION: String = "$projectVersion"
             
             """.trimIndent(),
         )


### PR DESCRIPTION
Moves capture of the project version to execution time to avoid a gradle configuration cache issue

## Motivation and Context
Improves support for configuration cache

## How Has This Been Tested?
Its been tested locally and removes the gradle warning

## Breaking Changes
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

