### PR TITLE
fix: Support custom routing paths in mcp() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ fun Application.module() {
 Inside a custom Ktor's `Route`:
 ```kotlin
 import io.ktor.server.application.*
+import io.ktor.server.routing.*
 import io.ktor.server.sse.SSE
 import io.modelcontextprotocol.kotlin.sdk.server.mcp
 
@@ -179,22 +180,20 @@ fun Application.module() {
     install(SSE)
 
     routing {
-        route("myRoute") {
-            mcp {
-                Server(
-                    serverInfo = Implementation(
-                        name = "example-sse-server",
-                        version = "1.0.0"
-                    ),
-                    options = ServerOptions(
-                        capabilities = ServerCapabilities(
-                            prompts = ServerCapabilities.Prompts(listChanged = null),
-                            resources = ServerCapabilities.Resources(subscribe = null, listChanged = null)
-                        )
-                    ),
-                ) {
-                    "Connect via SSE to interact with this MCP server."
-                }
+        mcp("/myRoute") {
+            Server(
+                serverInfo = Implementation(
+                    name = "example-sse-server",
+                    version = "1.0.0"
+                ),
+                options = ServerOptions(
+                    capabilities = ServerCapabilities(
+                        prompts = ServerCapabilities.Prompts(listChanged = null),
+                        resources = ServerCapabilities.Resources(subscribe = null, listChanged = null)
+                    )
+                ),
+            ) {
+                "Connect via SSE to interact with this MCP server."
             }
         }
     }

--- a/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/KtorServer.kt
+++ b/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/KtorServer.kt
@@ -8,7 +8,6 @@ import io.ktor.server.response.respond
 import io.ktor.server.routing.Routing
 import io.ktor.server.routing.RoutingContext
 import io.ktor.server.routing.post
-import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
 import io.ktor.server.sse.SSE
 import io.ktor.server.sse.ServerSSESession
@@ -38,8 +37,16 @@ internal class SseTransportManager(transports: Map<String, SseServerTransport> =
 
 @KtorDsl
 public fun Routing.mcp(path: String, block: ServerSSESession.() -> Server) {
-    route(path) {
-        mcp(block)
+    val sseTransportManager = SseTransportManager()
+
+    // SSE endpoint at the specified path
+    sse(path) {
+        mcpSseEndpoint("", sseTransportManager, block)
+    }
+
+    // POST endpoint at the same path
+    post(path) {
+        mcpPostEndpoint(sseTransportManager)
     }
 }
 


### PR DESCRIPTION
- Fix Routing.mcp(path) to properly create SSE and POST endpoints
- Add tests for custom paths (/sse, /api/mcp)
- Fix README example to use mcp(path) instead of route + mcp

Resolves custom routing 404 issue reported in #356

## Motivation and Context

When using custom routing paths (e.g., `/sse`, `/api/mcp`) with the `mcp(path)` function, the endpoints return 404 Not Found. This prevents users from serving MCP at custom paths for backward compatibility or organizational requirements.

The root cause is that the current implementation uses `route(path) { mcp(block) }`, which creates a routing context but doesn't properly propagate the path to the `sse {}` and `post {}` endpoints inside. As a result, these endpoints get registered at the root level instead of the specified custom path.

This fix ensures that custom routing works as documented in the README, allowing users to serve MCP at any path they choose.

## How Has This Been Tested?

**Test scenarios:**
1. ✅ Custom SSE path (`/sse`) - JVM test added and passing
2. ✅ Custom nested path (`/api/mcp`) - JVM test added
3. ✅ Root path (`/`) - Existing tests continue to pass
4. ✅ Real application testing with MCP-Magic application and Cursor IDE

**Manual verification:**
```bash
# Before fix
curl -X POST http://127.0.0.1:3056/sse
# Result: HTTP/1.1 404 Not Found

# After fix
curl -X POST http://127.0.0.1:3056/sse
# Result: HTTP/1.1 400 Bad Request - "sessionId query parameter is not provided"
# (This is the correct MCP protocol response)
```

**Build validation:**
- `./gradlew :kotlin-sdk-server:build` - Success
- `./gradlew :kotlin-sdk-test:jvmTest` - All tests pass
- `./gradlew apiCheck` - No API changes detected

## Breaking Changes

None. This is a bug fix that maintains backward compatibility:
- **Root path usage**: `mcp { server }` - unchanged, works as before
- **Custom paths**: `mcp("/sse") { server }` - now works correctly (was broken)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

**Implementation details:**

Changed from:
```kotlin
public fun Routing.mcp(path: String, block: ServerSSESession.() -> Server) {
    route(path) {
        mcp(block)  // Endpoints registered at root, not at path
    }
}
```

To:
```kotlin
public fun Routing.mcp(path: String, block: ServerSSESession.() -> Server) {
    val sseTransportManager = SseTransportManager()

    sse(path) {  // Explicit path registration
        mcpSseEndpoint("", sseTransportManager, block)
    }

    post(path) {  // Explicit path registration
        mcpPostEndpoint(sseTransportManager)
    }
}
```

**Why this approach:**
- Uses the same pattern as the parameterless `mcp(block)` function
- Each custom path gets its own `SseTransportManager` instance
- Explicitly specifies paths for `sse()` and `post()` to ensure proper registration
- Minimal code changes, preserving existing behavior

**Related upgrade note:**
Users experiencing empty POST body issues should upgrade to Ktor 3.1.3+ as recommended in #356.

