### PR TITLE
fix tests after typescript-sdk became modulized 

### DIFF
--- a/kotlin-sdk-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/typescript/OldSchemaTsTestBase.kt
+++ b/kotlin-sdk-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/typescript/OldSchemaTsTestBase.kt
@@ -93,8 +93,15 @@ abstract class OldSchemaTsTestBase {
                 }
             }
 
-            println("Installing TypeScript SDK dependencies")
-            executeCommand("npm install", sdkDir, allowFailure = false, timeoutSeconds = null)
+            println("Installing and build TypeScript SDK dependencies")
+            executeCommand(
+                "" +
+                    "corepack enable && " +
+                    "corepack install && " +
+                    "pnpm install && " +
+                    "pnpm build:all",
+                sdkDir, allowFailure = false, timeoutSeconds = null
+            )
         }
 
         @JvmStatic
@@ -248,21 +255,21 @@ abstract class OldSchemaTsTestBase {
                 .command(
                     "cmd.exe",
                     "/c",
-                    "set MCP_PORT=$port && set NODE_PATH=${sdkDir.absolutePath}\\node_modules && npx --prefix \"${sdkDir.absolutePath}\" tsx \"$localServerPath\"",
+                    "set MCP_PORT=$port && pnpm exec tsx --tsconfig \"${sdkDir.absolutePath}/packages/server/tsconfig.json\" \"$localServerPath\"",
                 )
         } else {
             ProcessBuilder()
                 .command(
                     "bash",
                     "-c",
-                    "MCP_PORT=$port NODE_PATH='${sdkDir.absolutePath}/node_modules' npx --prefix '${sdkDir.absolutePath}' tsx \"$localServerPath\"",
+                    "MCP_PORT=$port && pnpm exec tsx --tsconfig '${sdkDir.absolutePath}/packages/server/tsconfig.json' \"$localServerPath\"",
                 )
         }
 
         processBuilder.environment()["TYPESCRIPT_SDK_DIR"] = sdkDir.absolutePath
 
         val process = processBuilder
-            .directory(tsClientDir)
+            .directory(sdkDir)
             .redirectErrorStream(true)
             .start()
 
@@ -314,19 +321,19 @@ abstract class OldSchemaTsTestBase {
                 .command(
                     "cmd.exe",
                     "/c",
-                    "set NODE_PATH=${sdkDir.absolutePath}\\node_modules && npx --prefix \"${sdkDir.absolutePath}\" tsx \"$localServerPath\"",
+                    "pnpm exec tsx --tsconfig \"${sdkDir.absolutePath}/packages/server/tsconfig.json\" \"$localServerPath\"",
                 )
         } else {
             ProcessBuilder()
                 .command(
                     "bash",
                     "-c",
-                    "NODE_PATH='${sdkDir.absolutePath}/node_modules' npx --prefix '${sdkDir.absolutePath}' tsx \"$localServerPath\"",
+                    "pnpm exec tsx --tsconfig '${sdkDir.absolutePath}/packages/server/tsconfig.json' \"$localServerPath\"",
                 )
         }
         processBuilder.environment()["TYPESCRIPT_SDK_DIR"] = sdkDir.absolutePath
         val process = processBuilder
-            .directory(tsClientDir)
+            .directory(sdkDir)
             .redirectErrorStream(false)
             .start()
         // For stdio transports, do NOT read from stdout (it's used for protocol). Read stderr for logs only.
@@ -378,8 +385,8 @@ abstract class OldSchemaTsTestBase {
                     "/c",
                     (
                         "set TYPESCRIPT_SDK_DIR=${sdkDir.absolutePath} && " +
-                            "set NODE_PATH=${sdkDir.absolutePath}\\node_modules && " +
-                            "npx --prefix \"${sdkDir.absolutePath}\" tsx \"$clientPath\" " +
+                            "cd \"${sdkDir.absolutePath}\" && " +
+                            "pnpm exec tsx --tsconfig \"${sdkDir.absolutePath}/packages/client/tsconfig.json\" \"$clientPath\" " +
                             args.joinToString(" ")
                         ),
                 )
@@ -393,8 +400,8 @@ abstract class OldSchemaTsTestBase {
                     "-c",
                     (
                         "TYPESCRIPT_SDK_DIR='${sdkDir.absolutePath}' " +
-                            "NODE_PATH='${sdkDir.absolutePath}/node_modules' " +
-                            "npx --prefix '${sdkDir.absolutePath}' tsx \"$clientPath\" " +
+                            "cd '${sdkDir.absolutePath}' && " +
+                            "pnpm exec tsx --tsconfig '${sdkDir.absolutePath}/packages/client/tsconfig.json' \"$clientPath\" " +
                             args.joinToString(" ")
                         ),
                 )

--- a/kotlin-sdk-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/typescript/TsTestBase.kt
+++ b/kotlin-sdk-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/typescript/TsTestBase.kt
@@ -92,8 +92,15 @@ abstract class TsTestBase {
                 }
             }
 
-            println("Installing TypeScript SDK dependencies")
-            executeCommand("npm install", sdkDir, allowFailure = false, timeoutSeconds = null)
+            println("Installing and build TypeScript SDK dependencies")
+            executeCommand(
+                "" +
+                    "corepack enable && " +
+                    "corepack install && " +
+                    "pnpm install && " +
+                    "pnpm build:all",
+                sdkDir, allowFailure = false, timeoutSeconds = null
+            )
         }
 
         @JvmStatic
@@ -247,21 +254,21 @@ abstract class TsTestBase {
                 .command(
                     "cmd.exe",
                     "/c",
-                    "set MCP_PORT=$port && set NODE_PATH=${sdkDir.absolutePath}\\node_modules && npx --prefix \"${sdkDir.absolutePath}\" tsx \"$localServerPath\"",
+                    "set MCP_PORT=$port && pnpm exec tsx --tsconfig \"${sdkDir.absolutePath}/packages/server/tsconfig.json\" \"$localServerPath\"",
                 )
         } else {
             ProcessBuilder()
                 .command(
                     "bash",
                     "-c",
-                    "MCP_PORT=$port NODE_PATH='${sdkDir.absolutePath}/node_modules' npx --prefix '${sdkDir.absolutePath}' tsx \"$localServerPath\"",
+                    "MCP_PORT=$port && pnpm exec tsx --tsconfig '${sdkDir.absolutePath}/packages/server/tsconfig.json' \"$localServerPath\"",
                 )
         }
 
         processBuilder.environment()["TYPESCRIPT_SDK_DIR"] = sdkDir.absolutePath
 
         val process = processBuilder
-            .directory(tsClientDir)
+            .directory(sdkDir)
             .redirectErrorStream(true)
             .start()
 
@@ -313,14 +320,14 @@ abstract class TsTestBase {
                 .command(
                     "cmd.exe",
                     "/c",
-                    "set NODE_PATH=${sdkDir.absolutePath}\\node_modules && npx --prefix \"${sdkDir.absolutePath}\" tsx \"$localServerPath\"",
+                    "cd \"${sdkDir.absolutePath}\" && pnpm exec tsx --tsconfig \"${sdkDir.absolutePath}/packages/server/tsconfig.json\" \"$localServerPath\"",
                 )
         } else {
             ProcessBuilder()
                 .command(
                     "bash",
                     "-c",
-                    "NODE_PATH='${sdkDir.absolutePath}/node_modules' npx --prefix '${sdkDir.absolutePath}' tsx \"$localServerPath\"",
+                    "cd '${sdkDir.absolutePath}' && pnpm exec tsx --tsconfig '${sdkDir.absolutePath}/packages/server/tsconfig.json' \"$localServerPath\"",
                 )
         }
         processBuilder.environment()["TYPESCRIPT_SDK_DIR"] = sdkDir.absolutePath
@@ -377,8 +384,8 @@ abstract class TsTestBase {
                     "/c",
                     (
                         "set TYPESCRIPT_SDK_DIR=${sdkDir.absolutePath} && " +
-                            "set NODE_PATH=${sdkDir.absolutePath}\\node_modules && " +
-                            "npx --prefix \"${sdkDir.absolutePath}\" tsx \"$clientPath\" " +
+                            "cd \"${sdkDir.absolutePath}\" && " +
+                            "pnpm exec tsx --tsconfig \"${sdkDir.absolutePath}/packages/client/tsconfig.json\" \"$clientPath\" " +
                             args.joinToString(" ")
                         ),
                 )
@@ -392,8 +399,8 @@ abstract class TsTestBase {
                     "-c",
                     (
                         "TYPESCRIPT_SDK_DIR='${sdkDir.absolutePath}' " +
-                            "NODE_PATH='${sdkDir.absolutePath}/node_modules' " +
-                            "npx --prefix '${sdkDir.absolutePath}' tsx \"$clientPath\" " +
+                            "cd '${sdkDir.absolutePath}' && " +
+                            "pnpm exec tsx --tsconfig '${sdkDir.absolutePath}/packages/client/tsconfig.json' \"$clientPath\" " +
                             args.joinToString(" ")
                         ),
                 )

--- a/kotlin-sdk-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/typescript/sse/TsClientKotlinServerTestSse.kt
+++ b/kotlin-sdk-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/typescript/sse/TsClientKotlinServerTestSse.kt
@@ -4,6 +4,7 @@ import io.modelcontextprotocol.kotlin.sdk.integration.typescript.AbstractTsClien
 import io.modelcontextprotocol.kotlin.sdk.integration.typescript.TransportKind
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import java.io.File
 
 class TsClientKotlinServerTestSse : AbstractTsClientKotlinServerTest() {
 
@@ -37,14 +38,17 @@ class TsClientKotlinServerTestSse : AbstractTsClientKotlinServerTest() {
     override fun afterServer() {}
 
     override fun runClient(vararg args: String): String {
+        val myClientPath = File(tsClientDir, "myClient.ts").absolutePath
         val cmd = buildString {
-            append("npx tsx myClient.ts ")
+            append("pnpm exec tsx \"")
+            append(myClientPath)
+            append("\" ")
             append(serverUrl)
             if (args.isNotEmpty()) {
                 append(' ')
                 append(args.joinToString(" "))
             }
         }
-        return executeCommand(cmd, tsClientDir)
+        return executeCommand(cmd, sdkDir)
     }
 }

--- a/kotlin-sdk-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/typescript/sse/myClient.ts
+++ b/kotlin-sdk-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/typescript/sse/myClient.ts
@@ -17,12 +17,11 @@ async function main() {
         const path = await import('path');
         // @ts-ignore
         const { pathToFileURL } = await import('url');
-        const clientUrl = pathToFileURL(path.join(sdkDir, 'src', 'client', 'index.ts')).href;
-        const streamUrl = pathToFileURL(path.join(sdkDir, 'src', 'client', 'streamableHttp.js')).href;
+        const clientUrl = pathToFileURL(path.join(sdkDir, 'packages', 'client', 'dist', 'index.mjs')).href;
         // @ts-ignore
-        ({ Client } = await import(clientUrl));
+        const clientModule = await import(clientUrl);
         // @ts-ignore
-        ({ StreamableHTTPClientTransport } = await import(streamUrl));
+        ({ Client, StreamableHTTPClientTransport } = clientModule);
     } else {
         // @ts-ignore
         ({Client} = await import("../../../../../../../resources/typescript-sdk/src/client"));

--- a/kotlin-sdk-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/typescript/sse/simpleStreamableHttp.ts
+++ b/kotlin-sdk-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/typescript/sse/simpleStreamableHttp.ts
@@ -18,19 +18,17 @@ async function importFromSdk<T = any>(rel: string): Promise<T> {
 }
 
 async function main() {
-    const {McpServer} = await importFromSdk<any>('src/server/mcp.ts');
-    const {StreamableHTTPServerTransport} = await importFromSdk<any>('src/server/streamableHttp.ts');
+    const {McpServer} = await importFromSdk<any>('packages/server/src/index.ts');
+    const {StreamableHTTPServerTransport} = await importFromSdk<any>('packages/server/src/index.ts');
     const {
         getOAuthProtectedResourceMetadataUrl,
-        mcpAuthMetadataRouter
-    } = await importFromSdk<any>('src/server/auth/router.ts');
-    const {requireBearerAuth} = await importFromSdk<any>('src/server/auth/middleware/bearerAuth.ts');
-    const {
-        isInitializeRequest,
-    } = await importFromSdk<any>('src/types.ts');
-    const {InMemoryEventStore} = await importFromSdk<any>('src/examples/shared/inMemoryEventStore.ts');
-    const {setupAuthServer} = await importFromSdk<any>('src/examples/server/demoInMemoryOAuthProvider.ts');
-    const {checkResourceAllowed} = await importFromSdk<any>('src/shared/auth-utils.ts');
+        mcpAuthMetadataRouter,
+        checkResourceAllowed,
+        requireBearerAuth
+    } = await importFromSdk<any>('packages/server/src/index.ts');
+    const {InMemoryEventStore} = await importFromSdk<any>('examples/server/src/inMemoryEventStore.ts');
+    const {isInitializeRequest} = await importFromSdk<any>('packages/core/src/index.ts');
+    const {setupAuthServer} = await importFromSdk<any>('examples/shared/src/index.ts');
 
     // Check for OAuth flag
     const useOAuth = process.argv.includes('--oauth');

--- a/kotlin-sdk-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/typescript/stdio/myClient.ts
+++ b/kotlin-sdk-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/typescript/stdio/myClient.ts
@@ -16,7 +16,7 @@ async function main() {
 
     const path = await import('path');
     const { pathToFileURL } = await import('url');
-    const clientUrl = pathToFileURL(path.join(sdkDir, 'src', 'client', 'index.ts')).href;
+    const clientUrl = pathToFileURL(path.join(sdkDir, 'packages', 'client', 'dist', 'index.mjs')).href;
     ({ Client } = await import(clientUrl));
 
     if (!toolName) {

--- a/kotlin-sdk-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/typescript/stdio/simpleStdio.ts
+++ b/kotlin-sdk-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/typescript/stdio/simpleStdio.ts
@@ -15,8 +15,8 @@ async function importFromSdk(rel: string): Promise<any> {
 }
 
 async function main() {
-  const { McpServer } = await importFromSdk('src/server/mcp.ts');
-  const { StdioServerTransport } = await importFromSdk('src/server/stdio.ts');
+  const { McpServer } = await importFromSdk('packages/server/src/index.ts');
+  const { StdioServerTransport } = await importFromSdk('packages/server/src/index.ts');
 
   const server = new McpServer({
     name: 'simple-stdio-server',


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
`kotlin-sdk-test` uses `typescript-sdk` from git.
Structure of `typescript-sdk` was changed, it was splitted on modules, now it requires pnpm.

## How Has This Been Tested?
regular gradle build now works as expected

## Breaking Changes
no, only tests was changed

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
