### PR TITLE
fix(test): add timeout to prevent indefinite blocking in StdioClientTransportTest (#514)

### DIFF
--- a/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/client/StdioClientTransportTest.kt
+++ b/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/client/StdioClientTransportTest.kt
@@ -9,6 +9,7 @@ import io.modelcontextprotocol.kotlin.test.utils.createTeeProcessBuilder
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import kotlinx.io.asSink
 import kotlinx.io.asSource
 import kotlinx.io.buffered
@@ -56,8 +57,11 @@ class StdioClientTransportTest : BaseTransportTest() {
         )
 
         // The error in stderr should cause connecting to fail
+        // Use explicit timeout to avoid blocking indefinitely due to kotlinx.io cancellation issue (#514)
         assertThrows<McpException> {
-            client.connect(transport)
+            withTimeout(5.seconds) {
+                client.connect(transport)
+            }
         }
 
         process.destroyForcibly()


### PR DESCRIPTION
- Introduced `withTimeout` to avoid indefinite hangs during test execution (#514)

## Motivation and Context
Workaround for #514 in tests

## How Has This Been Tested?
Integration test updated, CI

## Breaking Changes
No

## Types of changes
- [x] Test fix

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
#514
