### PR TITLE
Conditionally imports the samples only if its the root project

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,7 +25,9 @@ include(
     ":kotlin-sdk-test",
 )
 
-// Include sample projects as composite builds
-includeBuild("samples/kotlin-mcp-client")
-includeBuild("samples/kotlin-mcp-server")
-includeBuild("samples/weather-stdio-server")
+// Include sample projects as composite builds if this is the root project
+if (gradle.parent == null) {
+    includeBuild("samples/kotlin-mcp-client")
+    includeBuild("samples/kotlin-mcp-server")
+    includeBuild("samples/weather-stdio-server")
+}


### PR DESCRIPTION
When pulling this project into a composite project, via IncludeBuild, the samples are not necessary nor probably desired. They also cause issues as a transitive dependency

## Motivation and Context
Improves the ability to pull the SDK into a composite build

## How Has This Been Tested?
yes, tested locally in a composite build

## Breaking Changes
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
