### PR TITLE
Update GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,9 @@ permissions:
   pull-requests: write # only required if `comment: true` was enabled
 
 jobs:
-  validate-pr:
+  build:
     runs-on: macos-latest-xlarge
-    name: Validate PR
+    name: Build
     timeout-minutes: 20
     env:
       JAVA_OPTS: "-Xmx8g -Dfile.encoding=UTF-8 -Djava.awt.headless=true -Dkotlin.daemon.jvm.options=-Xmx6g"
@@ -75,7 +75,7 @@ jobs:
         if: ${{ !cancelled() }} # always run even if the previous step fails
         with:
           annotate_only: true
-          comment: true
+          comment: ${{ github.repository == 'modelcontextprotocol/kotlin-sdk' }}
           detailed_summary: true
           flaky_summary: true
           group_suite: true
@@ -83,7 +83,7 @@ jobs:
           include_time_in_summary: true
           report_paths: '**/test-results/**/TEST-*.xml'
           truncate_stack_traces: false
-          updateComment: true
+          updateComment: ${{ github.repository == 'modelcontextprotocol/kotlin-sdk' }}
 
       - name: Disable Auto-Merge on Fail
         if: failure() && github.event_name == 'pull_request'


### PR DESCRIPTION
Update GitHub Actions workflow

- Rename `validate-pr` job to `build`
- Update `comment` and `updateComment` parameters to be false on forks

<!-- Provide a brief summary of your changes -->

## Motivation and Context

mikepenz/action-junit-report GH Action can't create/update comments on forks

## How Has This Been Tested?
CI

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
