### PR TITLE
Fix kotlin-mcp-server sample

### DIFF
--- a/samples/kotlin-mcp-server/src/main/kotlin/io/modelcontextprotocol/sample/server/server.kt
+++ b/samples/kotlin-mcp-server/src/main/kotlin/io/modelcontextprotocol/sample/server/server.kt
@@ -103,13 +103,13 @@ fun configureServer(): Server {
     return server
 }
 
-fun runSseMcpServerWithPlainConfiguration(port: Int, wait: Boolean = true) {
+fun runSseMcpServerWithPlainConfiguration(port: Int, wait: Boolean = true): EmbeddedServer<*, *> {
     printBanner(port = port, path = "/sse")
     val serverSessions = ConcurrentMap<String, ServerSession>()
 
     val server = configureServer()
 
-    embeddedServer(CIO, host = "127.0.0.1", port = port) {
+    val ktorServer = embeddedServer(CIO, host = "127.0.0.1", port = port) {
         installCors()
         install(SSE)
         routing {
@@ -141,6 +141,8 @@ fun runSseMcpServerWithPlainConfiguration(port: Int, wait: Boolean = true) {
             }
         }
     }.start(wait = wait)
+
+    return ktorServer
 }
 
 /**

--- a/samples/kotlin-mcp-server/src/test/kotlin/McpServerType.kt
+++ b/samples/kotlin-mcp-server/src/test/kotlin/McpServerType.kt
@@ -1,0 +1,17 @@
+import io.ktor.server.engine.EmbeddedServer
+import io.modelcontextprotocol.sample.server.runSseMcpServerUsingKtorPlugin
+import io.modelcontextprotocol.sample.server.runSseMcpServerWithPlainConfiguration
+
+enum class McpServerType(
+    val sseEndpoint: String,
+    val serverFactory: (port: Int) -> EmbeddedServer<*, *>
+) {
+    KTOR_PLUGIN(
+        sseEndpoint = "",
+        serverFactory = { port -> runSseMcpServerUsingKtorPlugin(port, wait = false) }
+    ),
+    PLAIN_CONFIGURATION(
+        sseEndpoint = "/sse",
+        serverFactory = { port -> runSseMcpServerWithPlainConfiguration(port, wait = false) }
+    )
+}

--- a/samples/kotlin-mcp-server/src/test/kotlin/SseServerIntegrationTest.kt
+++ b/samples/kotlin-mcp-server/src/test/kotlin/SseServerIntegrationTest.kt
@@ -11,9 +11,9 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
-class SseServerIntegrationTest {
+abstract class SseServerIntegrationTestBase {
 
-    private val client: Client = TestEnvironment.client
+    abstract val client: Client
 
     @Test
     fun `should list tools`(): Unit = runBlocking {
@@ -87,4 +87,14 @@ class SseServerIntegrationTest {
         assertEquals(expected = "Hello, world!", actual = content.text)
         assertEquals(expected = "text", actual = "${content.type}".lowercase())
     }
+}
+
+class SseServerKtorPluginIntegrationTest : SseServerIntegrationTestBase() {
+    private val testEnvironment = TestEnvironment(McpServerType.KTOR_PLUGIN)
+    override val client: Client = testEnvironment.client
+}
+
+class SseServerPlainConfigurationIntegrationTest : SseServerIntegrationTestBase() {
+    private val testEnvironment = TestEnvironment(McpServerType.PLAIN_CONFIGURATION)
+    override val client: Client = testEnvironment.client
 }


### PR DESCRIPTION
Added `awaitCancellation` in `runSseMcpServerWithPlainConfiguration()`

## How Has This Been Tested?
Added test for plain configuration server
Checked with inspector

## Breaking Changes
None

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
