### PR TITLE
Compatibility updates for gradle 9.x.x

### DIFF
--- a/kotlin-sdk-core/build.gradle.kts
+++ b/kotlin-sdk-core/build.gradle.kts
@@ -46,8 +46,8 @@ openApiGenerate {
     generateModelDocumentation = false
     cleanupOutput = false
     skipValidateSpec = true // do not validate spec
-    library = "multiplatform"
-    ignoreFileOverride = "${layout.projectDirectory}/.openapi-generator-ignore"
+    library.set("multiplatform")
+    ignoreFileOverride.set("${layout.projectDirectory}/.openapi-generator-ignore")
     globalProperties.set(
         mapOf(
             "supportingFiles" to "",


### PR DESCRIPTION
Changes to kotlin-sdk-core/build.gradle.kts to be compatible with gradle 9.x.x

## Motivation and Context
If including this project into a composite build that uses gradle 9.x.x, recent changes to the build.gradle.kts are not compatible.

## How Has This Been Tested?
The build still works with gradle 8.x

## Breaking Changes
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
