### PR TITLE
Change sample server host from 0.0.0.0 to 127.0.0.1

### DIFF
--- a/samples/kotlin-mcp-server/src/commonMain/kotlin/server.kt
+++ b/samples/kotlin-mcp-server/src/commonMain/kotlin/server.kt
@@ -101,7 +101,7 @@ suspend fun runSseMcpServerWithPlainConfiguration(port: Int) {
 
     val server = configureServer()
 
-    embeddedServer(CIO, host = "0.0.0.0", port = port) {
+    embeddedServer(CIO, host = "127.0.0.1", port = port) {
         install(SSE)
         routing {
             sse("/sse") {
@@ -145,7 +145,7 @@ suspend fun runSseMcpServerUsingKtorPlugin(port: Int) {
     println("Starting sse server on port $port")
     println("Use inspector to connect to the http://localhost:$port/sse")
 
-    embeddedServer(CIO, host = "0.0.0.0", port = port) {
+    embeddedServer(CIO, host = "127.0.0.1", port = port) {
         mcp {
             return@mcp configureServer()
         }


### PR DESCRIPTION
Don't bind the sample server to `0.0.0.0` by default as that exposes the server to anyone else on the local network.

If anyone were to use these samples as staring points to build larger services, those servers would thus expose developers to attack immediately upon launch.

I'd prefer if we avoided that 😆

## Motivation and Context

🔒  Security

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
I haven't checked out the code locally to verify it works. All the editing to the code was done on GitHub.com

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

No.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
