### PR TITLE
refactor: Harden detekt setup, address some issues

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ subprojects {
     detekt {
         config = files("$rootDir/config/detekt/detekt.yml")
         buildUponDefaultConfig = true
-        failOnSeverity.set(FailOnSeverity.Never)
+        failOnSeverity.set(FailOnSeverity.Error)
     }
 }
 

--- a/conformance-test/detekt-baseline.xml
+++ b/conformance-test/detekt-baseline.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>BracesOnWhenStatements:ConformanceServer.kt:HttpServerTransport$when</ID>
+    <ID>BracesOnWhenStatements:ConformanceTest.kt:ConformanceTest$when</ID>
+    <ID>ForbiddenComment:ConformanceTest.kt:ConformanceTest.Companion$// TODO: Fix</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/conformance-test/src/test/kotlin/io/modelcontextprotocol/kotlin/sdk/conformance/ConformanceServer.kt
+++ b/conformance-test/src/test/kotlin/io/modelcontextprotocol/kotlin/sdk/conformance/ConformanceServer.kt
@@ -73,6 +73,7 @@ private const val MESSAGE_QUEUE_CAPACITY = 256
 private fun isInitializeRequest(json: JsonElement): Boolean =
     json is JsonObject && json["method"]?.jsonPrimitive?.contentOrNull == "initialize"
 
+@Suppress("CyclomaticComplexMethod", "LongMethod")
 fun main(args: Array<String>) {
     val port = args.getOrNull(0)?.toIntOrNull() ?: 3000
 
@@ -236,6 +237,7 @@ fun main(args: Array<String>) {
     }.start(wait = true)
 }
 
+@Suppress("LongMethod")
 private fun createConformanceServer(): Server {
     val server = Server(
         Implementation(
@@ -371,7 +373,9 @@ private class HttpServerTransport(private val sessionId: String) : AbstractTrans
                     }
                 }
 
-                else -> call.respond(HttpStatusCode.Accepted)
+                else -> {
+                    call.respond(HttpStatusCode.Accepted)
+                }
             }
         } catch (e: CancellationException) {
             throw e

--- a/conformance-test/src/test/kotlin/io/modelcontextprotocol/kotlin/sdk/conformance/ConformanceTest.kt
+++ b/conformance-test/src/test/kotlin/io/modelcontextprotocol/kotlin/sdk/conformance/ConformanceTest.kt
@@ -17,6 +17,7 @@ import java.net.URI
 import java.util.concurrent.TimeUnit
 import kotlin.io.path.createTempFile
 import kotlin.properties.Delegates
+import kotlin.test.fail
 
 private val logger = KotlinLogging.logger {}
 
@@ -320,7 +321,8 @@ class ConformanceTest {
             }
             process.destroyForcibly()
             throw AssertionError(
-                "❌ $capitalizedType conformance test [$transportType] '$scenario' timed out after $timeoutSeconds seconds",
+                "❌ $capitalizedType conformance test [$transportType] '$scenario' " +
+                    "timed out after $timeoutSeconds seconds",
             )
         }
 
@@ -331,8 +333,9 @@ class ConformanceTest {
                 logger.error {
                     "$capitalizedType conformance test [$transportType] '$scenario' failed with exit code: $exitCode"
                 }
-                throw AssertionError(
-                    "❌ $capitalizedType conformance test [$transportType] '$scenario' failed (exit code: $exitCode). Check test output above for details.",
+                fail(
+                    "❌ $capitalizedType conformance test [$transportType] '$scenario' " +
+                        "failed (exit code: $exitCode). Check test output above for details.",
                 )
             }
         }

--- a/conformance-test/src/test/kotlin/io/modelcontextprotocol/kotlin/sdk/conformance/WebSocketConformanceClient.kt
+++ b/conformance-test/src/test/kotlin/io/modelcontextprotocol/kotlin/sdk/conformance/WebSocketConformanceClient.kt
@@ -24,6 +24,7 @@ class WebSocketClientTransport(override val session: WebSocketSession) : WebSock
     }
 }
 
+@Suppress("LongMethod")
 fun main(args: Array<String>) {
     require(args.isNotEmpty()) {
         "Server WebSocket URL must be provided as an argument"

--- a/integration-test/detekt-baseline-commonTestSourceSet.xml
+++ b/integration-test/detekt-baseline-commonTestSourceSet.xml
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>EmptyFunctionBlock:ClientTest.kt:ClientTest.&lt;no name provided>${ }</ID>
+    <ID>EmptyFunctionBlock:ClientTest.kt:ClientTest.&lt;no name provided>${}</ID>
+    <ID>LargeClass:ClientTest.kt:ClientTest</ID>
+    <ID>LongMethod:ClientTest.kt:ClientTest$@Test fun `JSONRPCRequest with ToolsList method and default params returns list of tools`</ID>
+    <ID>LongMethod:ClientTest.kt:ClientTest$@Test fun `should handle logging setLevel request`</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/integration-test/detekt-baseline-test.xml
+++ b/integration-test/detekt-baseline-test.xml
@@ -1,0 +1,47 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>AbstractClassCanBeConcreteClass:AbstractPromptIntegrationTest.kt:AbstractPromptIntegrationTest$AbstractPromptIntegrationTest</ID>
+    <ID>AbstractClassCanBeConcreteClass:AbstractResourceIntegrationTest.kt:AbstractResourceIntegrationTest$AbstractResourceIntegrationTest</ID>
+    <ID>AbstractClassCanBeConcreteClass:AbstractToolIntegrationTest.kt:AbstractToolIntegrationTest$AbstractToolIntegrationTest</ID>
+    <ID>AbstractClassCanBeConcreteClass:BaseTransportTest.kt:BaseTransportTest$BaseTransportTest</ID>
+    <ID>CyclomaticComplexMethod:AbstractToolIntegrationTest.kt:AbstractToolIntegrationTest$private fun setupCalculatorTool</ID>
+    <ID>EmptyFunctionBlock:ClientTest.kt:ClientTest.&lt;no name provided>${ }</ID>
+    <ID>EmptyFunctionBlock:ClientTest.kt:ClientTest.&lt;no name provided>${}</ID>
+    <ID>ForbiddenComment:StdioClientTransportTest.kt:StdioClientTransportTest$// TODO: fix running on windows</ID>
+    <ID>InjectDispatcher:AbstractKotlinClientTsServerTest.kt:AbstractKotlinClientTsServerTest$IO</ID>
+    <ID>InjectDispatcher:AbstractPromptIntegrationTest.kt:AbstractPromptIntegrationTest$IO</ID>
+    <ID>InjectDispatcher:AbstractResourceIntegrationTest.kt:AbstractResourceIntegrationTest$IO</ID>
+    <ID>InjectDispatcher:AbstractToolIntegrationTest.kt:AbstractToolIntegrationTest$IO</ID>
+    <ID>InjectDispatcher:KotlinClientTsServerEdgeCasesTestSse.kt:KotlinClientTsServerEdgeCasesTestSse$IO</ID>
+    <ID>InjectDispatcher:KotlinClientTsServerEdgeCasesTestStdio.kt:KotlinClientTsServerEdgeCasesTestStdio$IO</ID>
+    <ID>InjectDispatcher:SseIntegrationTest.kt:SseIntegrationTest$IO</ID>
+    <ID>InjectDispatcher:StdioClientTransportTest.kt:StdioClientTransportTest$IO</ID>
+    <ID>InjectDispatcher:StreamableHttpIntegrationTest.kt:StreamableHttpIntegrationTest$IO</ID>
+    <ID>InjectDispatcher:TsEdgeCasesTestSse.kt:TsEdgeCasesTestSse$IO</ID>
+    <ID>InjectDispatcher:WebSocketIntegrationTest.kt:WebSocketIntegrationTest$IO</ID>
+    <ID>LargeClass:AbstractToolIntegrationTest.kt:AbstractToolIntegrationTest : KotlinTestBase</ID>
+    <ID>LargeClass:ClientTest.kt:ClientTest</ID>
+    <ID>LongMethod:AbstractPromptIntegrationTest.kt:AbstractPromptIntegrationTest$@Test fun testMissingRequiredArguments</ID>
+    <ID>LongMethod:AbstractPromptIntegrationTest.kt:AbstractPromptIntegrationTest$override fun configureServer</ID>
+    <ID>LongMethod:AbstractResourceIntegrationTest.kt:AbstractResourceIntegrationTest$override fun configureServer</ID>
+    <ID>LongMethod:AbstractToolIntegrationTest.kt:AbstractToolIntegrationTest$private fun setupCalculatorTool</ID>
+    <ID>LongMethod:ClientTest.kt:ClientTest$@Test fun `JSONRPCRequest with ToolsList method and default params returns list of tools`</ID>
+    <ID>LongMethod:ClientTest.kt:ClientTest$@Test fun `should handle logging setLevel request`</ID>
+    <ID>LongMethod:KotlinServerForTsClientSse.kt:HttpServerTransport$suspend fun handleRequest</ID>
+    <ID>LongMethod:KotlinServerForTsClientSse.kt:KotlinServerForTsClient$fun createMcpServer: Server</ID>
+    <ID>LongMethod:KotlinServerForTsClientSse.kt:KotlinServerForTsClient$fun start</ID>
+    <ID>LongMethod:KotlinTestBase.kt:KotlinTestBase$protected fun setupServer</ID>
+    <ID>LongMethod:ServerResourcesNotificationSubscribeTest.kt:ServerResourcesNotificationSubscribeTest$@Test fun `should send resource notifications`</ID>
+    <ID>LongMethod:TsEdgeCasesTestSse.kt:TsEdgeCasesTestSse$@Test @Timeout(30, unit = TimeUnit.SECONDS) fun testComplexConcurrentRequests: Unit</ID>
+    <ID>MatchingDeclarationName:PromptIntegrationTestSse.kt:SchemaPromptIntegrationTestSse : AbstractPromptIntegrationTest</ID>
+    <ID>SleepInsteadOfDelay:KotlinServerForTsClientSse.kt:KotlinServerForTsClient$sleep(500)</ID>
+    <ID>ThrowsCount:AbstractPromptIntegrationTest.kt:AbstractPromptIntegrationTest$override fun configureServer</ID>
+    <ID>UnusedPrivateProperty:KotlinClientTsServerTestSse.kt:KotlinClientTsServerTestSse$private val host = "localhost"</ID>
+    <ID>UseCheckOrError:ClientTest.kt:ClientTest.&lt;no name provided>$throw IllegalStateException("Test error")</ID>
+    <ID>UseOrEmpty:AbstractToolIntegrationTest.kt:AbstractToolIntegrationTest$(request.params.arguments?.get("tags") as? JsonArray)?.mapNotNull { (it as? JsonPrimitive)?.content } ?: emptyList()</ID>
+    <ID>UseRequire:AbstractPromptIntegrationTest.kt:AbstractPromptIntegrationTest$throw IllegalArgumentException("Missing required argument: $argName")</ID>
+    <ID>VarCouldBeVal:KotlinClientTsServerEdgeCasesTestSse.kt:KotlinClientTsServerEdgeCasesTestSse$private lateinit var client: Client</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/integration-test/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/shared/InMemoryTransport.kt
+++ b/integration-test/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/shared/InMemoryTransport.kt
@@ -40,7 +40,7 @@ class InMemoryTransport : AbstractTransport() {
     }
 
     override suspend fun send(message: JSONRPCMessage, options: TransportSendOptions?) {
-        val other = otherTransport ?: throw IllegalStateException("Not connected")
+        val other = checkNotNull(otherTransport) { "Not connected" }
 
         other._onMessage.invoke(message)
     }

--- a/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/kotlin/AbstractPromptIntegrationTest.kt
+++ b/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/kotlin/AbstractPromptIntegrationTest.kt
@@ -266,7 +266,7 @@ abstract class AbstractPromptIntegrationTest : KotlinTestBase() {
                 ),
             ),
         ) { request ->
-            val args = request.params.arguments ?: emptyMap()
+            val args = request.params.arguments.orEmpty()
             val arg1 = args["requiredArg1"] ?: throw IllegalArgumentException(
                 "Missing required argument: requiredArg1",
             )

--- a/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ServerPromptsNotificationTest.kt
+++ b/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ServerPromptsNotificationTest.kt
@@ -24,8 +24,10 @@ class ServerPromptsNotificationTest : AbstractServerFeaturesTest() {
     fun `addPrompt should send notification`() = runTest {
         // Configure notification handler
         val notifications = mutableListOf<PromptListChangedNotification>()
-        client.setNotificationHandler<PromptListChangedNotification>(Method.Defined.NotificationsPromptsListChanged) {
-            notifications.add(it)
+        client.setNotificationHandler<PromptListChangedNotification>(
+            Method.Defined.NotificationsPromptsListChanged,
+        ) { notification ->
+            notifications.add(notification)
             CompletableDeferred(Unit)
         }
 
@@ -96,8 +98,10 @@ class ServerPromptsNotificationTest : AbstractServerFeaturesTest() {
     fun `notification should not be send when removed prompt does not exists`() = runTest {
         // Track notifications
         val notifications = mutableListOf<PromptListChangedNotification>()
-        client.setNotificationHandler<PromptListChangedNotification>(Method.Defined.NotificationsPromptsListChanged) {
-            notifications.add(it)
+        client.setNotificationHandler<PromptListChangedNotification>(
+            Method.Defined.NotificationsPromptsListChanged,
+        ) { notification ->
+            notifications.add(notification)
             CompletableDeferred(Unit)
         }
 

--- a/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ServerPromptsTest.kt
+++ b/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ServerPromptsTest.kt
@@ -34,7 +34,7 @@ class ServerPromptsTest : AbstractServerFeaturesTest() {
         server.addPrompt(testPrompt) {
             GetPromptResult(
                 description = "Test prompt description",
-                messages = listOf(),
+                messages = emptyList(),
             )
         }
 
@@ -70,13 +70,13 @@ class ServerPromptsTest : AbstractServerFeaturesTest() {
         server.addPrompt(testPrompt1) {
             GetPromptResult(
                 description = "Test prompt description 1",
-                messages = listOf(),
+                messages = emptyList(),
             )
         }
         server.addPrompt(testPrompt2) {
             GetPromptResult(
                 description = "Test prompt description 2",
-                messages = listOf(),
+                messages = emptyList(),
             )
         }
 

--- a/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ServerResourcesNotificationSubscribeTest.kt
+++ b/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ServerResourcesNotificationSubscribeTest.kt
@@ -50,12 +50,12 @@ class ServerResourcesNotificationSubscribeTest : AbstractServerFeaturesTest() {
             name = "Test Resource 1",
             description = "A test resource 1",
             mimeType = "text/plain",
-        ) {
+        ) { request ->
             ReadResourceResult(
                 contents = listOf(
                     TextResourceContents(
                         text = "Test resource content 1",
-                        uri = it.uri,
+                        uri = request.uri,
                         mimeType = "text/plain",
                     ),
                 ),
@@ -67,12 +67,12 @@ class ServerResourcesNotificationSubscribeTest : AbstractServerFeaturesTest() {
             name = "Test Resource 2",
             description = "A test resource 2",
             mimeType = "text/plain",
-        ) {
+        ) { request ->
             ReadResourceResult(
                 contents = listOf(
                     TextResourceContents(
                         text = "Test resource content 2",
-                        uri = it.uri,
+                        uri = request.uri,
                         mimeType = "text/plain",
                     ),
                 ),
@@ -121,8 +121,8 @@ class ServerResourcesNotificationSubscribeTest : AbstractServerFeaturesTest() {
         println("Thread ${Thread.currentThread().name} test 1")
         // Track notifications
         val notifications = ConcurrentLinkedQueue<ResourceUpdatedNotification>()
-        client.setNotificationHandler<ResourceUpdatedNotification>(NotificationsResourcesUpdated) {
-            notifications.add(it)
+        client.setNotificationHandler<ResourceUpdatedNotification>(NotificationsResourcesUpdated) { notification ->
+            notifications.add(notification)
             CompletableDeferred(Unit)
         }
 

--- a/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ServerResourcesNotificationTest.kt
+++ b/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ServerResourcesNotificationTest.kt
@@ -26,8 +26,8 @@ class ServerResourcesNotificationTest : AbstractServerFeaturesTest() {
         val notifications = mutableListOf<ResourceListChangedNotification>()
         client.setNotificationHandler<ResourceListChangedNotification>(
             Method.Defined.NotificationsResourcesListChanged,
-        ) {
-            notifications.add(it)
+        ) { notification ->
+            notifications.add(notification)
             CompletableDeferred(Unit)
         }
 

--- a/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ServerToolsNotificationTest.kt
+++ b/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ServerToolsNotificationTest.kt
@@ -51,8 +51,10 @@ class ServerToolsNotificationTest : AbstractServerFeaturesTest() {
     fun `removeTools should remove multiple tools and send two notifications`() = runTest {
         // Configure notification handler
         val notifications = mutableListOf<ToolListChangedNotification>()
-        client.setNotificationHandler<ToolListChangedNotification>(Method.Defined.NotificationsToolsListChanged) {
-            notifications.add(it)
+        client.setNotificationHandler<ToolListChangedNotification>(
+            Method.Defined.NotificationsToolsListChanged,
+        ) { notification ->
+            notifications.add(notification)
             CompletableDeferred(Unit)
         }
 
@@ -83,8 +85,10 @@ class ServerToolsNotificationTest : AbstractServerFeaturesTest() {
     fun `notification should not be send when removed tool does not exists`() = runTest {
         // Track notifications
         val notifications = mutableListOf<ToolListChangedNotification>()
-        client.setNotificationHandler<ToolListChangedNotification>(Method.Defined.NotificationsToolsListChanged) {
-            notifications.add(it)
+        client.setNotificationHandler<ToolListChangedNotification>(
+            Method.Defined.NotificationsToolsListChanged,
+        ) { notification ->
+            notifications.add(notification)
             CompletableDeferred(Unit)
         }
 

--- a/kotlin-sdk-client/detekt-baseline-commonMainSourceSet.xml
+++ b/kotlin-sdk-client/detekt-baseline-commonMainSourceSet.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>CyclomaticComplexMethod:StdioClientTransport.kt:StdioClientTransport$override suspend fun initialize</ID>
+    <ID>LongMethod:StdioClientTransport.kt:StdioClientTransport$override suspend fun initialize</ID>
+    <ID>MaxLineLength:StdioClientTransport.kt:StdioClientTransport$*</ID>
+    <ID>ThrowsCount:SseClientTransport.kt:SseClientTransport$private suspend fun CoroutineScope.collectMessages</ID>
+    <ID>ThrowsCount:StreamableHttpClientTransport.kt:StreamableHttpClientTransport$@Suppress("ReturnCount", "CyclomaticComplexMethod") override suspend fun performSend</ID>
+    <ID>TooGenericExceptionCaught:Client.kt:Client$error: Throwable</ID>
+    <ID>TooGenericExceptionCaught:SseClientTransport.kt:SseClientTransport$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:StdioClientTransport.kt:StdioClientTransport$e: Throwable</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/kotlin-sdk-client/detekt-baseline-commonTestSourceSet.xml
+++ b/kotlin-sdk-client/detekt-baseline-commonTestSourceSet.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>LongMethod:StreamableHttpClientTransportTest.kt:StreamableHttpClientTransportTest$@Ignore @Test fun testNotificationSchemaE2E</ID>
+    <ID>MaxLineLength:StreamableHttpClientTransportTest.kt:StreamableHttpClientTransportTest$"""data: {"jsonrpc":"2.0","method":"notifications/progress","params":{"progressToken":"upload-123","progress":50,"total":100}}"""</ID>
+    <ID>MaxLineLength:StreamableHttpClientTransportTest.kt:StreamableHttpClientTransportTest$"""data: {"jsonrpc":"2.0","method":"notifications/resumed","params":{"fromToken":"$lastEventIdSent"}}"""</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/kotlin-sdk-client/detekt-baseline-main.xml
+++ b/kotlin-sdk-client/detekt-baseline-main.xml
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>CyclomaticComplexMethod:StdioClientTransport.kt:StdioClientTransport$override suspend fun initialize</ID>
+    <ID>InjectDispatcher:StdioClientTransport.kt:StdioClientTransport$Default</ID>
+    <ID>InjectDispatcher:StreamableHttpClientTransport.kt:StreamableHttpClientTransport$Default</ID>
+    <ID>LongMethod:StdioClientTransport.kt:StdioClientTransport$override suspend fun initialize</ID>
+    <ID>MaxLineLength:StdioClientTransport.kt:StdioClientTransport$*</ID>
+    <ID>NoNameShadowing:StdioClientTransport.kt:StdioClientTransport$source</ID>
+    <ID>ThrowsCount:SseClientTransport.kt:SseClientTransport$private suspend fun CoroutineScope.collectMessages</ID>
+    <ID>ThrowsCount:StreamableHttpClientTransport.kt:StreamableHttpClientTransport$@Suppress("ReturnCount", "CyclomaticComplexMethod") override suspend fun performSend</ID>
+    <ID>TooGenericExceptionCaught:Client.kt:Client$error: Throwable</ID>
+    <ID>TooGenericExceptionCaught:SseClientTransport.kt:SseClientTransport$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:StdioClientTransport.kt:StdioClientTransport$e: Throwable</ID>
+    <ID>UseCheckOrError:Client.kt:Client$throw IllegalStateException( "Server does not support resource subscriptions (required for $method)", )</ID>
+    <ID>UseCheckOrError:Client.kt:Client$throw IllegalStateException("Client does not support roots capability.")</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/kotlin-sdk-client/detekt-baseline-test.xml
+++ b/kotlin-sdk-client/detekt-baseline-test.xml
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>AbstractClassCanBeConcreteClass:AbstractStreamableHttpClientTest.kt:AbstractStreamableHttpClientTest$AbstractStreamableHttpClientTest</ID>
+    <ID>ForbiddenComment:StreamableHttpClientTest.kt:StreamableHttpClientTest$// TODO: how to get notifications via Client API?</ID>
+    <ID>InjectDispatcher:StdioClientTransportErrorHandlingTest.kt:StdioClientTransportErrorHandlingTest$IO</ID>
+    <ID>InjectDispatcher:StreamableHttpClientTransportTest.kt:StreamableHttpClientTransportTest$Default</ID>
+    <ID>LongMethod:StreamableHttpClientTest.kt:StreamableHttpClientTest$@Test fun `test streamableHttpClient`</ID>
+    <ID>LongMethod:StreamableHttpClientTransportTest.kt:StreamableHttpClientTransportTest$@Ignore @Test fun testNotificationSchemaE2E</ID>
+    <ID>LongParameterList:MockMcp.kt:MockMcp$fun handleJSONRPCRequest</ID>
+    <ID>LongParameterList:MockMcp.kt:MockMcp$fun handleWithResult</ID>
+    <ID>LongParameterList:MockMcp.kt:MockMcp$fun onInitialize</ID>
+    <ID>MaxLineLength:StreamableHttpClientTransportTest.kt:StreamableHttpClientTransportTest$"""data: {"jsonrpc":"2.0","method":"notifications/progress","params":{"progressToken":"upload-123","progress":50,"total":100}}"""</ID>
+    <ID>MaxLineLength:StreamableHttpClientTransportTest.kt:StreamableHttpClientTransportTest$"""data: {"jsonrpc":"2.0","method":"notifications/resumed","params":{"fromToken":"$lastEventIdSent"}}"""</ID>
+    <ID>UseOrEmpty:ClientMetaParameterTest.kt:ClientMetaParameterTest$exception.message ?: ""</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/kotlin-sdk-client/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/client/StreamableHttpClientTransport.kt
+++ b/kotlin-sdk-client/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/client/StreamableHttpClientTransport.kt
@@ -85,6 +85,7 @@ public class StreamableHttpClientTransport(
     /**
      * Sends a single message with optional resumption support
      */
+    @Suppress("ReturnCount", "CyclomaticComplexMethod")
     override suspend fun performSend(message: JSONRPCMessage, options: TransportSendOptions?) {
         logger.debug { "Client sending message via POST to $url: ${McpJson.encodeToString(message)}" }
 
@@ -259,6 +260,7 @@ public class StreamableHttpClientTransport(
         }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private suspend fun collectSse(
         session: ClientSSESession,
         replayMessageId: RequestId?,
@@ -295,6 +297,7 @@ public class StreamableHttpClientTransport(
         }
     }
 
+    @Suppress("CyclomaticComplexMethod")
     private suspend fun handleInlineSse(
         response: HttpResponse,
         replayMessageId: RequestId?,
@@ -331,6 +334,7 @@ public class StreamableHttpClientTransport(
             }
         }
 
+        @Suppress("LoopWithTooManyJumpStatements")
         while (!channel.isClosedForRead) {
             val line = channel.readUTF8Line() ?: break
             if (line.isEmpty()) {

--- a/kotlin-sdk-client/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/client/WebSocketClientTransport.kt
+++ b/kotlin-sdk-client/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/client/WebSocketClientTransport.kt
@@ -26,8 +26,8 @@ public class WebSocketClientTransport(
     override suspend fun initializeSession() {
         logger.debug { "Websocket session initialization started..." }
 
-        session = urlString?.let {
-            client.webSocketSession(it) {
+        session = urlString?.let { url ->
+            client.webSocketSession(url) {
                 requestBuilder()
 
                 header(HttpHeaders.SecWebSocketProtocol, MCP_SUBPROTOCOL)

--- a/kotlin-sdk-core/detekt-baseline-commonMainSourceSet.xml
+++ b/kotlin-sdk-core/detekt-baseline-commonMainSourceSet.xml
@@ -1,0 +1,27 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>CyclomaticComplexMethod:jsonUtils.kt:@OptIn(ExperimentalUnsignedTypes::class, ExperimentalSerializationApi::class) private fun convertToJsonElement: JsonElement</ID>
+    <ID>LongMethod:Protocol.kt:Protocol$public suspend fun &lt;T : RequestResult> request: T</ID>
+    <ID>MagicNumber:completion.kt:CompleteResult.Completion$100</ID>
+    <ID>MatchingDeclarationName:capabilities.dsl.kt:ClientCapabilitiesBuilder</ID>
+    <ID>MatchingDeclarationName:methods.kt:Method</ID>
+    <ID>MaxLineLength:AbstractClientTransport.kt:AbstractClientTransport$*</ID>
+    <ID>MaxLineLength:ClientTransportState.kt:ClientTransportState.Initializing$*</ID>
+    <ID>MaxLineLength:Protocol.kt:Protocol$"Received progress notification: token=${notification.params.progressToken}, progress=${notification.params.progress}/${notification.params.total}"</ID>
+    <ID>MaxLineLength:Protocol.kt:Protocol$*</ID>
+    <ID>MaxLineLength:Protocol.kt:RequestOptions$*</ID>
+    <ID>MaxLineLength:Transport.kt:Transport$*</ID>
+    <ID>MaxLineLength:TransportSendOptions.kt:TransportSendOptions$*</ID>
+    <ID>ReturnCount:ReadBuffer.kt:ReadBuffer$public fun readMessage: JSONRPCMessage?</ID>
+    <ID>ThrowsCount:AbstractClientTransport.kt:AbstractClientTransport$public override suspend fun send</ID>
+    <ID>TooGenericExceptionCaught:AbstractClientTransport.kt:AbstractClientTransport$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:Protocol.kt:Protocol$cause: Throwable</ID>
+    <ID>TooGenericExceptionCaught:Protocol.kt:Protocol$error: Throwable</ID>
+    <ID>TooGenericExceptionCaught:Protocol.kt:Protocol$sendError: Throwable</ID>
+    <ID>TooGenericExceptionCaught:ReadBuffer.kt:ReadBuffer$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:WebSocketMcpTransport.kt:WebSocketMcpTransport$e: Exception</ID>
+    <ID>TooManyFunctions:Protocol.kt:Protocol</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/kotlin-sdk-core/detekt-baseline-commonTestSourceSet.xml
+++ b/kotlin-sdk-core/detekt-baseline-commonTestSourceSet.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>EmptyFunctionBlock:ProtocolTest.kt:RecordingTransport${}</ID>
+    <ID>EmptyFunctionBlock:ProtocolTest.kt:TestProtocol${}</ID>
+    <ID>LongMethod:ElicitationTest.kt:ElicitationTest$@Test fun `should serialize ElicitRequest with requested schema`</ID>
+    <ID>LongMethod:SamplingDslTest.kt:SamplingDslTest$@Test fun `buildCreateMessageRequest should build with all fields`</ID>
+    <ID>LongMethod:SamplingTest.kt:SamplingTest$@Test fun `should serialize CreateMessageRequest with all fields`</ID>
+    <ID>LongMethod:ToolsTest.kt:ToolsTest$@Test fun `should serialize Tool with annotations and schemas`</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/kotlin-sdk-core/detekt-baseline-main.xml
+++ b/kotlin-sdk-core/detekt-baseline-main.xml
@@ -1,0 +1,32 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>CyclomaticComplexMethod:jsonUtils.kt:@OptIn(ExperimentalUnsignedTypes::class, ExperimentalSerializationApi::class) private fun convertToJsonElement: JsonElement</ID>
+    <ID>InjectDispatcher:utils.jvm.kt:IO</ID>
+    <ID>InstanceOfCheckForException:AbstractClientTransport.kt:AbstractClientTransport$e is McpException</ID>
+    <ID>LongMethod:Protocol.kt:Protocol$public suspend fun &lt;T : RequestResult> request: T</ID>
+    <ID>MagicNumber:completion.kt:CompleteResult.Completion$100</ID>
+    <ID>MatchingDeclarationName:capabilities.dsl.kt:ClientCapabilitiesBuilder</ID>
+    <ID>MatchingDeclarationName:methods.kt:Method</ID>
+    <ID>MaxLineLength:AbstractClientTransport.kt:AbstractClientTransport$*</ID>
+    <ID>MaxLineLength:ClientTransportState.kt:ClientTransportState.Initializing$*</ID>
+    <ID>MaxLineLength:Protocol.kt:Protocol$"Received progress notification: token=${notification.params.progressToken}, progress=${notification.params.progress}/${notification.params.total}"</ID>
+    <ID>MaxLineLength:Protocol.kt:Protocol$*</ID>
+    <ID>MaxLineLength:Protocol.kt:RequestOptions$*</ID>
+    <ID>MaxLineLength:Transport.kt:Transport$*</ID>
+    <ID>MaxLineLength:TransportSendOptions.kt:TransportSendOptions$*</ID>
+    <ID>NoNameShadowing:Protocol.kt:Protocol$error</ID>
+    <ID>ReturnCount:ReadBuffer.kt:ReadBuffer$public fun readMessage: JSONRPCMessage?</ID>
+    <ID>ThrowsCount:AbstractClientTransport.kt:AbstractClientTransport$public override suspend fun send</ID>
+    <ID>TooGenericExceptionCaught:AbstractClientTransport.kt:AbstractClientTransport$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:Protocol.kt:Protocol$cause: Throwable</ID>
+    <ID>TooGenericExceptionCaught:Protocol.kt:Protocol$error: Throwable</ID>
+    <ID>TooGenericExceptionCaught:Protocol.kt:Protocol$sendError: Throwable</ID>
+    <ID>TooGenericExceptionCaught:ReadBuffer.kt:ReadBuffer$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:WebSocketMcpTransport.kt:WebSocketMcpTransport$e: Exception</ID>
+    <ID>TooManyFunctions:Protocol.kt:Protocol</ID>
+    <ID>UnsafeCallOnNullableType:Protocol.kt:Protocol$response!!</ID>
+    <ID>UseCheckNotNull:Protocol.kt:Protocol$check(error != null)</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/kotlin-sdk-core/detekt-baseline-test.xml
+++ b/kotlin-sdk-core/detekt-baseline-test.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>EmptyFunctionBlock:ProtocolTest.kt:RecordingTransport${}</ID>
+    <ID>EmptyFunctionBlock:ProtocolTest.kt:TestProtocol${}</ID>
+    <ID>LongMethod:ElicitationTest.kt:ElicitationTest$@Test fun `should serialize ElicitRequest with requested schema`</ID>
+    <ID>LongMethod:SamplingDslTest.kt:SamplingDslTest$@Test fun `buildCreateMessageRequest should build with all fields`</ID>
+    <ID>LongMethod:SamplingTest.kt:SamplingTest$@Test fun `should serialize CreateMessageRequest with all fields`</ID>
+    <ID>LongMethod:ToolsTest.kt:ToolsTest$@Test fun `should serialize Tool with annotations and schemas`</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types.kt
@@ -1,16 +1,14 @@
-@file:Suppress("FunctionName")
+@file:Suppress("FunctionName", "TooManyFunctions")
 
 package io.modelcontextprotocol.kotlin.sdk
 
-import io.modelcontextprotocol.kotlin.sdk.types.ClientCapabilities.Roots
 import io.modelcontextprotocol.kotlin.sdk.types.ContentBlock
 import io.modelcontextprotocol.kotlin.sdk.types.fromJSON
 import io.modelcontextprotocol.kotlin.sdk.types.toJSON
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
-import kotlin.concurrent.atomics.AtomicLong
-import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import io.modelcontextprotocol.kotlin.sdk.types.ClientCapabilities.Roots as TypesRoots
 
 @Deprecated(
     message = "Use `LATEST_PROTOCOL_VERSION` instead",
@@ -39,14 +37,6 @@ public val SUPPORTED_PROTOCOL_VERSIONS: List<String> =
     level = DeprecationLevel.ERROR,
 )
 public const val JSONRPC_VERSION: String = io.modelcontextprotocol.kotlin.sdk.types.JSONRPC_VERSION
-
-@OptIn(ExperimentalAtomicApi::class)
-@Deprecated(
-    message = "Use `REQUEST_MESSAGE_ID` instead",
-    replaceWith = ReplaceWith("REQUEST_MESSAGE_ID", "io.modelcontextprotocol.kotlin.sdk.types.REQUEST_MESSAGE_ID"),
-    level = DeprecationLevel.ERROR,
-)
-private val REQUEST_MESSAGE_ID: AtomicLong = AtomicLong(0L)
 
 /**
  * A progress token, used to associate progress notifications with the original request.
@@ -81,8 +71,6 @@ public typealias WithMeta = io.modelcontextprotocol.kotlin.sdk.types.WithMeta
 
 /**
  * An implementation of [WithMeta] containing custom metadata.
- *
- * @param _meta The JSON object holding metadata. Defaults to an empty JSON object.
  */
 @Deprecated(
     message = "This class will be removed. Use `WithMeta` instead",
@@ -431,8 +419,6 @@ internal fun JSONRPCRequest.fromJSON(): Request = this.fromJSON()
 
 /**
  * A custom request with a specified method.
- *
- * @param method The method associated with the request.
  */
 @Deprecated(
     message = "Use `CustomRequest` instead",
@@ -489,8 +475,6 @@ public typealias RequestResult = io.modelcontextprotocol.kotlin.sdk.types.Reques
 
 /**
  * An empty result for a request containing optional metadata.
- *
- * @param _meta Additional metadata for the response. Defaults to an empty JSON object.
  */
 @Deprecated(
     message = "Use `EmptyResult` instead",
@@ -708,7 +692,8 @@ public object CancelledNotification {
 /**
  * This notification can be sent by either side to indicate that it is cancelling a previously issued request.
  *
- * The request SHOULD still be in-flight, but due to communication latency, it is always possible that this notification MAY arrive after the request has already finished.
+ * The request SHOULD still be in-flight, but due to communication latency, it is always possible that
+ * this notification MAY arrive after the request has already finished.
  *
  * This notification indicates that the result will be unused, so any associated processing SHOULD cease.
  *
@@ -745,6 +730,15 @@ public typealias Implementation = io.modelcontextprotocol.kotlin.sdk.types.Imple
     level = DeprecationLevel.ERROR,
 )
 public object ClientCapabilities {
+    /**
+     * Creates an instance of [Roots], representing the client's capability
+     * to list roots and optionally listen for changes in the roots list.
+     *
+     * @param listChanged Optional flag indicating whether the client supports notifications
+     * for changes to the roots list. If set to true, the client will notify the server when
+     * roots are added or removed.
+     * @return A new instance of [Roots] configured with the provided [listChanged] value.
+     */
     @Deprecated(
         message = "Use `ClientCapabilities.Roots` instead",
         replaceWith = ReplaceWith(
@@ -753,8 +747,7 @@ public object ClientCapabilities {
         ),
         level = DeprecationLevel.ERROR,
     )
-    public fun Roots(listChanged: Boolean? = null): io.modelcontextprotocol.kotlin.sdk.types.ClientCapabilities.Roots =
-        io.modelcontextprotocol.kotlin.sdk.types.ClientCapabilities.Roots(listChanged)
+    public fun Roots(listChanged: Boolean? = null): TypesRoots = TypesRoots(listChanged)
 }
 
 /**
@@ -769,7 +762,7 @@ public object ClientCapabilities {
 )
 public fun ClientCapabilities(
     sampling: JsonObject? = null,
-    roots: Roots? = null,
+    roots: TypesRoots? = null,
     elicitation: JsonObject? = null,
     experimental: JsonObject? = null,
 ): io.modelcontextprotocol.kotlin.sdk.types.ClientCapabilities =
@@ -918,6 +911,7 @@ public object ServerCapabilities {
     replaceWith = ReplaceWith("ServerCapabilities", "io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities"),
     level = DeprecationLevel.ERROR,
 )
+@Suppress("LongParameterList")
 public fun ServerCapabilities(
     tools: io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities.Tools? = null,
     resources: io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities.Resources? = null,
@@ -1027,9 +1021,6 @@ public sealed interface ProgressBase {
 
 /**
  * Represents a progress notification.
- *
- * @property progress The current progress value.
- * @property total The total progress required, if known.
  */
 @Deprecated(
     message = "Use `Progress` instead",
@@ -1117,8 +1108,6 @@ public typealias ResourceContents = io.modelcontextprotocol.kotlin.sdk.types.Res
 
 /**
  * Represents the text contents of a resource.
- *
- * @property text The text of the item. This must only be set if the item can actually be represented as text (not binary data).
  */
 @Deprecated(
     message = "Use `TextResourceContents` instead",
@@ -1129,8 +1118,6 @@ public typealias TextResourceContents = io.modelcontextprotocol.kotlin.sdk.types
 
 /**
  * Represents the binary contents of a resource encoded as a base64 string.
- *
- * @property blob A base64-encoded string representing the binary data of the item.
  */
 @Deprecated(
     message = "Use `BlobResourceContents` instead",
@@ -1278,7 +1265,8 @@ public fun ResourceListChangedNotification(
     io.modelcontextprotocol.kotlin.sdk.types.ResourceListChangedNotification(params)
 
 /**
- * Sent from the client to request resources/updated notifications from the server whenever a particular resource changes.
+ * Sent from the client to request resources/updated notifications from the server
+ * whenever a particular resource changes.
  */
 @Deprecated(
     message = "Use `SubscribeRequest` instead",
@@ -1288,7 +1276,8 @@ public fun ResourceListChangedNotification(
 public typealias SubscribeRequest = io.modelcontextprotocol.kotlin.sdk.types.SubscribeRequest
 
 /**
- * Sent from the client to request cancellation of resources/updated notifications from the server. This should follow a previous resources/subscribe request.
+ * Sent from the client to request cancellation of resources/updated notifications from the server.
+ * This should follow a previous resources/subscribe request.
  */
 @Deprecated(
     message = "Use `UnsubscribeRequest` instead",
@@ -1322,7 +1311,8 @@ public object ResourceUpdatedNotification {
 }
 
 /**
- * A notification from the server to the client, informing it that a resource has changed and may need to be read again. This should only be sent if the client previously sent a resources/subscribe request.
+ * A notification from the server to the client, informing it that a resource has changed and may need to be read again.
+ * This should only be sent if the client previously sent a resources/subscribe request.
  */
 @Deprecated(
     message = "Use `ResourceUpdatedNotification` instead",
@@ -1397,7 +1387,7 @@ public typealias GetPromptRequest = io.modelcontextprotocol.kotlin.sdk.types.Get
     replaceWith = ReplaceWith("ContentBlock"),
     level = DeprecationLevel.ERROR,
 )
-public typealias PromptMessageContent = io.modelcontextprotocol.kotlin.sdk.types.ContentBlock
+public typealias PromptMessageContent = ContentBlock
 
 /**
  * Represents prompt message content that is either text, image or audio.
@@ -1610,6 +1600,7 @@ public object Tool {
     replaceWith = ReplaceWith("Tool", "io.modelcontextprotocol.kotlin.sdk.types.Tool"),
     level = DeprecationLevel.ERROR,
 )
+@Suppress("LongParameterList", "FunctionParameterNaming")
 public fun Tool(
     name: String,
     inputSchema: io.modelcontextprotocol.kotlin.sdk.types.ToolSchema,
@@ -1698,7 +1689,7 @@ public fun CallToolResult(
     replaceWith = ReplaceWith("ToolCallResult"),
     level = DeprecationLevel.ERROR,
 )
-@Suppress("DEPRECATION_ERROR")
+@Suppress("DEPRECATION_ERROR", "ConstructorParameterNaming")
 public class CompatibilityCallToolResult(
     public val content: List<PromptMessageContent>,
     public val structuredContent: JsonObject? = null,
@@ -2250,10 +2241,6 @@ public fun CreateElicitationResult(
 
 /**
  * Represents an error specific to the MCP protocol.
- *
- * @property code The error code.
- * @property message The error message.
- * @property data Additional error data as a JSON object.
  */
 @Deprecated(
     message = "Use `McpException` instead",

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/completion.dsl.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/completion.dsl.kt
@@ -160,7 +160,8 @@ public class CompleteRequestBuilder @PublishedApi internal constructor() : Reque
         }
 
         val reference = requireNotNull(ref) {
-            "Missing required field 'ref(Reference)'. Use ref(PromptReference(\"name\")) or ref(ResourceTemplateReference(\"uri\"))"
+            "Missing required field 'ref(Reference)'. Use ref(PromptReference(\"name\")) " +
+                "or ref(ResourceTemplateReference(\"uri\"))"
         }
 
         val params = CompleteRequestParams(argument = argument, ref = reference, context = ctx, meta = meta)

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/jsonRpc.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/jsonRpc.kt
@@ -16,8 +16,22 @@ import kotlin.uuid.Uuid
 
 public const val JSONRPC_VERSION: String = "2.0"
 
+/**
+ * Creates a `RequestId` instance using the provided string value.
+ *
+ * @param value The string representation of the request ID. This value is used
+ *              to uniquely identify a request in the JSON-RPC context.
+ * @return A `RequestId` instance of type `StringId` with the provided string value.
+ */
 public fun RequestId(value: String): RequestId = RequestId.StringId(value)
 
+/**
+ * Creates a `RequestId` instance using the given numeric value.
+ *
+ * @param value The numeric value to be used for the `RequestId`. This should uniquely
+ *              identify a request when represented as a `NumberId`.
+ * @return A `RequestId.NumberId` instance encapsulating the provided numeric value.
+ */
 public fun RequestId(value: Long): RequestId = RequestId.NumberId(value)
 
 /**

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/jsonUtils.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/jsonUtils.kt
@@ -24,6 +24,17 @@ public val McpJson: Json by lazy {
     }
 }
 
+/**
+ * Converts a [Map] with [String] keys and nullable [Any] values into a [Map] with
+ * [String] keys and [JsonElement] values.
+ *
+ * Each value in the resulting map is derived from the corresponding value
+ * in the input map, transformed into a [JsonElement]. If the transformation
+ * fails for any reason, the value is replaced with a [JsonPrimitive] containing
+ * the original value's `toString` representation.
+ *
+ * @return A new map where the values are converted to [JsonElement] instances.
+ */
 public fun Map<String, Any?>.toJson(): Map<String, JsonElement> = this.mapValues { (_, value) ->
     runCatching { convertToJsonElement(value) }
         .getOrElse { JsonPrimitive(value.toString()) }
@@ -77,7 +88,5 @@ private fun convertToJsonElement(value: Any?): JsonElement = when (value) {
 
     is UByteArray -> buildJsonArray { value.forEach { add(JsonPrimitive(it)) } }
 
-    else -> {
-        JsonPrimitive(value.toString())
-    }
+    else -> JsonPrimitive(value.toString())
 }

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/notification.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/notification.kt
@@ -262,7 +262,8 @@ public data class PromptListChangedNotification(override val params: BaseNotific
 // ============================================================================
 
 /**
- * An optional notification from the server to the client, informing it that the list of resources it can read from has changed.
+ * An optional notification from the server to the client,
+ * informing it that the list of resources it can read from has changed.
  *
  * Servers may issue this without any previous subscription from the client.
  * Sent only if the server's [ServerCapabilities.resources] has `listChanged = true`.

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/request.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/request.kt
@@ -22,6 +22,12 @@ public value class RequestMeta(public val json: JsonObject) {
             }
         }
 
+    /**
+     * Retrieves the value associated with the specified key from the JSON object.
+     *
+     * @param key the key whose corresponding value is to be returned
+     * @return the JsonElement associated with the specified key, or null if the key does not exist
+     */
     public operator fun get(key: String): JsonElement? = json[key]
 }
 

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/RequestTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/RequestTest.kt
@@ -1,6 +1,7 @@
 package io.modelcontextprotocol.kotlin.sdk.types
 
 import io.kotest.assertions.json.shouldEqualJson
+import io.kotest.matchers.shouldBe
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.double
 import kotlinx.serialization.json.jsonPrimitive
@@ -149,7 +150,9 @@ class RequestTest {
         val method = custom.method
         val customMethod = assertIs<Method.Custom>(method)
         assertEquals("extensions/customAction", customMethod.value)
-        assertEquals("custom-1", custom.params?.meta?.json?.get("progressToken")?.jsonPrimitive?.content)
+        custom.params?.meta?.json
+            ?.get("progressToken")
+            ?.jsonPrimitive?.content shouldBe "custom-1"
     }
 
     @Test

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/dsl/PingRequestDslTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/dsl/PingRequestDslTest.kt
@@ -49,12 +49,16 @@ class PingRequestDslTest {
         val requestInt = buildPingRequest {
             meta { progressToken(123) }
         }
-        requestInt.params?.meta?.json?.get("progressToken")?.jsonPrimitive?.int shouldBe 123
+        requestInt.params?.meta?.json
+            ?.get("progressToken")
+            ?.jsonPrimitive?.int shouldBe 123
 
         val requestLong = buildPingRequest {
             meta { progressToken(456L) }
         }
-        requestLong.params?.meta?.json?.get("progressToken")?.jsonPrimitive?.int shouldBe 456
+        requestLong.params?.meta?.json
+            ?.get("progressToken")
+            ?.jsonPrimitive?.int shouldBe 456
     }
 
     @Test

--- a/kotlin-sdk-server/detekt-baseline-commonMainSourceSet.xml
+++ b/kotlin-sdk-server/detekt-baseline-commonMainSourceSet.xml
@@ -1,0 +1,21 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>MagicNumber:StdioServerTransport.kt:StdioServerTransport$8192</ID>
+    <ID>MaxLineLength:SSEServerTransport.kt:SseServerTransport$"SSEServerTransport already started! If using Server class, note that connect() calls start() automatically."</ID>
+    <ID>MaxLineLength:SSEServerTransport.kt:SseServerTransport$*</ID>
+    <ID>MaxLineLength:ServerSession.kt:ServerSession$"Client requested unsupported protocol version $requestedVersion, falling back to $LATEST_PROTOCOL_VERSION"</ID>
+    <ID>MaxLineLength:ServerSession.kt:ServerSession$"Creating message with ${params.params.messages.size} messages, maxTokens=${params.params.maxTokens}, temperature=${params.params.temperature}, systemPrompt=${if (params.params.systemPrompt != null) "present" else "absent"}"</ID>
+    <ID>ReturnCount:KtorServer.kt:private suspend fun existingStreamableTransport: StreamableHttpServerTransport?</ID>
+    <ID>ThrowsCount:ServerSession.kt:ServerSession$override fun assertCapabilityForMethod</ID>
+    <ID>ThrowsCount:ServerSession.kt:ServerSession$override fun assertNotificationCapability</ID>
+    <ID>ThrowsCount:ServerSession.kt:ServerSession$override fun assertRequestHandlerCapability</ID>
+    <ID>TooGenericExceptionCaught:SSEServerTransport.kt:SseServerTransport$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:Server.kt:Server$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:StdioServerTransport.kt:StdioServerTransport$e: Throwable</ID>
+    <ID>TooManyFunctions:KtorServer.kt:io.modelcontextprotocol.kotlin.sdk.server.KtorServer.kt</ID>
+    <ID>TooManyFunctions:Server.kt:Server</ID>
+    <ID>TooManyFunctions:ServerSession.kt:ServerSession : Protocol</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/kotlin-sdk-server/detekt-baseline-main.xml
+++ b/kotlin-sdk-server/detekt-baseline-main.xml
@@ -1,0 +1,51 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>InjectDispatcher:FeatureNotificationService.kt:FeatureNotificationService$Default</ID>
+    <ID>LongParameterList:KtorServer.kt:private suspend fun RoutingContext.streamableTransport: StreamableHttpServerTransport?</ID>
+    <ID>LongParameterList:Server.kt:Server$public fun addTool</ID>
+    <ID>MagicNumber:StdioServerTransport.kt:StdioServerTransport$8192</ID>
+    <ID>MaxLineLength:SSEServerTransport.kt:SseServerTransport$"SSEServerTransport already started! If using Server class, note that connect() calls start() automatically."</ID>
+    <ID>MaxLineLength:SSEServerTransport.kt:SseServerTransport$*</ID>
+    <ID>MaxLineLength:ServerSession.kt:ServerSession$"Client requested unsupported protocol version $requestedVersion, falling back to $LATEST_PROTOCOL_VERSION"</ID>
+    <ID>MaxLineLength:ServerSession.kt:ServerSession$"Creating message with ${params.params.messages.size} messages, maxTokens=${params.params.maxTokens}, temperature=${params.params.temperature}, systemPrompt=${if (params.params.systemPrompt != null) "present" else "absent"}"</ID>
+    <ID>NoNameShadowing:FeatureNotificationService.kt:FeatureNotificationService${ it.remove(job) }</ID>
+    <ID>RedundantSuspendModifier:ServerSession.kt:ServerSession$suspend</ID>
+    <ID>ReturnCount:KtorServer.kt:private suspend fun existingStreamableTransport: StreamableHttpServerTransport?</ID>
+    <ID>ThrowsCount:ServerSession.kt:ServerSession$override fun assertCapabilityForMethod</ID>
+    <ID>ThrowsCount:ServerSession.kt:ServerSession$override fun assertNotificationCapability</ID>
+    <ID>ThrowsCount:ServerSession.kt:ServerSession$override fun assertRequestHandlerCapability</ID>
+    <ID>TooGenericExceptionCaught:SSEServerTransport.kt:SseServerTransport$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:Server.kt:Server$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:StdioServerTransport.kt:StdioServerTransport$e: Throwable</ID>
+    <ID>TooManyFunctions:KtorServer.kt:io.modelcontextprotocol.kotlin.sdk.server.KtorServer.kt</ID>
+    <ID>TooManyFunctions:Server.kt:Server</ID>
+    <ID>TooManyFunctions:ServerSession.kt:ServerSession : Protocol</ID>
+    <ID>UnsafeCallOnNullableType:StreamableHttpServerTransport.kt:StreamableHttpServerTransport$responseRequestId!!</ID>
+    <ID>UseCheckNotNull:Server.kt:Server$check(options.capabilities.prompts != null) { logger.error { "Failed to add prompt '${prompt.name}': Server does not support prompts capability" } "Server does not support prompts capability." }</ID>
+    <ID>UseCheckNotNull:Server.kt:Server$check(options.capabilities.prompts != null) { logger.error { "Failed to add prompts: Server does not support prompts capability" } "Server does not support prompts capability." }</ID>
+    <ID>UseCheckNotNull:Server.kt:Server$check(options.capabilities.prompts != null) { logger.error { "Failed to remove prompt '$name': Server does not support prompts capability" } "Server does not support prompts capability." }</ID>
+    <ID>UseCheckNotNull:Server.kt:Server$check(options.capabilities.prompts != null) { logger.error { "Failed to remove prompts: Server does not support prompts capability" } "Server does not support prompts capability." }</ID>
+    <ID>UseCheckNotNull:Server.kt:Server$check(options.capabilities.resources != null) { logger.error { "Failed to add resource '$name': Server does not support resources capability" } "Server does not support resources capability." }</ID>
+    <ID>UseCheckNotNull:Server.kt:Server$check(options.capabilities.resources != null) { logger.error { "Failed to add resources: Server does not support resources capability" } "Server does not support resources capability." }</ID>
+    <ID>UseCheckNotNull:Server.kt:Server$check(options.capabilities.resources != null) { logger.error { "Failed to remove resource '$uri': Server does not support resources capability" } "Server does not support resources capability." }</ID>
+    <ID>UseCheckNotNull:Server.kt:Server$check(options.capabilities.resources != null) { logger.error { "Failed to remove resources: Server does not support resources capability" } "Server does not support resources capability." }</ID>
+    <ID>UseCheckNotNull:Server.kt:Server$check(options.capabilities.tools != null) { logger.error { "Failed to add tool '${tool.name}': Server does not support tools capability" } "Server does not support tools capability. Enable it in ServerOptions." }</ID>
+    <ID>UseCheckNotNull:Server.kt:Server$check(options.capabilities.tools != null) { logger.error { "Failed to add tools: Server does not support tools capability" } "Server does not support tools capability." }</ID>
+    <ID>UseCheckNotNull:Server.kt:Server$check(options.capabilities.tools != null) { logger.error { "Failed to remove tool '$name': Server does not support tools capability" } "Server does not support tools capability." }</ID>
+    <ID>UseCheckNotNull:Server.kt:Server$check(options.capabilities.tools != null) { logger.error { "Failed to remove tools: Server does not support tools capability" } "Server does not support tools capability." }</ID>
+    <ID>UseCheckOrError:ServerSession.kt:ServerSession$throw IllegalStateException( "Server does not support notifying about resources (required for ${method.value})", )</ID>
+    <ID>UseCheckOrError:ServerSession.kt:ServerSession$throw IllegalStateException( "Server does not support notifying of prompt list changes (required for ${method.value})", )</ID>
+    <ID>UseCheckOrError:ServerSession.kt:ServerSession$throw IllegalStateException( "Server does not support notifying of tool list changes (required for ${method.value})", )</ID>
+    <ID>UseCheckOrError:ServerSession.kt:ServerSession$throw IllegalStateException("Client does not support elicitation (required for ${method.value})")</ID>
+    <ID>UseCheckOrError:ServerSession.kt:ServerSession$throw IllegalStateException("Client does not support listing roots (required for ${method.value})")</ID>
+    <ID>UseCheckOrError:ServerSession.kt:ServerSession$throw IllegalStateException("Client does not support sampling (required for ${method.value})")</ID>
+    <ID>UseCheckOrError:ServerSession.kt:ServerSession$throw IllegalStateException("Server does not support logging (required for $method)")</ID>
+    <ID>UseCheckOrError:ServerSession.kt:ServerSession$throw IllegalStateException("Server does not support logging (required for ${method.value})")</ID>
+    <ID>UseCheckOrError:ServerSession.kt:ServerSession$throw IllegalStateException("Server does not support prompts (required for $method)")</ID>
+    <ID>UseCheckOrError:ServerSession.kt:ServerSession$throw IllegalStateException("Server does not support resources (required for $method)")</ID>
+    <ID>UseCheckOrError:ServerSession.kt:ServerSession$throw IllegalStateException("Server does not support sampling (required for $method)")</ID>
+    <ID>UseCheckOrError:ServerSession.kt:ServerSession$throw IllegalStateException("Server does not support tools (required for $method)")</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/KtorServer.kt
+++ b/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/KtorServer.kt
@@ -46,6 +46,12 @@ internal class TransportManager(transports: Map<String, AbstractTransport> = emp
     }
 }
 
+/**
+ * Registers a server-sent events (SSE) route at the specified path.
+ *
+ * @param path the URL path to register the route for SSE.
+ * @param block the block of code that defines the server's behavior for the SSE session.
+ */
 @KtorDsl
 public fun Routing.mcp(path: String, block: ServerSSESession.() -> Server) {
     route(path) {
@@ -53,7 +59,7 @@ public fun Routing.mcp(path: String, block: ServerSSESession.() -> Server) {
     }
 }
 
-/*
+/**
 * Configures the Ktor Application to handle Model Context Protocol (MCP) over Server-Sent Events (SSE).
 */
 @KtorDsl

--- a/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/WebSocketMcpKtorServerExtensions.kt
+++ b/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/WebSocketMcpKtorServerExtensions.kt
@@ -1,3 +1,5 @@
+@file:Suppress("TooManyFunctions")
+
 package io.modelcontextprotocol.kotlin.sdk.server
 
 import io.github.oshai.kotlinlogging.KotlinLogging

--- a/test-utils/detekt-baseline.xml
+++ b/test-utils/detekt-baseline.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>CyclomaticComplexMethod:Retry.kt:RetryExtension$private fun executeWithRetry</ID>
+    <ID>ReturnCount:TypeScriptRunner.kt:TypeScriptRunner$public fun installDependencies</ID>
+    <ID>ThrowsCount:Retry.kt:RetryExtension$private fun executeWithRetry</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/test-utils/src/main/kotlin/io/modelcontextprotocol/kotlin/test/utils/TypeScriptRunner.kt
+++ b/test-utils/src/main/kotlin/io/modelcontextprotocol/kotlin/test/utils/TypeScriptRunner.kt
@@ -1,5 +1,6 @@
 package io.modelcontextprotocol.kotlin.test.utils
 
+import org.junit.jupiter.api.fail
 import java.io.File
 
 /**
@@ -83,7 +84,7 @@ public object TypeScriptRunner {
         patchPackageJsonRecursively(typescriptDir, patchProtocols = true)
         if (tryCommand(listOf("npm", "install"), typescriptDir)) return
 
-        throw RuntimeException("Failed to install TypeScript dependencies in ${typescriptDir.absolutePath}")
+        fail("Failed to install TypeScript dependencies in ${typescriptDir.absolutePath}")
     }
 
     private fun tryCommand(command: List<String>, workingDir: File): Boolean {

--- a/test-utils/src/main/kotlin/io/modelcontextprotocol/kotlin/test/utils/processUtils.kt
+++ b/test-utils/src/main/kotlin/io/modelcontextprotocol/kotlin/test/utils/processUtils.kt
@@ -14,6 +14,7 @@ import kotlin.time.Duration.Companion.seconds
  */
 public fun killProcessOnPort(port: Int) {
     val killCommand = if (isWindows) {
+        @Suppress("MaxLineLength")
         listOf(
             "cmd.exe",
             "/c",


### PR DESCRIPTION
# Detekt setup hardeing; address some issues

- Address some detekt findings: missing KDocs, formatting, use `check*` & `orEmpty()``
- Remove unnecessary KDoc comments from deprecated classes in `types.kt`
- Add Detekt baseline XML files for all modules
- Enforce stricter Detekt rules by setting `failOnSeverity` from `None` to `Error`

## Motivation and Context

Detekt is not actually failing the build on violations. This PR is enabling Detekt to fail on errors. Baseline fines added for historical issues. Follow-up for #501 

## How Has This Been Tested?
Regressions

## Breaking Changes

No breaking changes.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

