### PR TITLE
Revert publishing junit-report comments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,6 @@ jobs:
         if: ${{ !cancelled() }} # always run even if the previous step fails
         with:
           annotate_only: true
-          comment: ${{ github.repository == 'modelcontextprotocol/kotlin-sdk' }}
           detailed_summary: true
           flaky_summary: true
           group_suite: true
@@ -83,7 +82,6 @@ jobs:
           include_time_in_summary: true
           report_paths: '**/test-results/**/TEST-*.xml'
           truncate_stack_traces: false
-          updateComment: ${{ github.repository == 'modelcontextprotocol/kotlin-sdk' }}
 
       - name: Disable Auto-Merge on Fail
         if: failure() && github.event_name == 'pull_request'


### PR DESCRIPTION
# Revert publishing junit-report comments

Build on Forks is broken now, because Junit-Reports plugin can't write comments. 

<!-- Provide a brief summary of your changes -->

## Motivation and Context
Revert [this change](https://github.com/modelcontextprotocol/kotlin-sdk/pull/442/files#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721)

## How Has This Been Tested?
CI

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
