### PR TITLE
Fix flaky StdioClientTransportErrorHandlingTest

### DIFF
--- a/kotlin-sdk-client/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/client/stdio/StdioClientTransportErrorHandlingTest.kt
+++ b/kotlin-sdk-client/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/client/stdio/StdioClientTransportErrorHandlingTest.kt
@@ -41,8 +41,9 @@ class StdioClientTransportErrorHandlingTest {
         val stderrBuffer = Buffer()
         // Empty stderr = immediate EOF
 
-        val inputBuffer = Buffer()
-        inputBuffer.writeString("""data: {"jsonrpc":"2.0","method":"ping","id":1}\n\n""")
+        val inputBuffer = createNonEmptyBuffer {
+            """data: {"jsonrpc":"2.0","method":"ping","id":1}\n\n"""
+        }
         val outputBuffer = Buffer()
 
         transport = StdioClientTransport(
@@ -66,8 +67,9 @@ class StdioClientTransportErrorHandlingTest {
 
     @Test
     fun `should call onClose exactly once on error scenarios`() = runTest {
-        val stderrBuffer = Buffer()
-        stderrBuffer.write("FATAL: critical error\n".encodeToByteArray())
+        val stderrBuffer = createNonEmptyBuffer {
+            "FATAL: critical error\n"
+        }
 
         val inputBuffer = Buffer()
         val outputBuffer = Buffer()
@@ -149,8 +151,9 @@ class StdioClientTransportErrorHandlingTest {
     fun `Send should handle exceptions`(throwable: Throwable, shouldWrap: Boolean, expectedCode: Int?) = runTest {
         val sendChannel: Channel<JSONRPCMessage> = mockk(relaxed = true)
 
+        val stdin = createNonEmptyBuffer { "id: 1\ndata:\n" }
         transport = StdioClientTransport(
-            input = Buffer(),
+            input = stdin,
             output = Buffer(),
             sendChannel = sendChannel,
         )
@@ -172,5 +175,11 @@ class StdioClientTransportErrorHandlingTest {
         } else {
             exception shouldBeSameInstanceAs throwable
         }
+    }
+
+    fun createNonEmptyBuffer(block: () -> String): Buffer {
+        val buffer = Buffer()
+        buffer.writeString(block())
+        return buffer
     }
 }


### PR DESCRIPTION
## Changes
Fix flaky StdioClientTransportErrorHandlingTest

Use non-empty buffer for reliability

## How Has This Been Tested?
Unit test

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
