### PR TITLE
Fix: Return CallToolResult with isError for tool errors to conform with MCP spec

### DIFF
--- a/kotlin-sdk-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/typescript/stdio/KotlinClientTsServerEdgeCasesTestStdio.kt
+++ b/kotlin-sdk-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/typescript/stdio/KotlinClientTsServerEdgeCasesTestStdio.kt
@@ -14,7 +14,6 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
-import org.junit.jupiter.api.assertThrows
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -31,16 +30,19 @@ class KotlinClientTsServerEdgeCasesTestStdio : TsTestBase() {
             val nonExistentToolName = "non-existent-tool"
             val arguments = mapOf("name" to "TestUser")
 
-            val exception = assertThrows<IllegalStateException> {
-                client.callTool(nonExistentToolName, arguments)
-            }
+            val result = client.callTool(nonExistentToolName, arguments)
+            assertNotNull(result, "Tool call result should not be null")
 
-            val expectedMessage =
-                "JSONRPCError(code=InvalidParams, message=MCP error -32602: Tool non-existent-tool not found, data={})"
-            assertEquals(
-                expectedMessage,
-                exception.message,
-                "Unexpected error message for non-existent tool",
+            val callResult = result as CallToolResult
+            assertTrue(callResult.isError ?: false, "isError should be true for non-existent tool")
+
+            val textContent = callResult.content.firstOrNull { it is TextContent } as? TextContent
+            assertNotNull(textContent, "Error content should be present in the result")
+
+            val errorText = textContent.text ?: ""
+            assertTrue(
+                errorText.contains("non-existent-tool") && errorText.contains("not found"),
+                "Error message should indicate the tool was not found",
             )
         }
     }
@@ -133,26 +135,20 @@ class KotlinClientTsServerEdgeCasesTestStdio : TsTestBase() {
                 "name" to JsonObject(mapOf("nested" to JsonPrimitive("value"))),
             )
 
-            val exception = assertThrows<IllegalStateException> {
-                client.callTool("greet", invalidArguments)
-            }
+            val result = client.callTool("greet", invalidArguments)
+            assertNotNull(result, "Tool call result should not be null")
 
-            val msg = exception.message ?: ""
-            val expectedMessage = """
-                        JSONRPCError(code=InvalidParams, message=MCP error -32602: Invalid arguments for tool greet: [
-                          {
-                            "code": "invalid_type",
-                            "expected": "string",
-                            "received": "object",
-                            "path": [
-                              "name"
-                            ],
-                            "message": "Expected string, received object"
-                          }
-                        ], data={})
-            """.trimIndent()
+            val callResult = result as CallToolResult
+            assertTrue(callResult.isError ?: false, "isError should be true for invalid arguments")
 
-            assertEquals(expectedMessage, msg, "Unexpected error message for invalid arguments")
+            val textContent = callResult.content.firstOrNull { it is TextContent } as? TextContent
+            assertNotNull(textContent, "Error content should be present in the result")
+
+            val errorText = textContent.text ?: ""
+            assertTrue(
+                errorText.contains("Invalid arguments") && errorText.contains("greet"),
+                "Error message should indicate invalid arguments for tool greet",
+            )
         }
     }
 


### PR DESCRIPTION
Update server-side tool error handling to return `CallToolResult` with `isError: true` instead of throwing protocol-level exceptions, conforming with MCP specification

## Motivation and Context
[The MCP specification states](https://modelcontextprotocol.io/specification/2025-06-18/schema#calltoolresult):
  > Any errors that originate from the tool SHOULD be reported inside the result object, with isError set to true, not as an MCP protocol-level error response. Otherwise, the LLM would not be able
  to see that an error occurred and self-correct.

This PR updates the kotlin sdk to match this behavior

## How Has This Been Tested?
All tests pass successfully with the new behavior

## Breaking Changes
None

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

The TypeScript SDK was recently updated [#1044](https://github.com/modelcontextprotocol/typescript-sdk/pull/1044) to conform with the MCP specification regarding tool error handling. That’s why we got exceptions in the integration tests
