### PR TITLE
fix(stdio-client)!: Stdio- and StreamableHttpClientTransport should throw McpException on send when not ready

### DIFF
--- a/integration-test/src/jvmTest/typescript/package-lock.json
+++ b/integration-test/src/jvmTest/typescript/package-lock.json
@@ -989,7 +989,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1824,7 +1823,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/kotlin-sdk-client/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/client/StdioClientTransport.kt
+++ b/kotlin-sdk-client/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/client/StdioClientTransport.kt
@@ -230,8 +230,18 @@ public class StdioClientTransport @JvmOverloads public constructor(
     }
 
     override suspend fun send(message: JSONRPCMessage, options: TransportSendOptions?) {
-        check(initialized.load()) { "Transport is not started" }
-        check(!onCloseCalled.load()) { "Transport is closed" }
+        if (!initialized.load()) {
+            throw McpException(
+                code = CONNECTION_CLOSED,
+                message = "Transport is not started",
+            )
+        }
+        if (onCloseCalled.load()) {
+            throw McpException(
+                code = CONNECTION_CLOSED,
+                message = "Transport is closed",
+            )
+        }
         @Suppress("TooGenericExceptionCaught", "SwallowedException")
         try {
             sendChannel.send(message)

--- a/kotlin-sdk-client/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/client/StreamableHttpClientTransport.kt
+++ b/kotlin-sdk-client/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/client/StreamableHttpClientTransport.kt
@@ -27,7 +27,9 @@ import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCMessage
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCNotification
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCRequest
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCResponse
+import io.modelcontextprotocol.kotlin.sdk.types.McpException
 import io.modelcontextprotocol.kotlin.sdk.types.McpJson
+import io.modelcontextprotocol.kotlin.sdk.types.RPCError.ErrorCode.CONNECTION_CLOSED
 import io.modelcontextprotocol.kotlin.sdk.types.RequestId
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineName
@@ -105,7 +107,12 @@ public class StreamableHttpClientTransport(
         resumptionToken: String?,
         onResumptionToken: ((String) -> Unit)? = null,
     ) {
-        check(initialized.load()) { "Transport is not started" }
+        if (!initialized.load()) {
+            throw McpException(
+                code = CONNECTION_CLOSED,
+                message = "Transport is not started",
+            )
+        }
         logger.debug { "Client sending message via POST to $url: ${McpJson.encodeToString(message)}" }
 
         // If we have a resumption token, reconnect the SSE stream with it

--- a/kotlin-sdk-client/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/client/AbstractClientTransportLifecycleTest.kt
+++ b/kotlin-sdk-client/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/client/AbstractClientTransportLifecycleTest.kt
@@ -4,7 +4,9 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.modelcontextprotocol.kotlin.sdk.shared.AbstractTransport
+import io.modelcontextprotocol.kotlin.sdk.types.McpException
 import io.modelcontextprotocol.kotlin.sdk.types.PingRequest
+import io.modelcontextprotocol.kotlin.sdk.types.RPCError.ErrorCode.CONNECTION_CLOSED
 import io.modelcontextprotocol.kotlin.sdk.types.toJSON
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
@@ -46,10 +48,11 @@ abstract class AbstractClientTransportLifecycleTest<T : AbstractTransport> {
     fun `should throw when sending before start`() = runTest {
         val transport = createTransport()
 
-        val exception = shouldThrow<IllegalStateException> {
+        val exception = shouldThrow<McpException> {
             transport.send(PingRequest().toJSON())
         }
         exception.message shouldContain "not started"
+        exception.code shouldBe CONNECTION_CLOSED
     }
 
     @Test


### PR DESCRIPTION
# Stdio- and StreamableHttpClientTransport should throw McpException on send when not ready

- Update `StdioClientTransport.send(...)` and `StreamableHttpClientTransport.send(...)` to throw McpException instead of IllegalStateException. Adjust tests
- Update flaky StdioClientTransportErrorHandlingTest

## Motivation and Context

Throwing `McpException` from SDK is consistent behavior.

## How Has This Been Tested?
Unit test updated

## Breaking Changes

`StdioClientTransport.send(...)` now and `StreamableHttpClientTransport.send(...)` throw `McpException`. Might break some expectations

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
Flaky [test](https://github.com/modelcontextprotocol/kotlin-sdk/actions/runs/21166350414/job/60871922436) catches the issue.
