### PR TITLE
Add new helper properties to request and notification types

### DIFF
--- a/kotlin-sdk-core/api/kotlin-sdk-core.api
+++ b/kotlin-sdk-core/api/kotlin-sdk-core.api
@@ -773,9 +773,12 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/CancelledNotificatio
 	public final fun copy (Lio/modelcontextprotocol/kotlin/sdk/types/CancelledNotificationParams;)Lio/modelcontextprotocol/kotlin/sdk/types/CancelledNotification;
 	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/types/CancelledNotification;Lio/modelcontextprotocol/kotlin/sdk/types/CancelledNotificationParams;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/CancelledNotification;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMeta ()Lkotlinx/serialization/json/JsonObject;
 	public fun getMethod ()Lio/modelcontextprotocol/kotlin/sdk/types/Method;
 	public fun getParams ()Lio/modelcontextprotocol/kotlin/sdk/types/CancelledNotificationParams;
 	public synthetic fun getParams ()Lio/modelcontextprotocol/kotlin/sdk/types/NotificationParams;
+	public final fun getReason ()Ljava/lang/String;
+	public final fun getRequestId ()Lio/modelcontextprotocol/kotlin/sdk/types/RequestId;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -931,9 +934,13 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/CompleteRequest : io
 	public final fun copy (Lio/modelcontextprotocol/kotlin/sdk/types/CompleteRequestParams;)Lio/modelcontextprotocol/kotlin/sdk/types/CompleteRequest;
 	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/types/CompleteRequest;Lio/modelcontextprotocol/kotlin/sdk/types/CompleteRequestParams;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/CompleteRequest;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArgument ()Lio/modelcontextprotocol/kotlin/sdk/types/CompleteRequestParams$Argument;
+	public final fun getContext ()Lio/modelcontextprotocol/kotlin/sdk/types/CompleteRequestParams$Context;
+	public final fun getMeta-VI-3G7E ()Lkotlinx/serialization/json/JsonObject;
 	public fun getMethod ()Lio/modelcontextprotocol/kotlin/sdk/types/Method;
 	public fun getParams ()Lio/modelcontextprotocol/kotlin/sdk/types/CompleteRequestParams;
 	public synthetic fun getParams ()Lio/modelcontextprotocol/kotlin/sdk/types/RequestParams;
+	public final fun getRef ()Lio/modelcontextprotocol/kotlin/sdk/types/Reference;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -1140,9 +1147,18 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/CreateMessageRequest
 	public final fun copy (Lio/modelcontextprotocol/kotlin/sdk/types/CreateMessageRequestParams;)Lio/modelcontextprotocol/kotlin/sdk/types/CreateMessageRequest;
 	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/types/CreateMessageRequest;Lio/modelcontextprotocol/kotlin/sdk/types/CreateMessageRequestParams;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/CreateMessageRequest;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIncludeContext ()Lio/modelcontextprotocol/kotlin/sdk/types/IncludeContext;
+	public final fun getMaxTokens ()I
+	public final fun getMessages ()Ljava/util/List;
+	public final fun getMeta-VI-3G7E ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getMetadata ()Lkotlinx/serialization/json/JsonObject;
 	public fun getMethod ()Lio/modelcontextprotocol/kotlin/sdk/types/Method;
+	public final fun getModelPreferences ()Lio/modelcontextprotocol/kotlin/sdk/types/ModelPreferences;
 	public fun getParams ()Lio/modelcontextprotocol/kotlin/sdk/types/CreateMessageRequestParams;
 	public synthetic fun getParams ()Lio/modelcontextprotocol/kotlin/sdk/types/RequestParams;
+	public final fun getStopSequences ()Ljava/util/List;
+	public final fun getSystemPrompt ()Ljava/lang/String;
+	public final fun getTemperature ()Ljava/lang/Double;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -1251,6 +1267,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/CustomNotification :
 	public final fun copy (Lio/modelcontextprotocol/kotlin/sdk/types/Method;Lio/modelcontextprotocol/kotlin/sdk/types/BaseNotificationParams;)Lio/modelcontextprotocol/kotlin/sdk/types/CustomNotification;
 	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/types/CustomNotification;Lio/modelcontextprotocol/kotlin/sdk/types/Method;Lio/modelcontextprotocol/kotlin/sdk/types/BaseNotificationParams;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/CustomNotification;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMeta ()Lkotlinx/serialization/json/JsonObject;
 	public fun getMethod ()Lio/modelcontextprotocol/kotlin/sdk/types/Method;
 	public fun getParams ()Lio/modelcontextprotocol/kotlin/sdk/types/BaseNotificationParams;
 	public synthetic fun getParams ()Lio/modelcontextprotocol/kotlin/sdk/types/NotificationParams;
@@ -1305,9 +1322,12 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/ElicitRequest : io/m
 	public final fun copy (Lio/modelcontextprotocol/kotlin/sdk/types/ElicitRequestParams;)Lio/modelcontextprotocol/kotlin/sdk/types/ElicitRequest;
 	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/types/ElicitRequest;Lio/modelcontextprotocol/kotlin/sdk/types/ElicitRequestParams;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/ElicitRequest;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getMeta-VI-3G7E ()Lkotlinx/serialization/json/JsonObject;
 	public fun getMethod ()Lio/modelcontextprotocol/kotlin/sdk/types/Method;
 	public fun getParams ()Lio/modelcontextprotocol/kotlin/sdk/types/ElicitRequestParams;
 	public synthetic fun getParams ()Lio/modelcontextprotocol/kotlin/sdk/types/RequestParams;
+	public final fun getRequestedSchema ()Lio/modelcontextprotocol/kotlin/sdk/types/ElicitRequestParams$RequestedSchema;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -1733,9 +1753,13 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/InitializeRequest : 
 	public final fun copy (Lio/modelcontextprotocol/kotlin/sdk/types/InitializeRequestParams;)Lio/modelcontextprotocol/kotlin/sdk/types/InitializeRequest;
 	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/types/InitializeRequest;Lio/modelcontextprotocol/kotlin/sdk/types/InitializeRequestParams;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/InitializeRequest;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCapabilities ()Lio/modelcontextprotocol/kotlin/sdk/types/ClientCapabilities;
+	public final fun getClientInfo ()Lio/modelcontextprotocol/kotlin/sdk/types/Implementation;
+	public final fun getMeta-VI-3G7E ()Lkotlinx/serialization/json/JsonObject;
 	public fun getMethod ()Lio/modelcontextprotocol/kotlin/sdk/types/Method;
 	public fun getParams ()Lio/modelcontextprotocol/kotlin/sdk/types/InitializeRequestParams;
 	public synthetic fun getParams ()Lio/modelcontextprotocol/kotlin/sdk/types/RequestParams;
+	public final fun getProtocolVersion ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -2014,6 +2038,8 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/ListPromptsRequest :
 	public final fun copy (Lio/modelcontextprotocol/kotlin/sdk/types/PaginatedRequestParams;)Lio/modelcontextprotocol/kotlin/sdk/types/ListPromptsRequest;
 	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/types/ListPromptsRequest;Lio/modelcontextprotocol/kotlin/sdk/types/PaginatedRequestParams;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/ListPromptsRequest;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getMeta-VI-3G7E ()Lkotlinx/serialization/json/JsonObject;
 	public fun getMethod ()Lio/modelcontextprotocol/kotlin/sdk/types/Method;
 	public fun getParams ()Lio/modelcontextprotocol/kotlin/sdk/types/PaginatedRequestParams;
 	public synthetic fun getParams ()Lio/modelcontextprotocol/kotlin/sdk/types/RequestParams;
@@ -2077,6 +2103,8 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/ListResourceTemplate
 	public final fun copy (Lio/modelcontextprotocol/kotlin/sdk/types/PaginatedRequestParams;)Lio/modelcontextprotocol/kotlin/sdk/types/ListResourceTemplatesRequest;
 	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/types/ListResourceTemplatesRequest;Lio/modelcontextprotocol/kotlin/sdk/types/PaginatedRequestParams;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/ListResourceTemplatesRequest;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getMeta-VI-3G7E ()Lkotlinx/serialization/json/JsonObject;
 	public fun getMethod ()Lio/modelcontextprotocol/kotlin/sdk/types/Method;
 	public fun getParams ()Lio/modelcontextprotocol/kotlin/sdk/types/PaginatedRequestParams;
 	public synthetic fun getParams ()Lio/modelcontextprotocol/kotlin/sdk/types/RequestParams;
@@ -2140,6 +2168,8 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/ListResourcesRequest
 	public final fun copy (Lio/modelcontextprotocol/kotlin/sdk/types/PaginatedRequestParams;)Lio/modelcontextprotocol/kotlin/sdk/types/ListResourcesRequest;
 	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/types/ListResourcesRequest;Lio/modelcontextprotocol/kotlin/sdk/types/PaginatedRequestParams;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/ListResourcesRequest;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getMeta-VI-3G7E ()Lkotlinx/serialization/json/JsonObject;
 	public fun getMethod ()Lio/modelcontextprotocol/kotlin/sdk/types/Method;
 	public fun getParams ()Lio/modelcontextprotocol/kotlin/sdk/types/PaginatedRequestParams;
 	public synthetic fun getParams ()Lio/modelcontextprotocol/kotlin/sdk/types/RequestParams;
@@ -2203,6 +2233,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/ListRootsRequest : i
 	public final fun copy (Lio/modelcontextprotocol/kotlin/sdk/types/BaseRequestParams;)Lio/modelcontextprotocol/kotlin/sdk/types/ListRootsRequest;
 	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/types/ListRootsRequest;Lio/modelcontextprotocol/kotlin/sdk/types/BaseRequestParams;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/ListRootsRequest;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMeta-VI-3G7E ()Lkotlinx/serialization/json/JsonObject;
 	public fun getMethod ()Lio/modelcontextprotocol/kotlin/sdk/types/Method;
 	public fun getParams ()Lio/modelcontextprotocol/kotlin/sdk/types/BaseRequestParams;
 	public synthetic fun getParams ()Lio/modelcontextprotocol/kotlin/sdk/types/RequestParams;
@@ -2264,6 +2295,8 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/ListToolsRequest : i
 	public final fun copy (Lio/modelcontextprotocol/kotlin/sdk/types/PaginatedRequestParams;)Lio/modelcontextprotocol/kotlin/sdk/types/ListToolsRequest;
 	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/types/ListToolsRequest;Lio/modelcontextprotocol/kotlin/sdk/types/PaginatedRequestParams;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/ListToolsRequest;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getMeta-VI-3G7E ()Lkotlinx/serialization/json/JsonObject;
 	public fun getMethod ()Lio/modelcontextprotocol/kotlin/sdk/types/Method;
 	public fun getParams ()Lio/modelcontextprotocol/kotlin/sdk/types/PaginatedRequestParams;
 	public synthetic fun getParams ()Lio/modelcontextprotocol/kotlin/sdk/types/RequestParams;
@@ -2626,6 +2659,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/PingRequest : io/mod
 	public final fun copy (Lio/modelcontextprotocol/kotlin/sdk/types/BaseRequestParams;)Lio/modelcontextprotocol/kotlin/sdk/types/PingRequest;
 	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/types/PingRequest;Lio/modelcontextprotocol/kotlin/sdk/types/BaseRequestParams;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/PingRequest;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMeta-VI-3G7E ()Lkotlinx/serialization/json/JsonObject;
 	public fun getMethod ()Lio/modelcontextprotocol/kotlin/sdk/types/Method;
 	public fun getParams ()Lio/modelcontextprotocol/kotlin/sdk/types/BaseRequestParams;
 	public synthetic fun getParams ()Lio/modelcontextprotocol/kotlin/sdk/types/RequestParams;
@@ -3717,6 +3751,8 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/SetLevelRequest : io
 	public final fun copy (Lio/modelcontextprotocol/kotlin/sdk/types/SetLevelRequestParams;)Lio/modelcontextprotocol/kotlin/sdk/types/SetLevelRequest;
 	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/types/SetLevelRequest;Lio/modelcontextprotocol/kotlin/sdk/types/SetLevelRequestParams;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/SetLevelRequest;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLevel ()Lio/modelcontextprotocol/kotlin/sdk/types/LoggingLevel;
+	public final fun getMeta-VI-3G7E ()Lkotlinx/serialization/json/JsonObject;
 	public fun getMethod ()Lio/modelcontextprotocol/kotlin/sdk/types/Method;
 	public synthetic fun getParams ()Lio/modelcontextprotocol/kotlin/sdk/types/RequestParams;
 	public fun getParams ()Lio/modelcontextprotocol/kotlin/sdk/types/SetLevelRequestParams;
@@ -3809,9 +3845,11 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/SubscribeRequest : i
 	public final fun copy (Lio/modelcontextprotocol/kotlin/sdk/types/SubscribeRequestParams;)Lio/modelcontextprotocol/kotlin/sdk/types/SubscribeRequest;
 	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/types/SubscribeRequest;Lio/modelcontextprotocol/kotlin/sdk/types/SubscribeRequestParams;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/SubscribeRequest;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMeta-VI-3G7E ()Lkotlinx/serialization/json/JsonObject;
 	public fun getMethod ()Lio/modelcontextprotocol/kotlin/sdk/types/Method;
 	public synthetic fun getParams ()Lio/modelcontextprotocol/kotlin/sdk/types/RequestParams;
 	public fun getParams ()Lio/modelcontextprotocol/kotlin/sdk/types/SubscribeRequestParams;
+	public final fun getUri ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -4116,9 +4154,11 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/UnsubscribeRequest :
 	public final fun copy (Lio/modelcontextprotocol/kotlin/sdk/types/UnsubscribeRequestParams;)Lio/modelcontextprotocol/kotlin/sdk/types/UnsubscribeRequest;
 	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/types/UnsubscribeRequest;Lio/modelcontextprotocol/kotlin/sdk/types/UnsubscribeRequestParams;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/UnsubscribeRequest;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMeta-VI-3G7E ()Lkotlinx/serialization/json/JsonObject;
 	public fun getMethod ()Lio/modelcontextprotocol/kotlin/sdk/types/Method;
 	public synthetic fun getParams ()Lio/modelcontextprotocol/kotlin/sdk/types/RequestParams;
 	public fun getParams ()Lio/modelcontextprotocol/kotlin/sdk/types/UnsubscribeRequestParams;
+	public final fun getUri ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/PingRequest.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/PingRequest.kt
@@ -11,4 +11,7 @@ public data class PingRequest(override val params: BaseRequestParams? = null) :
     @OptIn(ExperimentalSerializationApi::class)
     @EncodeDefault
     override val method: Method = Method.Defined.Ping
+
+    public val meta: RequestMeta?
+        get() = params?.meta
 }

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/completion.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/completion.kt
@@ -16,6 +16,27 @@ public data class CompleteRequest(override val params: CompleteRequestParams) : 
     @OptIn(ExperimentalSerializationApi::class)
     @EncodeDefault
     public override val method: Method = Method.Defined.CompletionComplete
+
+    /**
+     * The argument's information for which completion options are requested.
+     */
+    public val argument: CompleteRequestParams.Argument
+        get() = params.argument
+
+    /**
+     * A reference to either a prompt or resource template to complete within.
+     */
+    public val ref: Reference
+        get() = params.ref
+
+    /**
+     * Additional, context for generating completions.
+     */
+    public val context: CompleteRequestParams.Context?
+        get() = params.context
+
+    public val meta: RequestMeta?
+        get() = params.meta
 }
 
 /**

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/elicitation.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/elicitation.kt
@@ -20,6 +20,24 @@ public data class ElicitRequest(override val params: ElicitRequestParams) : Serv
     @OptIn(ExperimentalSerializationApi::class)
     @EncodeDefault
     public override val method: Method = Method.Defined.ElicitationCreate
+
+    /**
+     * The message to present to the user. This should clearly explain what information is being requested and why.
+     */
+    public val message: String
+        get() = params.message
+
+    /**
+     * A restricted subset of JSON Schema defining the structure of the requested data.
+     */
+    public val requestedSchema: ElicitRequestParams.RequestedSchema
+        get() = params.requestedSchema
+
+    /**
+     * Metadata for this request. May include a progressToken for out-of-band progress notifications.
+     */
+    public val meta: RequestMeta?
+        get() = params.meta
 }
 
 /**

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/initialize.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/initialize.kt
@@ -21,6 +21,30 @@ public data class InitializeRequest(override val params: InitializeRequestParams
     @OptIn(ExperimentalSerializationApi::class)
     @EncodeDefault
     override val method: Method = Method.Defined.Initialize
+
+    /**
+     * The latest version of the Model Context Protocol that the client supports.
+     */
+    public val protocolVersion: String
+        get() = params.protocolVersion
+
+    /**
+     * The capabilities that this client supports. Describes which optional features the client has implemented.
+     */
+    public val capabilities: ClientCapabilities
+        get() = params.capabilities
+
+    /**
+     * Information about the client implementation, including name, version, and branding.
+     */
+    public val clientInfo: Implementation
+        get() = params.clientInfo
+
+    /**
+     * Metadata for this request. May include a progressToken for out-of-band progress notifications.
+     */
+    public val meta: RequestMeta?
+        get() = params.meta
 }
 
 /**

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/logging.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/logging.kt
@@ -63,6 +63,18 @@ public data class SetLevelRequest(override val params: SetLevelRequestParams) : 
     @OptIn(ExperimentalSerializationApi::class)
     @EncodeDefault
     override val method: Method = Method.Defined.LoggingSetLevel
+
+    /**
+     * The minimum severity level of logging that the client wants to receive from the server.
+     */
+    public val level: LoggingLevel
+        get() = params.level
+
+    /**
+     * Metadata for this request. May include a progressToken for out-of-band progress notifications.
+     */
+    public val meta: RequestMeta?
+        get() = params.meta
 }
 
 /**

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/notification.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/notification.kt
@@ -77,7 +77,11 @@ public class Progress(
 @Serializable
 public data class CustomNotification(override val method: Method, override val params: BaseNotificationParams? = null) :
     ClientNotification,
-    ServerNotification
+    ServerNotification {
+
+    public val meta: JsonObject?
+        get() = params?.meta
+}
 
 // ============================================================================
 // Cancelled Notification
@@ -101,6 +105,24 @@ public data class CancelledNotification(override val params: CancelledNotificati
     ServerNotification {
     @EncodeDefault
     override val method: Method = Method.Defined.NotificationsCancelled
+
+    /**
+     * The ID of the request to cancel.
+     */
+    public val requestId: RequestId
+        get() = params.requestId
+
+    /**
+     * A string describing the reason for the cancellation.
+     */
+    public val reason: String?
+        get() = params.reason
+
+    /**
+     * Metadata for this notification.
+     */
+    public val meta: JsonObject?
+        get() = params.meta
 }
 
 /**

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/prompts.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/prompts.kt
@@ -187,6 +187,18 @@ public data class ListPromptsRequest(override val params: PaginatedRequestParams
     PaginatedRequest {
     @EncodeDefault
     override val method: Method = Method.Defined.PromptsList
+
+    /**
+     * An opaque token representing the current pagination position.
+     */
+    public val cursor: String?
+        get() = params?.cursor
+
+    /**
+     * Metadata for this request. May include a progressToken for out-of-band progress notifications.
+     */
+    public val meta: RequestMeta?
+        get() = params?.meta
 }
 
 /**

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/resources.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/resources.kt
@@ -190,6 +190,18 @@ public data class ListResourcesRequest(override val params: PaginatedRequestPara
     PaginatedRequest {
     @EncodeDefault
     override val method: Method = Method.Defined.ResourcesList
+
+    /**
+     * An opaque token representing the current pagination position.
+     */
+    public val cursor: String?
+        get() = params?.cursor
+
+    /**
+     * Metadata for this request. May include a progressToken for out-of-band progress notifications.
+     */
+    public val meta: RequestMeta?
+        get() = params?.meta
 }
 
 /**
@@ -218,22 +230,6 @@ public data class ListResourcesResult(
 // ============================================================================
 
 /**
- * Parameters for a resources/read request.
- *
- * @property uri The URI of the resource to read. The URI can use any protocol;
- *              it is up to the server how to interpret it. Common schemes include
- *              file://, http://, https://, or custom application-specific schemes.
- * @property meta Optional metadata for this request. May include a progressToken for
- *                out-of-band progress notifications.
- */
-@Serializable
-public data class ReadResourceRequestParams(
-    val uri: String,
-    @SerialName("_meta")
-    override val meta: RequestMeta? = null,
-) : RequestParams
-
-/**
  * Sent from the client to the server to read a specific resource URI.
  *
  * The server will return the resource's contents, which can be either text or binary data.
@@ -259,6 +255,22 @@ public data class ReadResourceRequest(override val params: ReadResourceRequestPa
 }
 
 /**
+ * Parameters for a resources/read request.
+ *
+ * @property uri The URI of the resource to read. The URI can use any protocol;
+ *              it is up to the server how to interpret it. Common schemes include
+ *              file://, http://, https://, or custom application-specific schemes.
+ * @property meta Optional metadata for this request. May include a progressToken for
+ *                out-of-band progress notifications.
+ */
+@Serializable
+public data class ReadResourceRequestParams(
+    val uri: String,
+    @SerialName("_meta")
+    override val meta: RequestMeta? = null,
+) : RequestParams
+
+/**
  * The server's response to a [ReadResourceRequest] from the client.
  *
  * Contains the resource contents, which can be a mix of text and binary data.
@@ -281,6 +293,34 @@ public data class ReadResourceResult(
 // ============================================================================
 
 /**
+ * Sent from the client to request resources/updated notifications from the server
+ * whenever a particular resource changes.
+ *
+ * After subscribing, the server will send [ResourceUpdatedNotification] messages
+ * whenever the subscribed resource is modified. This requires the server to support
+ * the `subscribe` capability in [ServerCapabilities.resources].
+ *
+ * @property params The parameters specifying which resource URI to subscribe to.
+ */
+@Serializable
+public data class SubscribeRequest(override val params: SubscribeRequestParams) : ClientRequest {
+    @EncodeDefault
+    override val method: Method = Method.Defined.ResourcesSubscribe
+
+    /**
+     * The URI of the resource to subscribe to.
+     */
+    public val uri: String
+        get() = params.uri
+
+    /**
+     * Metadata for this request. May include a progressToken for out-of-band progress notifications.
+     */
+    public val meta: RequestMeta?
+        get() = params.meta
+}
+
+/**
  * Parameters for a resources/subscribe request.
  *
  * @property uri The URI of the resource to subscribe to. The URI can use any protocol;
@@ -295,25 +335,35 @@ public data class SubscribeRequestParams(
     override val meta: RequestMeta? = null,
 ) : RequestParams
 
-/**
- * Sent from the client to request resources/updated notifications from the server
- * whenever a particular resource changes.
- *
- * After subscribing, the server will send [ResourceUpdatedNotification] messages
- * whenever the subscribed resource is modified. This requires the server to support
- * the `subscribe` capability in [ServerCapabilities.resources].
- *
- * @property params The parameters specifying which resource URI to subscribe to.
- */
-@Serializable
-public data class SubscribeRequest(override val params: SubscribeRequestParams) : ClientRequest {
-    @EncodeDefault
-    override val method: Method = Method.Defined.ResourcesSubscribe
-}
-
 // ============================================================================
 // resources/unsubscribe
 // ============================================================================
+
+/**
+ * Sent from the client to request cancellation of resources/updated notifications from the server.
+ *
+ * This should follow a previous [SubscribeRequest]. After unsubscribing, the server will
+ * stop sending [ResourceUpdatedNotification] messages for this resource.
+ *
+ * @property params The parameters specifying which resource URI to unsubscribe from.
+ */
+@Serializable
+public data class UnsubscribeRequest(override val params: UnsubscribeRequestParams) : ClientRequest {
+    @EncodeDefault
+    override val method: Method = Method.Defined.ResourcesUnsubscribe
+
+    /**
+     * The URI of the resource to unsubscribe from.
+     */
+    public val uri: String
+        get() = params.uri
+
+    /**
+     * Metadata for this request. May include a progressToken for out-of-band progress notifications.
+     */
+    public val meta: RequestMeta?
+        get() = params.meta
+}
 
 /**
  * Parameters for a resources/unsubscribe request.
@@ -329,20 +379,6 @@ public data class UnsubscribeRequestParams(
     @SerialName("_meta")
     override val meta: RequestMeta? = null,
 ) : RequestParams
-
-/**
- * Sent from the client to request cancellation of resources/updated notifications from the server.
- *
- * This should follow a previous [SubscribeRequest]. After unsubscribing, the server will
- * stop sending [ResourceUpdatedNotification] messages for this resource.
- *
- * @property params The parameters specifying which resource URI to unsubscribe from.
- */
-@Serializable
-public data class UnsubscribeRequest(override val params: UnsubscribeRequestParams) : ClientRequest {
-    @EncodeDefault
-    override val method: Method = Method.Defined.ResourcesUnsubscribe
-}
 
 // ============================================================================
 // resources/templates/list
@@ -363,6 +399,18 @@ public data class ListResourceTemplatesRequest(override val params: PaginatedReq
     PaginatedRequest {
     @EncodeDefault
     override val method: Method = Method.Defined.ResourcesTemplatesList
+
+    /**
+     * An opaque token representing the current pagination position.
+     */
+    public val cursor: String?
+        get() = params?.cursor
+
+    /**
+     * Metadata for this request. May include a progressToken for out-of-band progress notifications.
+     */
+    public val meta: RequestMeta?
+        get() = params?.meta
 }
 
 /**

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/roots.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/roots.kt
@@ -59,6 +59,9 @@ public data class ListRootsRequest(override val params: BaseRequestParams? = nul
     @OptIn(ExperimentalSerializationApi::class)
     @EncodeDefault
     override val method: Method = Method.Defined.RootsList
+
+    public val meta: RequestMeta?
+        get() = params?.meta
 }
 
 /**

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/sampling.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/sampling.kt
@@ -107,31 +107,85 @@ public data class CreateMessageRequest(override val params: CreateMessageRequest
     @OptIn(ExperimentalSerializationApi::class)
     @EncodeDefault
     override val method: Method = Method.Defined.SamplingCreateMessage
+
+    /**
+     * The requested maximum number of tokens to sample (to prevent runaway completions).
+     */
+    public val maxTokens: Int
+        get() = params.maxTokens
+
+    /**
+     * The messages to use as context for sampling.
+     */
+    public val messages: List<SamplingMessage>
+        get() = params.messages
+
+    /**
+     * The server's preferences for which model to select.
+     */
+    public val modelPreferences: ModelPreferences?
+        get() = params.modelPreferences
+
+    /**
+     * An optional system prompt the server wants to use for sampling.
+     */
+    public val systemPrompt: String?
+        get() = params.systemPrompt
+
+    /**
+     * A request to include context from one or more MCP servers (including the caller), to be attached to the prompt.
+     */
+    public val includeContext: IncludeContext?
+        get() = params.includeContext
+
+    /**
+     * Temperature parameter for sampling (typically 0.0-2.0).
+     */
+    public val temperature: Double?
+        get() = params.temperature
+
+    /**
+     * List of sequences that will stop generation if encountered.
+     */
+    public val stopSequences: List<String>?
+        get() = params.stopSequences
+
+    /**
+     * Metadata to pass through to the LLM provider. The format of this metadata is provider-specific.
+     */
+    public val metadata: JsonObject?
+        get() = params.metadata
+
+    /**
+     * Metadata for this request. May include a progressToken for out-of-band progress notifications.
+     */
+    public val meta: RequestMeta?
+        get() = params.meta
 }
 
 /**
  * Parameters for a sampling/createMessage request.
  *
  * @property maxTokens The requested maximum number of tokens to sample (to prevent runaway completions).
- *                    The client MAY choose to sample fewer tokens than the requested maximum.
+ * The client MAY choose to sample fewer tokens than the requested maximum.
  * @property messages The messages to use as context for sampling. Typically includes conversation history
- *                   and the current user message.
+ * and the current user message.
  * @property modelPreferences The server's preferences for which model to select.
- *                           The client MAY ignore these preferences and choose any model.
+ * The client MAY ignore these preferences and choose any model.
  * @property systemPrompt An optional system prompt the server wants to use for sampling.
- *                       The client MAY modify or omit this prompt.
+ * The client MAY modify or omit this prompt.
  * @property includeContext A request to include context from one or more MCP servers (including the caller),
- *                         to be attached to the prompt. The client MAY ignore this request.
- *                         - "none": Don't include any server context
- *                         - "thisServer": Include context only from the requesting server
- *                         - "allServers": Include context from all connected MCP servers
+ * to be attached to the prompt. The client MAY ignore this request.
+ * - `none`: Don't include any server context
+ * - `thisServer`: Include context only from the requesting server
+ * - `allServers`: Include context from all connected MCP servers
  * @property temperature Optional temperature parameter for sampling (typically 0.0-2.0).
- *                      Higher values make output more random, lower values make it more deterministic.
+ * Higher values make output more random, lower values make it more deterministic.
  * @property stopSequences Optional list of sequences that will stop generation if encountered.
  * @property metadata Optional metadata to pass through to the LLM provider.
- *                   The format of this metadata is provider-specific.
+ * The format of this metadata is provider-specific.
  * @property meta Optional metadata for this request. May include a progressToken for
- *                out-of-band progress notifications.
+ * out-of-band progress notifications.
  */
 @Serializable
 public data class CreateMessageRequestParams(

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/tools.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/tools.kt
@@ -226,6 +226,18 @@ public data class ListToolsRequest(override val params: PaginatedRequestParams? 
     PaginatedRequest {
     @EncodeDefault
     override val method: Method = Method.Defined.ToolsList
+
+    /**
+     * An opaque token representing the current pagination position.
+     */
+    public val cursor: String?
+        get() = params?.cursor
+
+    /**
+     * Metadata for this request. May include a progressToken for out-of-band progress notifications.
+     */
+    public val meta: RequestMeta?
+        get() = params?.meta
 }
 
 /**


### PR DESCRIPTION
Add properties for types of new schema

## Motivation and Context
Added getters to simplify access to properties in request and notification types.

## How Has This Been Tested?
All tests pass 

## Breaking Changes
None

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed