### PR TITLE
Better exception handling in StdioClientTransport

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ mockk = "1.14.6"
 mokksy = "0.6.2"
 serialization = "1.9.0"
 slf4j = "2.0.17"
+junit="6.0.1"
 
 [libraries]
 # Plugins
@@ -58,6 +59,7 @@ mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 mokksy = { group = "dev.mokksy", name = "mokksy", version.ref = "mokksy" }
 netty-bom = { group = "io.netty", name = "netty-bom", version.ref = "netty" }
 slf4j-simple = { group = "org.slf4j", name = "slf4j-simple", version.ref = "slf4j" }
+junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit" }
 
 # Samples
 ktor-client-cio = { group = "io.ktor", name = "ktor-client-cio", version.ref = "ktor" }

--- a/kotlin-sdk-client/build.gradle.kts
+++ b/kotlin-sdk-client/build.gradle.kts
@@ -54,6 +54,7 @@ kotlin {
                 implementation(libs.awaitility)
                 implementation(libs.ktor.client.apache5)
                 implementation(libs.mockk)
+                implementation(libs.junit.jupiter.params)
                 implementation(libs.mokksy)
                 implementation(dependencies.platform(libs.netty.bom))
                 runtimeOnly(libs.slf4j.simple)

--- a/kotlin-sdk-core/api/kotlin-sdk-core.api
+++ b/kotlin-sdk-core/api/kotlin-sdk-core.api
@@ -2654,11 +2654,12 @@ public abstract interface annotation class io/modelcontextprotocol/kotlin/sdk/ty
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/types/McpException : java/lang/Exception {
+	public fun <init> (ILjava/lang/String;)V
 	public fun <init> (ILjava/lang/String;Lkotlinx/serialization/json/JsonElement;)V
-	public synthetic fun <init> (ILjava/lang/String;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ILjava/lang/String;Lkotlinx/serialization/json/JsonElement;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (ILjava/lang/String;Lkotlinx/serialization/json/JsonElement;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getCode ()I
 	public final fun getData ()Lkotlinx/serialization/json/JsonElement;
-	public fun getMessage ()Ljava/lang/String;
 }
 
 public abstract interface class io/modelcontextprotocol/kotlin/sdk/types/MediaContent : io/modelcontextprotocol/kotlin/sdk/types/ContentBlock {

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/McpException.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/McpException.kt
@@ -1,14 +1,19 @@
 package io.modelcontextprotocol.kotlin.sdk.types
 
 import kotlinx.serialization.json.JsonElement
+import kotlin.jvm.JvmOverloads
 
 /**
  * Represents an error specific to the MCP protocol.
  *
- * @property code The error code.
- * @property message The error message.
- * @property data Additional error data as a JSON object.
+ * @property code The MCP/JSON‑RPC error code.
+ * @property data Optional additional error payload as a JSON element; `null` when not provided.
+ * @param message The error message.
+ * @param cause The original cause.
  */
-public class McpException(public val code: Int, message: String, public val data: JsonElement? = null) : Exception() {
-    override val message: String = "MCP error $code: $message"
-}
+public class McpException @JvmOverloads public constructor(
+    public val code: Int,
+    message: String,
+    public val data: JsonElement? = null,
+    cause: Throwable? = null,
+) : Exception("MCP error $code: $message", cause)

--- a/kotlin-sdk-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/kotlin/AbstractPromptIntegrationTest.kt
+++ b/kotlin-sdk-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/kotlin/AbstractPromptIntegrationTest.kt
@@ -1,5 +1,7 @@
 package io.modelcontextprotocol.kotlin.sdk.integration.kotlin
 
+import io.kotest.assertions.withClue
+import io.kotest.matchers.string.shouldContain
 import io.modelcontextprotocol.kotlin.sdk.types.GetPromptRequest
 import io.modelcontextprotocol.kotlin.sdk.types.GetPromptRequestParams
 import io.modelcontextprotocol.kotlin.sdk.types.GetPromptResult
@@ -391,7 +393,9 @@ abstract class AbstractPromptIntegrationTest : KotlinTestBase() {
             }
         }
 
-        assertTrue(exception.message.contains("requiredArg2"), "Exception should mention the missing argument")
+        withClue("Exception should mention the missing argument") {
+            exception.message shouldContain "requiredArg2"
+        }
 
         // test with no args
         val exception2 = assertThrows<McpException> {
@@ -407,7 +411,9 @@ abstract class AbstractPromptIntegrationTest : KotlinTestBase() {
             }
         }
 
-        assertTrue(exception2.message.contains("requiredArg"), "Exception should mention a missing required argument")
+        withClue("Exception should mention a missing required argument") {
+            exception2.message shouldContain "requiredArg"
+        }
 
         // test with all required args
         val result = client.getPrompt(


### PR DESCRIPTION
# Better exception handling in StdioClientTransport

Refactor `McpException` for improved handling with convenience constructors and enhanced exception wrapping logic in `StdioClientTransport`. Update tests to use `kotest` matchers and add JUnit parameterized tests for exception handling.

## Motivation and Context
#442 follow up 

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
