### PR TITLE
feat(dsl): add result DSL builders

### DIFF
--- a/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/kotlin/AbstractToolIntegrationTest.kt
+++ b/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/kotlin/AbstractToolIntegrationTest.kt
@@ -1,6 +1,7 @@
 package io.modelcontextprotocol.kotlin.sdk.integration.kotlin
 
 import io.kotest.assertions.json.shouldEqualJson
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolRequest
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolRequestParams
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
@@ -9,6 +10,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.ImageContent
 import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import io.modelcontextprotocol.kotlin.sdk.types.buildCallToolResult
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -28,6 +30,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
+@OptIn(ExperimentalMcpApi::class)
 abstract class AbstractToolIntegrationTest : KotlinTestBase() {
     private val testToolName = "echo"
     private val testToolDescription = "A simple echo tool that returns the input text"
@@ -84,12 +87,12 @@ abstract class AbstractToolIntegrationTest : KotlinTestBase() {
         ) { request ->
             val text = (request.params.arguments?.get("text") as? JsonPrimitive)?.content ?: "No text provided"
 
-            CallToolResult(
-                content = listOf(TextContent(text = "Echo: $text")),
-                structuredContent = buildJsonObject {
+            buildCallToolResult {
+                textContent("Echo: $text")
+                structuredContent {
                     put("result", text)
-                },
-            )
+                }
+            }
         }
     }
 
@@ -112,12 +115,12 @@ abstract class AbstractToolIntegrationTest : KotlinTestBase() {
         ) { request ->
             val text = (request.params.arguments?.get("text") as? JsonPrimitive)?.content ?: "No text provided"
 
-            CallToolResult(
-                content = listOf(TextContent(text = "Echo: $text")),
-                structuredContent = buildJsonObject {
+            buildCallToolResult {
+                textContent("Echo: $text")
+                structuredContent {
                     put("result", text)
-                },
-            )
+                }
+            }
         }
 
         server.addTool(
@@ -164,9 +167,7 @@ abstract class AbstractToolIntegrationTest : KotlinTestBase() {
             val delay = (request.params.arguments?.get("delay") as? JsonPrimitive)?.content?.toIntOrNull() ?: 1000
 
             // simulate slow operation
-            runBlocking {
-                delay(delay.toLong())
-            }
+            delay(delay.toLong())
 
             CallToolResult(
                 content = listOf(TextContent(text = "Completed after ${delay}ms delay")),

--- a/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/typescript/sse/KotlinServerForTsClientSse.kt
+++ b/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/typescript/sse/KotlinServerForTsClientSse.kt
@@ -17,11 +17,11 @@ import io.ktor.server.routing.delete
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
 import io.modelcontextprotocol.kotlin.sdk.server.Server
 import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
 import io.modelcontextprotocol.kotlin.sdk.shared.AbstractTransport
 import io.modelcontextprotocol.kotlin.sdk.shared.TransportSendOptions
-import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.types.GetPromptResult
 import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCError
@@ -40,6 +40,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import io.modelcontextprotocol.kotlin.sdk.types.TextResourceContents
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import io.modelcontextprotocol.kotlin.sdk.types.buildCallToolResult
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.channels.Channel
@@ -59,6 +60,7 @@ import java.util.concurrent.ConcurrentHashMap
 
 private val logger = KotlinLogging.logger {}
 
+@OptIn(ExperimentalMcpApi::class)
 class KotlinServerForTsClient {
     private val serverTransports = ConcurrentHashMap<String, HttpServerTransport>()
     private val jsonFormat = Json { ignoreUnknownKeys = true }
@@ -226,12 +228,12 @@ class KotlinServerForTsClient {
             ),
         ) { request ->
             val name = (request.params.arguments?.get("name") as? JsonPrimitive)?.content ?: "World"
-            CallToolResult(
-                content = listOf(TextContent("Hello, $name!")),
-                structuredContent = buildJsonObject {
+            buildCallToolResult {
+                textContent("Hello, $name!")
+                structuredContent {
                     put("greeting", JsonPrimitive("Hello, $name!"))
-                },
-            )
+                }
+            }
         }
 
         server.addTool(
@@ -252,13 +254,13 @@ class KotlinServerForTsClient {
         ) { request ->
             val name = (request.params.arguments?.get("name") as? JsonPrimitive)?.content ?: "World"
 
-            CallToolResult(
-                content = listOf(TextContent("Multiple greetings sent to $name!")),
-                structuredContent = buildJsonObject {
+            buildCallToolResult {
+                textContent("Multiple greetings sent to $name!")
+                structuredContent {
                     put("greeting", JsonPrimitive("Multiple greetings sent to $name!"))
                     put("notificationCount", JsonPrimitive(3))
-                },
-            )
+                }
+            }
         }
 
         server.addPrompt(

--- a/kotlin-sdk-core/api/kotlin-sdk-core.api
+++ b/kotlin-sdk-core/api/kotlin-sdk-core.api
@@ -848,6 +848,20 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/CallToolResult$Compa
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class io/modelcontextprotocol/kotlin/sdk/types/CallToolResultBuilder : io/modelcontextprotocol/kotlin/sdk/types/ResultBuilder {
+	public fun <init> ()V
+	public final fun audioContent (Ljava/lang/String;Ljava/lang/String;)V
+	public fun build ()Lio/modelcontextprotocol/kotlin/sdk/types/CallToolResult;
+	public synthetic fun build$kotlin_sdk_core ()Lio/modelcontextprotocol/kotlin/sdk/types/RequestResult;
+	public final fun content (Lio/modelcontextprotocol/kotlin/sdk/types/ContentBlock;)V
+	public final fun imageContent (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun isError ()Ljava/lang/Boolean;
+	public final fun setError (Ljava/lang/Boolean;)V
+	public final fun structuredContent (Lkotlin/jvm/functions/Function1;)V
+	public final fun structuredContent (Lkotlinx/serialization/json/JsonObject;)V
+	public final fun textContent (Ljava/lang/String;)V
+}
+
 public final class io/modelcontextprotocol/kotlin/sdk/types/CancelledNotification : io/modelcontextprotocol/kotlin/sdk/types/ClientNotification, io/modelcontextprotocol/kotlin/sdk/types/ServerNotification {
 	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/types/CancelledNotification$Companion;
 	public fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/CancelledNotificationParams;)V
@@ -1228,8 +1242,21 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/CompleteResult$Compl
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class io/modelcontextprotocol/kotlin/sdk/types/CompleteResultBuilder : io/modelcontextprotocol/kotlin/sdk/types/ResultBuilder {
+	public fun <init> ()V
+	public fun build ()Lio/modelcontextprotocol/kotlin/sdk/types/CompleteResult;
+	public synthetic fun build$kotlin_sdk_core ()Lio/modelcontextprotocol/kotlin/sdk/types/RequestResult;
+	public final fun getHasMore ()Ljava/lang/Boolean;
+	public final fun getTotal ()Ljava/lang/Integer;
+	public final fun setHasMore (Ljava/lang/Boolean;)V
+	public final fun setTotal (Ljava/lang/Integer;)V
+	public final fun values (Ljava/util/List;)V
+	public final fun values ([Ljava/lang/String;)V
+}
+
 public final class io/modelcontextprotocol/kotlin/sdk/types/Completion_dslKt {
 	public static final fun buildCompleteRequest (Lkotlin/jvm/functions/Function1;)Lio/modelcontextprotocol/kotlin/sdk/types/CompleteRequest;
+	public static final fun buildCompleteResult (Lkotlin/jvm/functions/Function1;)Lio/modelcontextprotocol/kotlin/sdk/types/CompleteResult;
 }
 
 public abstract interface class io/modelcontextprotocol/kotlin/sdk/types/ContentBlock : io/modelcontextprotocol/kotlin/sdk/types/WithMeta {
@@ -1798,6 +1825,16 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/GetPromptResult$Comp
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class io/modelcontextprotocol/kotlin/sdk/types/GetPromptResultBuilder : io/modelcontextprotocol/kotlin/sdk/types/ResultBuilder {
+	public fun <init> ()V
+	public fun build ()Lio/modelcontextprotocol/kotlin/sdk/types/GetPromptResult;
+	public synthetic fun build$kotlin_sdk_core ()Lio/modelcontextprotocol/kotlin/sdk/types/RequestResult;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun message (Lio/modelcontextprotocol/kotlin/sdk/types/PromptMessage;)V
+	public final fun message (Lio/modelcontextprotocol/kotlin/sdk/types/Role;Lio/modelcontextprotocol/kotlin/sdk/types/ContentBlock;)V
+	public final fun setDescription (Ljava/lang/String;)V
+}
+
 public final class io/modelcontextprotocol/kotlin/sdk/types/Icon {
 	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/types/Icon$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/modelcontextprotocol/kotlin/sdk/types/Icon$Theme;)V
@@ -2057,8 +2094,23 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/InitializeResult$Com
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class io/modelcontextprotocol/kotlin/sdk/types/InitializeResultBuilder : io/modelcontextprotocol/kotlin/sdk/types/ResultBuilder {
+	public fun <init> ()V
+	public fun build ()Lio/modelcontextprotocol/kotlin/sdk/types/InitializeResult;
+	public synthetic fun build$kotlin_sdk_core ()Lio/modelcontextprotocol/kotlin/sdk/types/RequestResult;
+	public final fun capabilities (Lio/modelcontextprotocol/kotlin/sdk/types/ServerCapabilities;)V
+	public final fun getInstructions ()Ljava/lang/String;
+	public final fun getProtocolVersion ()Ljava/lang/String;
+	public final fun info (Lio/modelcontextprotocol/kotlin/sdk/types/Implementation;)V
+	public final fun info (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public static synthetic fun info$default (Lio/modelcontextprotocol/kotlin/sdk/types/InitializeResultBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)V
+	public final fun setInstructions (Ljava/lang/String;)V
+	public final fun setProtocolVersion (Ljava/lang/String;)V
+}
+
 public final class io/modelcontextprotocol/kotlin/sdk/types/Initialize_dslKt {
 	public static final fun buildInitializeRequest (Lkotlin/jvm/functions/Function1;)Lio/modelcontextprotocol/kotlin/sdk/types/InitializeRequest;
+	public static final fun buildInitializeResult (Lkotlin/jvm/functions/Function1;)Lio/modelcontextprotocol/kotlin/sdk/types/InitializeResult;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/types/InitializedNotification : io/modelcontextprotocol/kotlin/sdk/types/ClientNotification {
@@ -2330,6 +2382,14 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/ListPromptsResult$Co
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class io/modelcontextprotocol/kotlin/sdk/types/ListPromptsResultBuilder : io/modelcontextprotocol/kotlin/sdk/types/PaginatedResultBuilder {
+	public fun <init> ()V
+	public fun build ()Lio/modelcontextprotocol/kotlin/sdk/types/ListPromptsResult;
+	public synthetic fun build$kotlin_sdk_core ()Lio/modelcontextprotocol/kotlin/sdk/types/RequestResult;
+	public final fun prompt (Lio/modelcontextprotocol/kotlin/sdk/types/Prompt;)V
+	public final fun prompt (Lkotlin/jvm/functions/Function1;)V
+}
+
 public final class io/modelcontextprotocol/kotlin/sdk/types/ListResourceTemplatesRequest : io/modelcontextprotocol/kotlin/sdk/types/ClientRequest, io/modelcontextprotocol/kotlin/sdk/types/PaginatedRequest {
 	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/types/ListResourceTemplatesRequest$Companion;
 	public fun <init> ()V
@@ -2404,6 +2464,14 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/ListResourceTemplate
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class io/modelcontextprotocol/kotlin/sdk/types/ListResourceTemplatesResultBuilder : io/modelcontextprotocol/kotlin/sdk/types/PaginatedResultBuilder {
+	public fun <init> ()V
+	public fun build ()Lio/modelcontextprotocol/kotlin/sdk/types/ListResourceTemplatesResult;
+	public synthetic fun build$kotlin_sdk_core ()Lio/modelcontextprotocol/kotlin/sdk/types/RequestResult;
+	public final fun template (Lio/modelcontextprotocol/kotlin/sdk/types/ResourceTemplate;)V
+	public final fun template (Lkotlin/jvm/functions/Function1;)V
+}
+
 public final class io/modelcontextprotocol/kotlin/sdk/types/ListResourcesRequest : io/modelcontextprotocol/kotlin/sdk/types/ClientRequest, io/modelcontextprotocol/kotlin/sdk/types/PaginatedRequest {
 	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/types/ListResourcesRequest$Companion;
 	public fun <init> ()V
@@ -2476,6 +2544,14 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/types/ListResour
 
 public final class io/modelcontextprotocol/kotlin/sdk/types/ListResourcesResult$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/modelcontextprotocol/kotlin/sdk/types/ListResourcesResultBuilder : io/modelcontextprotocol/kotlin/sdk/types/PaginatedResultBuilder {
+	public fun <init> ()V
+	public fun build ()Lio/modelcontextprotocol/kotlin/sdk/types/ListResourcesResult;
+	public synthetic fun build$kotlin_sdk_core ()Lio/modelcontextprotocol/kotlin/sdk/types/RequestResult;
+	public final fun resource (Lio/modelcontextprotocol/kotlin/sdk/types/Resource;)V
+	public final fun resource (Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/types/ListRootsRequest : io/modelcontextprotocol/kotlin/sdk/types/ServerRequest {
@@ -2620,6 +2696,14 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/types/ListToolsR
 
 public final class io/modelcontextprotocol/kotlin/sdk/types/ListToolsResult$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/modelcontextprotocol/kotlin/sdk/types/ListToolsResultBuilder : io/modelcontextprotocol/kotlin/sdk/types/PaginatedResultBuilder {
+	public fun <init> ()V
+	public fun build ()Lio/modelcontextprotocol/kotlin/sdk/types/ListToolsResult;
+	public synthetic fun build$kotlin_sdk_core ()Lio/modelcontextprotocol/kotlin/sdk/types/RequestResult;
+	public final fun tool (Lio/modelcontextprotocol/kotlin/sdk/types/Tool;)V
+	public final fun tool (Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/types/LoggingLevel : java/lang/Enum {
@@ -2968,6 +3052,12 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/PaginatedResult$Defa
 	public static fun get_meta (Lio/modelcontextprotocol/kotlin/sdk/types/PaginatedResult;)Lkotlinx/serialization/json/JsonObject;
 }
 
+public abstract class io/modelcontextprotocol/kotlin/sdk/types/PaginatedResultBuilder : io/modelcontextprotocol/kotlin/sdk/types/ResultBuilder {
+	public fun <init> ()V
+	public final fun getNextCursor ()Ljava/lang/String;
+	public final fun setNextCursor (Ljava/lang/String;)V
+}
+
 public final class io/modelcontextprotocol/kotlin/sdk/types/PingRequest : io/modelcontextprotocol/kotlin/sdk/types/ClientRequest, io/modelcontextprotocol/kotlin/sdk/types/ServerRequest {
 	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/types/PingRequest$Companion;
 	public fun <init> ()V
@@ -3173,6 +3263,23 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/PromptArgument$Compa
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class io/modelcontextprotocol/kotlin/sdk/types/PromptBuilder {
+	public fun <init> ()V
+	public final fun build ()Lio/modelcontextprotocol/kotlin/sdk/types/Prompt;
+	public final fun getArguments ()Ljava/util/List;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getIcons ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getTitle ()Ljava/lang/String;
+	public final fun meta (Lkotlin/jvm/functions/Function1;)V
+	public final fun meta (Lkotlinx/serialization/json/JsonObject;)V
+	public final fun setArguments (Ljava/util/List;)V
+	public final fun setDescription (Ljava/lang/String;)V
+	public final fun setIcons (Ljava/util/List;)V
+	public final fun setName (Ljava/lang/String;)V
+	public final fun setTitle (Ljava/lang/String;)V
+}
+
 public final class io/modelcontextprotocol/kotlin/sdk/types/PromptListChangedNotification : io/modelcontextprotocol/kotlin/sdk/types/ServerNotification {
 	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/types/PromptListChangedNotification$Companion;
 	public fun <init> ()V
@@ -3266,7 +3373,9 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/PromptReference$Comp
 
 public final class io/modelcontextprotocol/kotlin/sdk/types/Prompts_dslKt {
 	public static final fun buildGetPromptRequest (Lkotlin/jvm/functions/Function1;)Lio/modelcontextprotocol/kotlin/sdk/types/GetPromptRequest;
+	public static final fun buildGetPromptResult (Lkotlin/jvm/functions/Function1;)Lio/modelcontextprotocol/kotlin/sdk/types/GetPromptResult;
 	public static final fun buildListPromptsRequest (Lkotlin/jvm/functions/Function1;)Lio/modelcontextprotocol/kotlin/sdk/types/ListPromptsRequest;
+	public static final fun buildListPromptsResult (Lkotlin/jvm/functions/Function1;)Lio/modelcontextprotocol/kotlin/sdk/types/ListPromptsResult;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/types/RPCError {
@@ -3412,6 +3521,17 @@ public final synthetic class io/modelcontextprotocol/kotlin/sdk/types/ReadResour
 
 public final class io/modelcontextprotocol/kotlin/sdk/types/ReadResourceResult$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/modelcontextprotocol/kotlin/sdk/types/ReadResourceResultBuilder : io/modelcontextprotocol/kotlin/sdk/types/ResultBuilder {
+	public fun <init> ()V
+	public final fun blobContent (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public static synthetic fun blobContent$default (Lio/modelcontextprotocol/kotlin/sdk/types/ReadResourceResultBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
+	public fun build ()Lio/modelcontextprotocol/kotlin/sdk/types/ReadResourceResult;
+	public synthetic fun build$kotlin_sdk_core ()Lio/modelcontextprotocol/kotlin/sdk/types/RequestResult;
+	public final fun content (Lio/modelcontextprotocol/kotlin/sdk/types/ResourceContents;)V
+	public final fun textContent (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public static synthetic fun textContent$default (Lio/modelcontextprotocol/kotlin/sdk/types/ReadResourceResultBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 }
 
 public abstract interface class io/modelcontextprotocol/kotlin/sdk/types/Reference {
@@ -3633,6 +3753,29 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/Resource$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class io/modelcontextprotocol/kotlin/sdk/types/ResourceBuilder {
+	public fun <init> ()V
+	public final fun build ()Lio/modelcontextprotocol/kotlin/sdk/types/Resource;
+	public final fun getAnnotations ()Lio/modelcontextprotocol/kotlin/sdk/types/Annotations;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getIcons ()Ljava/util/List;
+	public final fun getMimeType ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getSize ()Ljava/lang/Long;
+	public final fun getTitle ()Ljava/lang/String;
+	public final fun getUri ()Ljava/lang/String;
+	public final fun meta (Lkotlin/jvm/functions/Function1;)V
+	public final fun meta (Lkotlinx/serialization/json/JsonObject;)V
+	public final fun setAnnotations (Lio/modelcontextprotocol/kotlin/sdk/types/Annotations;)V
+	public final fun setDescription (Ljava/lang/String;)V
+	public final fun setIcons (Ljava/util/List;)V
+	public final fun setMimeType (Ljava/lang/String;)V
+	public final fun setName (Ljava/lang/String;)V
+	public final fun setSize (Ljava/lang/Long;)V
+	public final fun setTitle (Ljava/lang/String;)V
+	public final fun setUri (Ljava/lang/String;)V
+}
+
 public abstract interface class io/modelcontextprotocol/kotlin/sdk/types/ResourceContents : io/modelcontextprotocol/kotlin/sdk/types/WithMeta {
 	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/types/ResourceContents$Companion;
 	public abstract fun getMimeType ()Ljava/lang/String;
@@ -3779,6 +3922,27 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/ResourceTemplate$Com
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class io/modelcontextprotocol/kotlin/sdk/types/ResourceTemplateBuilder {
+	public fun <init> ()V
+	public final fun build ()Lio/modelcontextprotocol/kotlin/sdk/types/ResourceTemplate;
+	public final fun getAnnotations ()Lio/modelcontextprotocol/kotlin/sdk/types/Annotations;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getIcons ()Ljava/util/List;
+	public final fun getMimeType ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getTitle ()Ljava/lang/String;
+	public final fun getUriTemplate ()Ljava/lang/String;
+	public final fun meta (Lkotlin/jvm/functions/Function1;)V
+	public final fun meta (Lkotlinx/serialization/json/JsonObject;)V
+	public final fun setAnnotations (Lio/modelcontextprotocol/kotlin/sdk/types/Annotations;)V
+	public final fun setDescription (Ljava/lang/String;)V
+	public final fun setIcons (Ljava/util/List;)V
+	public final fun setMimeType (Ljava/lang/String;)V
+	public final fun setName (Ljava/lang/String;)V
+	public final fun setTitle (Ljava/lang/String;)V
+	public final fun setUriTemplate (Ljava/lang/String;)V
+}
+
 public final class io/modelcontextprotocol/kotlin/sdk/types/ResourceTemplateReference : io/modelcontextprotocol/kotlin/sdk/types/Reference {
 	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/types/ResourceTemplateReference$Companion;
 	public fun <init> (Ljava/lang/String;)V
@@ -3869,10 +4033,21 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/ResourceUpdatedNotif
 
 public final class io/modelcontextprotocol/kotlin/sdk/types/Resources_dslKt {
 	public static final fun buildListResourceTemplatesRequest (Lkotlin/jvm/functions/Function1;)Lio/modelcontextprotocol/kotlin/sdk/types/ListResourceTemplatesRequest;
+	public static final fun buildListResourceTemplatesResult (Lkotlin/jvm/functions/Function1;)Lio/modelcontextprotocol/kotlin/sdk/types/ListResourceTemplatesResult;
 	public static final fun buildListResourcesRequest (Lkotlin/jvm/functions/Function1;)Lio/modelcontextprotocol/kotlin/sdk/types/ListResourcesRequest;
+	public static final fun buildListResourcesResult (Lkotlin/jvm/functions/Function1;)Lio/modelcontextprotocol/kotlin/sdk/types/ListResourcesResult;
 	public static final fun buildReadResourceRequest (Lkotlin/jvm/functions/Function1;)Lio/modelcontextprotocol/kotlin/sdk/types/ReadResourceRequest;
+	public static final fun buildReadResourceResult (Lkotlin/jvm/functions/Function1;)Lio/modelcontextprotocol/kotlin/sdk/types/ReadResourceResult;
 	public static final fun buildSubscribeRequest (Lkotlin/jvm/functions/Function1;)Lio/modelcontextprotocol/kotlin/sdk/types/SubscribeRequest;
 	public static final fun buildUnsubscribeRequest (Lkotlin/jvm/functions/Function1;)Lio/modelcontextprotocol/kotlin/sdk/types/UnsubscribeRequest;
+}
+
+public abstract class io/modelcontextprotocol/kotlin/sdk/types/ResultBuilder {
+	public fun <init> ()V
+	protected final fun getMeta ()Lkotlinx/serialization/json/JsonObject;
+	public final fun meta (Lkotlin/jvm/functions/Function1;)V
+	public final fun meta (Lkotlinx/serialization/json/JsonObject;)V
+	protected final fun setMeta (Lkotlinx/serialization/json/JsonObject;)V
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/types/Role : java/lang/Enum {
@@ -4491,6 +4666,27 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/ToolAnnotations$Comp
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class io/modelcontextprotocol/kotlin/sdk/types/ToolBuilder {
+	public fun <init> ()V
+	public final fun build ()Lio/modelcontextprotocol/kotlin/sdk/types/Tool;
+	public final fun getAnnotations ()Lio/modelcontextprotocol/kotlin/sdk/types/ToolAnnotations;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getIcons ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getTitle ()Ljava/lang/String;
+	public final fun inputSchema (Lio/modelcontextprotocol/kotlin/sdk/types/ToolSchema;)V
+	public final fun inputSchema (Lkotlin/jvm/functions/Function1;)V
+	public final fun meta (Lkotlin/jvm/functions/Function1;)V
+	public final fun meta (Lkotlinx/serialization/json/JsonObject;)V
+	public final fun outputSchema (Lio/modelcontextprotocol/kotlin/sdk/types/ToolSchema;)V
+	public final fun outputSchema (Lkotlin/jvm/functions/Function1;)V
+	public final fun setAnnotations (Lio/modelcontextprotocol/kotlin/sdk/types/ToolAnnotations;)V
+	public final fun setDescription (Ljava/lang/String;)V
+	public final fun setIcons (Ljava/util/List;)V
+	public final fun setName (Ljava/lang/String;)V
+	public final fun setTitle (Ljava/lang/String;)V
+}
+
 public final class io/modelcontextprotocol/kotlin/sdk/types/ToolListChangedNotification : io/modelcontextprotocol/kotlin/sdk/types/ServerNotification {
 	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/types/ToolListChangedNotification$Companion;
 	public fun <init> ()V
@@ -4556,6 +4752,17 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/ToolSchema$Companion
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class io/modelcontextprotocol/kotlin/sdk/types/ToolSchemaBuilder {
+	public fun <init> ()V
+	public final fun build ()Lio/modelcontextprotocol/kotlin/sdk/types/ToolSchema;
+	public final fun getDefs ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getProperties ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getRequired ()Ljava/util/List;
+	public final fun setDefs (Lkotlinx/serialization/json/JsonObject;)V
+	public final fun setProperties (Lkotlinx/serialization/json/JsonObject;)V
+	public final fun setRequired (Ljava/util/List;)V
+}
+
 public final class io/modelcontextprotocol/kotlin/sdk/types/ToolsKt {
 	public static final fun error (Lio/modelcontextprotocol/kotlin/sdk/types/CallToolResult$Companion;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/CallToolResult;
 	public static synthetic fun error$default (Lio/modelcontextprotocol/kotlin/sdk/types/CallToolResult$Companion;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/CallToolResult;
@@ -4565,7 +4772,9 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/ToolsKt {
 
 public final class io/modelcontextprotocol/kotlin/sdk/types/Tools_dslKt {
 	public static final fun buildCallToolRequest (Lkotlin/jvm/functions/Function1;)Lio/modelcontextprotocol/kotlin/sdk/types/CallToolRequest;
+	public static final fun buildCallToolResult (Lkotlin/jvm/functions/Function1;)Lio/modelcontextprotocol/kotlin/sdk/types/CallToolResult;
 	public static final fun buildListToolsRequest (Lkotlin/jvm/functions/Function1;)Lio/modelcontextprotocol/kotlin/sdk/types/ListToolsRequest;
+	public static final fun buildListToolsResult (Lkotlin/jvm/functions/Function1;)Lio/modelcontextprotocol/kotlin/sdk/types/ListToolsResult;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/types/UnknownResourceContents : io/modelcontextprotocol/kotlin/sdk/types/ResourceContents {

--- a/kotlin-sdk-core/api/kotlin-sdk-core.api
+++ b/kotlin-sdk-core/api/kotlin-sdk-core.api
@@ -3675,6 +3675,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/RequestMeta$Companio
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/types/RequestMetaBuilder {
+	public fun <init> ()V
 	public final fun progressToken (I)V
 	public final fun progressToken (J)V
 	public final fun progressToken (Ljava/lang/String;)V

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/content.dsl.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/content.dsl.kt
@@ -21,7 +21,7 @@ import kotlinx.serialization.json.buildJsonObject
  * @see AudioContentBuilder
  */
 @McpDsl
-public abstract class MediaContentBuilder {
+public abstract class MediaContentBuilder @PublishedApi internal constructor() {
     protected var annotations: Annotations? = null
     protected var meta: JsonObject? = null
 

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/prompts.dsl.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/prompts.dsl.kt
@@ -155,7 +155,7 @@ public class ListPromptsRequestBuilder @PublishedApi internal constructor() : Pa
  * Creates a [GetPromptResult] using a type-safe DSL builder.
  *
  * ## Required
- * - [messages][GetPromptResultBuilder.messages] - List of prompt messages (at least one)
+ * - [messages][GetPromptResultBuilder.messagesList] - List of prompt messages (at least one)
  *
  * ## Optional
  * - [description][GetPromptResultBuilder.description] - Description of the prompt
@@ -260,7 +260,7 @@ public class GetPromptResultBuilder @PublishedApi internal constructor() : Resul
  * Creates a [ListPromptsResult] using a type-safe DSL builder.
  *
  * ## Required
- * - [prompts][ListPromptsResultBuilder.prompts] - List of available prompts (at least one)
+ * - [prompts][ListPromptsResultBuilder.promptsList] - List of available prompts (at least one)
  *
  * ## Optional
  * - [nextCursor][ListPromptsResultBuilder.nextCursor] - Pagination cursor for next page

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/request.dsl.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/request.dsl.kt
@@ -21,7 +21,7 @@ import kotlinx.serialization.json.buildJsonObject
  * @see PaginatedRequestBuilder
  */
 @McpDsl
-public abstract class RequestBuilder {
+public abstract class RequestBuilder @PublishedApi internal constructor() {
     protected var meta: RequestMeta? = null
 
     /**
@@ -73,7 +73,7 @@ public abstract class RequestBuilder {
  * @see RequestBuilder.meta
  */
 @McpDsl
-public class RequestMetaBuilder internal constructor() {
+public class RequestMetaBuilder @PublishedApi internal constructor() {
     private val content: MutableMap<String, JsonElement> = linkedMapOf()
 
     /**
@@ -196,7 +196,7 @@ public class RequestMetaBuilder internal constructor() {
  * @see RequestBuilder
  */
 @McpDsl
-public abstract class PaginatedRequestBuilder : RequestBuilder() {
+public abstract class PaginatedRequestBuilder @PublishedApi internal constructor() : RequestBuilder() {
     /**
      * Optional pagination cursor for fetching the next page of results.
      *

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/resources.dsl.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/resources.dsl.kt
@@ -1,6 +1,9 @@
 package io.modelcontextprotocol.kotlin.sdk.types
 
 import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonObjectBuilder
+import kotlinx.serialization.json.buildJsonObject
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
@@ -298,5 +301,225 @@ public class ListResourceTemplatesRequestBuilder @PublishedApi internal construc
     override fun build(): ListResourceTemplatesRequest {
         val params = paginatedRequestParams(cursor = cursor, meta = meta)
         return ListResourceTemplatesRequest(params)
+    }
+}
+
+// ============================================================================
+// Result Builders (Server-side)
+// ============================================================================
+
+/**
+ * Creates a [ListResourcesResult] using a type-safe DSL builder.
+ *
+ * Example:
+ * ```kotlin
+ * val result = buildListResourcesResult {
+ *     resource {
+ *         uri = "file:///path/to/file.txt"
+ *         name = "file.txt"
+ *         description = "A text file"
+ *         mimeType = "text/plain"
+ *     }
+ * }
+ * ```
+ */
+@OptIn(ExperimentalContracts::class)
+@ExperimentalMcpApi
+public inline fun buildListResourcesResult(block: ListResourcesResultBuilder.() -> Unit): ListResourcesResult {
+    contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
+    return ListResourcesResultBuilder().apply(block).build()
+}
+
+/**
+ * DSL builder for constructing [ListResourcesResult] instances.
+ */
+@McpDsl
+public class ListResourcesResultBuilder @PublishedApi internal constructor() : PaginatedResultBuilder() {
+    private val resourcesList: MutableList<Resource> = mutableListOf()
+
+    public fun resource(resource: Resource) {
+        resourcesList.add(resource)
+    }
+
+    public fun resource(block: ResourceBuilder.() -> Unit) {
+        resourcesList.add(ResourceBuilder().apply(block).build())
+    }
+
+    @PublishedApi
+    override fun build(): ListResourcesResult {
+        require(resourcesList.isNotEmpty()) {
+            "At least one resource is required. Use resource() or resource { } to add resources."
+        }
+
+        return ListResourcesResult(
+            resources = resourcesList.toList(),
+            nextCursor = nextCursor,
+            meta = meta,
+        )
+    }
+}
+
+/**
+ * DSL builder for constructing [Resource] instances.
+ */
+@McpDsl
+public class ResourceBuilder @PublishedApi internal constructor() {
+    public var uri: String? = null
+    public var name: String? = null
+    public var description: String? = null
+    public var mimeType: String? = null
+    public var size: Long? = null
+    public var title: String? = null
+    public var annotations: Annotations? = null
+    public var icons: List<Icon>? = null
+    private var metaValue: JsonObject? = null
+
+    public fun meta(meta: JsonObject) {
+        this.metaValue = meta
+    }
+
+    public fun meta(block: JsonObjectBuilder.() -> Unit) {
+        meta(buildJsonObject(block))
+    }
+
+    @PublishedApi
+    internal fun build(): Resource {
+        val uri = requireNotNull(uri) { "Missing required field 'uri'" }
+        val name = requireNotNull(name) { "Missing required field 'name'" }
+
+        return Resource(
+            uri = uri,
+            name = name,
+            description = description,
+            mimeType = mimeType,
+            size = size,
+            title = title,
+            annotations = annotations,
+            icons = icons,
+            meta = metaValue,
+        )
+    }
+}
+
+/**
+ * Creates a [ReadResourceResult] using a type-safe DSL builder.
+ */
+@OptIn(ExperimentalContracts::class)
+@ExperimentalMcpApi
+public inline fun buildReadResourceResult(block: ReadResourceResultBuilder.() -> Unit): ReadResourceResult {
+    contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
+    return ReadResourceResultBuilder().apply(block).build()
+}
+
+/**
+ * DSL builder for constructing [ReadResourceResult] instances.
+ */
+@McpDsl
+public class ReadResourceResultBuilder @PublishedApi internal constructor() : ResultBuilder() {
+    private val contentsList: MutableList<ResourceContents> = mutableListOf()
+
+    public fun textContent(uri: String, text: String, mimeType: String? = null) {
+        contentsList.add(TextResourceContents(text = text, uri = uri, mimeType = mimeType))
+    }
+
+    public fun blobContent(uri: String, blob: String, mimeType: String? = null) {
+        contentsList.add(BlobResourceContents(blob = blob, uri = uri, mimeType = mimeType))
+    }
+
+    public fun content(content: ResourceContents) {
+        contentsList.add(content)
+    }
+
+    @PublishedApi
+    override fun build(): ReadResourceResult {
+        require(contentsList.isNotEmpty()) {
+            "At least one content block is required. Use textContent(), blobContent(), or content()."
+        }
+
+        return ReadResourceResult(
+            contents = contentsList.toList(),
+            meta = meta,
+        )
+    }
+}
+
+/**
+ * Creates a [ListResourceTemplatesResult] using a type-safe DSL builder.
+ */
+@OptIn(ExperimentalContracts::class)
+@ExperimentalMcpApi
+public inline fun buildListResourceTemplatesResult(
+    block: ListResourceTemplatesResultBuilder.() -> Unit,
+): ListResourceTemplatesResult {
+    contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
+    return ListResourceTemplatesResultBuilder().apply(block).build()
+}
+
+/**
+ * DSL builder for constructing [ListResourceTemplatesResult] instances.
+ */
+@McpDsl
+public class ListResourceTemplatesResultBuilder @PublishedApi internal constructor() : PaginatedResultBuilder() {
+    private val templatesList: MutableList<ResourceTemplate> = mutableListOf()
+
+    public fun template(template: ResourceTemplate) {
+        templatesList.add(template)
+    }
+
+    public fun template(block: ResourceTemplateBuilder.() -> Unit) {
+        templatesList.add(ResourceTemplateBuilder().apply(block).build())
+    }
+
+    @PublishedApi
+    override fun build(): ListResourceTemplatesResult {
+        require(templatesList.isNotEmpty()) {
+            "At least one template is required. Use template() or template { } to add templates."
+        }
+
+        return ListResourceTemplatesResult(
+            resourceTemplates = templatesList.toList(),
+            nextCursor = nextCursor,
+            meta = meta,
+        )
+    }
+}
+
+/**
+ * DSL builder for constructing [ResourceTemplate] instances.
+ */
+@McpDsl
+public class ResourceTemplateBuilder @PublishedApi internal constructor() {
+    public var uriTemplate: String? = null
+    public var name: String? = null
+    public var description: String? = null
+    public var mimeType: String? = null
+    public var title: String? = null
+    public var annotations: Annotations? = null
+    public var icons: List<Icon>? = null
+    private var metaValue: JsonObject? = null
+
+    public fun meta(meta: JsonObject) {
+        this.metaValue = meta
+    }
+
+    public fun meta(block: JsonObjectBuilder.() -> Unit) {
+        meta(buildJsonObject(block))
+    }
+
+    @PublishedApi
+    internal fun build(): ResourceTemplate {
+        val uriTemplate = requireNotNull(uriTemplate) { "Missing required field 'uriTemplate'" }
+        val name = requireNotNull(name) { "Missing required field 'name'" }
+
+        return ResourceTemplate(
+            uriTemplate = uriTemplate,
+            name = name,
+            description = description,
+            mimeType = mimeType,
+            title = title,
+            annotations = annotations,
+            icons = icons,
+            meta = metaValue,
+        )
     }
 }

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/result.dsl.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/result.dsl.kt
@@ -22,13 +22,18 @@ public abstract class ResultBuilder {
     /**
      * Sets result metadata directly from a JsonObject.
      *
+     * **Note:** Prefer using the DSL lambda variant [meta] for more idiomatic Kotlin code.
+     * This overload is provided for cases where you already have a constructed JsonObject.
+     *
      * Example:
      * ```kotlin
-     * meta(buildJsonObject {
+     * val existingMeta = buildJsonObject {
      *     put("source", "server")
-     *     put("timestamp", System.currentTimeMillis())
-     * })
+     * }
+     * meta(existingMeta)
      * ```
+     *
+     * @see meta
      */
     public fun meta(meta: JsonObject) {
         this.meta = meta
@@ -37,10 +42,13 @@ public abstract class ResultBuilder {
     /**
      * Sets result metadata using a DSL builder.
      *
+     * **This is the preferred way to set metadata.** The DSL syntax is more idiomatic
+     * and integrates better with Kotlin's type-safe builders.
+     *
      * Metadata can include custom fields for tracking responses and providing
      * additional context to clients.
      *
-     * Example:
+     * Example (preferred):
      * ```kotlin
      * listToolsResult {
      *     tools { /* ... */ }
@@ -76,6 +84,10 @@ public abstract class PaginatedResultBuilder : ResultBuilder() {
      *
      * If present, indicates there may be more results available.
      * Clients can pass this cursor in a subsequent paginated request.
+     *
+     * **Design note:** This field is nullable to distinguish between "no next page" (`null`)
+     * and "next page exists" (non-null string). When `null`, the field is omitted from the
+     * serialized JSON, keeping the protocol efficient.
      *
      * Example: `nextCursor = "eyJwYWdlIjogMn0="`
      */

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/result.dsl.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/result.dsl.kt
@@ -1,0 +1,83 @@
+package io.modelcontextprotocol.kotlin.sdk.types
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonObjectBuilder
+import kotlinx.serialization.json.buildJsonObject
+
+/**
+ * Base DSL builder for constructing MCP result instances.
+ *
+ * This abstract class provides common functionality for all result builders,
+ * including optional metadata support.
+ *
+ * All concrete result builder classes extend this base to inherit [meta] functionality.
+ *
+ * @see RequestResult
+ * @see ServerResult
+ */
+@McpDsl
+public abstract class ResultBuilder {
+    protected var meta: JsonObject? = null
+
+    /**
+     * Sets result metadata directly from a JsonObject.
+     *
+     * Example:
+     * ```kotlin
+     * meta(buildJsonObject {
+     *     put("source", "server")
+     *     put("timestamp", System.currentTimeMillis())
+     * })
+     * ```
+     */
+    public fun meta(meta: JsonObject) {
+        this.meta = meta
+    }
+
+    /**
+     * Sets result metadata using a DSL builder.
+     *
+     * Metadata can include custom fields for tracking responses and providing
+     * additional context to clients.
+     *
+     * Example:
+     * ```kotlin
+     * listToolsResult {
+     *     tools { /* ... */ }
+     *     meta {
+     *         put("serverVersion", "1.0.0")
+     *         put("cached", true)
+     *         put("generatedAt", System.currentTimeMillis())
+     *     }
+     * }
+     * ```
+     *
+     * @param builderAction Lambda for building result metadata
+     */
+    public fun meta(builderAction: JsonObjectBuilder.() -> Unit) {
+        meta = buildJsonObject(builderAction)
+    }
+
+    internal abstract fun build(): RequestResult
+}
+
+/**
+ * Base DSL builder for constructing paginated result instances.
+ *
+ * Extends [ResultBuilder] to add pagination support via [nextCursor].
+ *
+ * @see ResultBuilder
+ * @see PaginatedResult
+ */
+@McpDsl
+public abstract class PaginatedResultBuilder : ResultBuilder() {
+    /**
+     * Optional pagination cursor for fetching the next page of results.
+     *
+     * If present, indicates there may be more results available.
+     * Clients can pass this cursor in a subsequent paginated request.
+     *
+     * Example: `nextCursor = "eyJwYWdlIjogMn0="`
+     */
+    public var nextCursor: String? = null
+}

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/result.dsl.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/result.dsl.kt
@@ -16,7 +16,7 @@ import kotlinx.serialization.json.buildJsonObject
  * @see ServerResult
  */
 @McpDsl
-public abstract class ResultBuilder {
+public abstract class ResultBuilder @PublishedApi internal constructor() {
     protected var meta: JsonObject? = null
 
     /**
@@ -78,7 +78,7 @@ public abstract class ResultBuilder {
  * @see PaginatedResult
  */
 @McpDsl
-public abstract class PaginatedResultBuilder : ResultBuilder() {
+public abstract class PaginatedResultBuilder @PublishedApi internal constructor() : ResultBuilder() {
     /**
      * Optional pagination cursor for fetching the next page of results.
      *

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/sampling.dsl.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/sampling.dsl.kt
@@ -262,7 +262,7 @@ public class SamplingMessageBuilder @PublishedApi internal constructor() {
     }
 
     @PublishedApi
-    internal fun build(): List<SamplingMessage> = messages
+    internal fun build(): List<SamplingMessage> = messages.toList() // Defensive copy
 }
 
 /**

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/tools.dsl.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/tools.dsl.kt
@@ -170,3 +170,618 @@ public class ListToolsRequestBuilder @PublishedApi internal constructor() : Pagi
         return ListToolsRequest(params)
     }
 }
+
+// ============================================================================
+// Result Builders (Server-side)
+// ============================================================================
+
+/**
+ * Creates a [CallToolResult] using a type-safe DSL builder.
+ *
+ * ## Required
+ * - [content][CallToolResultBuilder.content] - List of content blocks (at least one)
+ *
+ * ## Optional
+ * - [isError][CallToolResultBuilder.isError] - Whether the tool call resulted in an error
+ * - [structuredContent][CallToolResultBuilder.structuredContent] - Machine-readable structured output
+ * - [meta][CallToolResultBuilder.meta] - Metadata for the response
+ *
+ * Example success response:
+ * ```kotlin
+ * val result = buildCallToolResult {
+ *     textContent("Operation completed successfully")
+ * }
+ * ```
+ *
+ * Example error response:
+ * ```kotlin
+ * val result = buildCallToolResult {
+ *     textContent("Failed to connect to database")
+ *     isError = true
+ * }
+ * ```
+ *
+ * Example with structured content:
+ * ```kotlin
+ * val result = buildCallToolResult {
+ *     textContent("Query returned 3 results")
+ *     structuredContent {
+ *         put("count", 3)
+ *         putJsonArray("results") {
+ *             add("result1")
+ *             add("result2")
+ *             add("result3")
+ *         }
+ *     }
+ * }
+ * ```
+ *
+ * @param block Configuration lambda for setting up the call tool result
+ * @return A configured [CallToolResult] instance
+ * @see CallToolResultBuilder
+ * @see CallToolResult
+ */
+@OptIn(ExperimentalContracts::class)
+@ExperimentalMcpApi
+public inline fun buildCallToolResult(block: CallToolResultBuilder.() -> Unit): CallToolResult {
+    contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
+    return CallToolResultBuilder().apply(block).build()
+}
+
+/**
+ * DSL builder for constructing [CallToolResult] instances.
+ *
+ * This builder creates the server's response to a tool call, including the result content
+ * and optional error status.
+ *
+ * ## Required
+ * - At least one content block (via [textContent], [imageContent], [audioContent], or [content])
+ *
+ * ## Optional
+ * - [isError] - Whether the tool call resulted in an error
+ * - [structuredContent] - Machine-readable structured output
+ * - [meta] - Metadata for the response
+ *
+ * @see buildCallToolResult
+ * @see CallToolResult
+ */
+@McpDsl
+public class CallToolResultBuilder @PublishedApi internal constructor() : ResultBuilder() {
+    private val contentList: MutableList<ContentBlock> = mutableListOf()
+
+    /**
+     * Whether the tool call resulted in an error.
+     *
+     * When true, the content should describe the error that occurred.
+     * If not set, this is assumed to be false (success).
+     *
+     * Example: `isError = true`
+     */
+    public var isError: Boolean? = null
+
+    private var structuredContentValue: JsonObject? = null
+
+    /**
+     * Adds a text content block to the result.
+     *
+     * This is the most common content type for tool results.
+     *
+     * Example:
+     * ```kotlin
+     * textContent("Operation completed successfully")
+     * ```
+     *
+     * @param text The text content
+     */
+    public fun textContent(text: String) {
+        contentList.add(TextContent(text = text))
+    }
+
+    /**
+     * Adds an image content block to the result.
+     *
+     * Example:
+     * ```kotlin
+     * imageContent(
+     *     data = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ...",
+     *     mimeType = "image/png"
+     * )
+     * ```
+     *
+     * @param data Base64-encoded image data
+     * @param mimeType The MIME type of the image (e.g., "image/png", "image/jpeg")
+     */
+    public fun imageContent(data: String, mimeType: String) {
+        contentList.add(ImageContent(data = data, mimeType = mimeType))
+    }
+
+    /**
+     * Adds an audio content block to the result.
+     *
+     * Example:
+     * ```kotlin
+     * audioContent(
+     *     data = "UklGRiQAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgA...",
+     *     mimeType = "audio/wav"
+     * )
+     * ```
+     *
+     * @param data Base64-encoded audio data
+     * @param mimeType The MIME type of the audio (e.g., "audio/wav", "audio/mp3")
+     */
+    public fun audioContent(data: String, mimeType: String) {
+        contentList.add(AudioContent(data = data, mimeType = mimeType))
+    }
+
+    /**
+     * Adds a pre-built content block to the result.
+     *
+     * Use this when you have already constructed a content block.
+     *
+     * Example:
+     * ```kotlin
+     * val block = TextContent("Prebuilt content")
+     * content(block)
+     * ```
+     *
+     * @param block The content block to add
+     */
+    public fun content(block: ContentBlock) {
+        contentList.add(block)
+    }
+
+    /**
+     * Sets structured content directly from a JsonObject.
+     *
+     * Example:
+     * ```kotlin
+     * structuredContent(buildJsonObject {
+     *     put("status", "success")
+     *     put("recordsAffected", 5)
+     * })
+     * ```
+     *
+     * @param content The structured content as a JsonObject
+     */
+    public fun structuredContent(content: JsonObject) {
+        this.structuredContentValue = content
+    }
+
+    /**
+     * Sets structured content using a DSL builder.
+     *
+     * Provides machine-readable output in addition to the human-readable content.
+     *
+     * Example:
+     * ```kotlin
+     * structuredContent {
+     *     put("status", "success")
+     *     put("count", 42)
+     *     putJsonArray("items") {
+     *         add("item1")
+     *         add("item2")
+     *     }
+     * }
+     * ```
+     *
+     * @param block Lambda for building the structured content JsonObject
+     */
+    public fun structuredContent(block: JsonObjectBuilder.() -> Unit) {
+        structuredContent(buildJsonObject(block))
+    }
+
+    @PublishedApi
+    override fun build(): CallToolResult {
+        require(contentList.isNotEmpty()) {
+            "At least one content block is required. Use textContent(), imageContent(), or audioContent()."
+        }
+
+        return CallToolResult(
+            content = contentList.toList(),
+            isError = isError,
+            structuredContent = structuredContentValue,
+            meta = meta,
+        )
+    }
+}
+
+/**
+ * Creates a [ListToolsResult] using a type-safe DSL builder.
+ *
+ * ## Required
+ * - [tools][ListToolsResultBuilder.toolsList] - List of available tools (at least one)
+ *
+ * ## Optional
+ * - [nextCursor][ListToolsResultBuilder.nextCursor] - Pagination cursor for next page
+ * - [meta][ListToolsResultBuilder.meta] - Metadata for the response
+ *
+ * Example with single tool:
+ * ```kotlin
+ * val result = buildListToolsResult {
+ *     tool {
+ *         name = "searchDatabase"
+ *         description = "Search the database for records"
+ *         inputSchema {
+ *             put("type", "object")
+ *             putJsonObject("properties") {
+ *                 putJsonObject("query") {
+ *                     put("type", "string")
+ *                     put("description", "Search query")
+ *                 }
+ *             }
+ *             putJsonArray("required") {
+ *                 add("query")
+ *             }
+ *         }
+ *     }
+ * }
+ * ```
+ *
+ * Example with pagination:
+ * ```kotlin
+ * val result = buildListToolsResult {
+ *     tool(Tool("tool1", ToolSchema()))
+ *     tool(Tool("tool2", ToolSchema()))
+ *     nextCursor = "eyJwYWdlIjogMn0="
+ * }
+ * ```
+ *
+ * @param block Configuration lambda for setting up the list tools result
+ * @return A configured [ListToolsResult] instance
+ * @see ListToolsResultBuilder
+ * @see ListToolsResult
+ */
+@OptIn(ExperimentalContracts::class)
+@ExperimentalMcpApi
+public inline fun buildListToolsResult(block: ListToolsResultBuilder.() -> Unit): ListToolsResult {
+    contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
+    return ListToolsResultBuilder().apply(block).build()
+}
+
+/**
+ * DSL builder for constructing [ListToolsResult] instances.
+ *
+ * This builder creates a response containing a list of tools available on the server,
+ * with optional pagination support.
+ *
+ * ## Required
+ * - At least one tool (via [tool] method)
+ *
+ * ## Optional
+ * - [nextCursor] - Pagination cursor (inherited from [PaginatedResultBuilder])
+ * - [meta] - Metadata for the response (inherited from [ResultBuilder])
+ *
+ * @see buildListToolsResult
+ * @see ListToolsResult
+ * @see PaginatedResultBuilder
+ */
+@McpDsl
+public class ListToolsResultBuilder @PublishedApi internal constructor() : PaginatedResultBuilder() {
+    private val toolsList: MutableList<Tool> = mutableListOf()
+
+    /**
+     * Adds a pre-built tool to the result.
+     *
+     * Use this when you have already constructed a Tool instance.
+     *
+     * Example:
+     * ```kotlin
+     * val myTool = Tool(
+     *     name = "calculate",
+     *     inputSchema = ToolSchema(/* ... */),
+     *     description = "Performs calculations"
+     * )
+     * tool(myTool)
+     * ```
+     *
+     * @param tool The tool to add
+     */
+    public fun tool(tool: Tool) {
+        toolsList.add(tool)
+    }
+
+    /**
+     * Adds a tool using a DSL builder.
+     *
+     * This is the recommended way to define tools inline.
+     *
+     * Example:
+     * ```kotlin
+     * tool {
+     *     name = "getCurrentTime"
+     *     description = "Get the current time"
+     *     inputSchema {
+     *         // Schema definition
+     *     }
+     * }
+     * ```
+     *
+     * @param block Lambda for building the Tool
+     */
+    public fun tool(block: ToolBuilder.() -> Unit) {
+        toolsList.add(ToolBuilder().apply(block).build())
+    }
+
+    @PublishedApi
+    override fun build(): ListToolsResult {
+        require(toolsList.isNotEmpty()) {
+            "At least one tool is required. Use tool() or tool { } to add tools."
+        }
+
+        return ListToolsResult(
+            tools = toolsList.toList(),
+            nextCursor = nextCursor,
+            meta = meta,
+        )
+    }
+}
+
+/**
+ * DSL builder for constructing [Tool] instances.
+ *
+ * Used within [ListToolsResultBuilder] to define individual tools.
+ *
+ * ## Required
+ * - [name] - The programmatic identifier for the tool
+ * - [inputSchema] - JSON Schema defining the tool's input parameters
+ *
+ * ## Optional
+ * - [description] - Human-readable description
+ * - [outputSchema] - JSON Schema defining the tool's output structure
+ * - [title] - Display name for the tool
+ * - [annotations] - Additional hints about tool behavior
+ * - [icons] - Icon representations for UIs
+ * - [meta] - Metadata for the tool
+ *
+ * @see Tool
+ * @see ListToolsResultBuilder
+ */
+@McpDsl
+public class ToolBuilder @PublishedApi internal constructor() {
+    /**
+     * The programmatic identifier for this tool. Required.
+     *
+     * Example: `name = "searchDatabase"`
+     */
+    public var name: String? = null
+
+    /**
+     * Human-readable description of what the tool does.
+     *
+     * Example: `description = "Search the database for records matching a query"`
+     */
+    public var description: String? = null
+
+    private var inputSchemaValue: ToolSchema? = null
+
+    private var outputSchemaValue: ToolSchema? = null
+
+    /**
+     * Optional display name for the tool.
+     *
+     * Example: `title = "Database Search"`
+     */
+    public var title: String? = null
+
+    /**
+     * Optional annotations providing hints about tool behavior.
+     *
+     * Example:
+     * ```kotlin
+     * annotations = ToolAnnotations(
+     *     readOnlyHint = true,
+     *     idempotentHint = true
+     * )
+     * ```
+     */
+    public var annotations: ToolAnnotations? = null
+
+    /**
+     * Optional list of icons for the tool.
+     *
+     * Example:
+     * ```kotlin
+     * icons = listOf(
+     *     Icon(url = "https://example.com/icon.png", size = "32x32", mimeType = "image/png")
+     * )
+     * ```
+     */
+    public var icons: List<Icon>? = null
+
+    private var metaValue: JsonObject? = null
+
+    /**
+     * Sets input schema directly from a ToolSchema.
+     *
+     * Example:
+     * ```kotlin
+     * inputSchema(ToolSchema(
+     *     properties = buildJsonObject { /* ... */ },
+     *     required = listOf("query")
+     * ))
+     * ```
+     *
+     * @param schema The input schema
+     */
+    public fun inputSchema(schema: ToolSchema) {
+        this.inputSchemaValue = schema
+    }
+
+    /**
+     * Sets input schema using a DSL builder.
+     *
+     * Example:
+     * ```kotlin
+     * inputSchema {
+     *     properties = buildJsonObject {
+     *         putJsonObject("query") {
+     *             put("type", "string")
+     *             put("description", "Search query")
+     *         }
+     *         putJsonObject("limit") {
+     *             put("type", "integer")
+     *             put("default", 10)
+     *         }
+     *     }
+     *     required = listOf("query")
+     * }
+     * ```
+     *
+     * @param block Lambda for building the ToolSchema
+     */
+    public fun inputSchema(block: ToolSchemaBuilder.() -> Unit) {
+        inputSchema(ToolSchemaBuilder().apply(block).build())
+    }
+
+    /**
+     * Sets output schema directly from a ToolSchema.
+     *
+     * Example:
+     * ```kotlin
+     * outputSchema(ToolSchema(
+     *     properties = buildJsonObject { /* ... */ }
+     * ))
+     * ```
+     *
+     * @param schema The output schema
+     */
+    public fun outputSchema(schema: ToolSchema) {
+        this.outputSchemaValue = schema
+    }
+
+    /**
+     * Sets output schema using a DSL builder.
+     *
+     * Example:
+     * ```kotlin
+     * outputSchema {
+     *     properties = buildJsonObject {
+     *         putJsonObject("results") {
+     *             put("type", "array")
+     *         }
+     *         putJsonObject("count") {
+     *             put("type", "integer")
+     *         }
+     *     }
+     * }
+     * ```
+     *
+     * @param block Lambda for building the ToolSchema
+     */
+    public fun outputSchema(block: ToolSchemaBuilder.() -> Unit) {
+        outputSchema(ToolSchemaBuilder().apply(block).build())
+    }
+
+    /**
+     * Sets metadata directly from a JsonObject.
+     *
+     * Example:
+     * ```kotlin
+     * meta(buildJsonObject {
+     *     put("version", "1.0")
+     * })
+     * ```
+     *
+     * @param meta The metadata as a JsonObject
+     */
+    public fun meta(meta: JsonObject) {
+        this.metaValue = meta
+    }
+
+    /**
+     * Sets metadata using a DSL builder.
+     *
+     * Example:
+     * ```kotlin
+     * meta {
+     *     put("version", "1.0")
+     *     put("deprecated", false)
+     * }
+     * ```
+     *
+     * @param block Lambda for building the metadata JsonObject
+     */
+    public fun meta(block: JsonObjectBuilder.() -> Unit) {
+        meta(buildJsonObject(block))
+    }
+
+    @PublishedApi
+    internal fun build(): Tool {
+        val name = requireNotNull(name) {
+            "Missing required field 'name'. Example: name = \"toolName\""
+        }
+        val inputSchema = requireNotNull(inputSchemaValue) {
+            "Missing required field 'inputSchema'. Use inputSchema { } to define the schema."
+        }
+
+        return Tool(
+            name = name,
+            inputSchema = inputSchema,
+            description = description,
+            outputSchema = outputSchemaValue,
+            title = title,
+            annotations = annotations,
+            icons = icons,
+            meta = metaValue,
+        )
+    }
+}
+
+/**
+ * DSL builder for constructing [ToolSchema] instances.
+ *
+ * Used to define JSON Schema for tool input/output parameters.
+ *
+ * @see ToolSchema
+ * @see ToolBuilder
+ */
+@McpDsl
+public class ToolSchemaBuilder @PublishedApi internal constructor() {
+    /**
+     * Map of property names to their schema definitions.
+     *
+     * Example:
+     * ```kotlin
+     * properties = buildJsonObject {
+     *     putJsonObject("query") {
+     *         put("type", "string")
+     *         put("description", "Search query")
+     *     }
+     * }
+     * ```
+     */
+    public var properties: JsonObject? = null
+
+    /**
+     * List of required property names.
+     *
+     * Example: `required = listOf("query", "userId")`
+     */
+    public var required: List<String>? = null
+
+    /**
+     * Schema definitions available to references in properties ($defs).
+     *
+     * Example:
+     * ```kotlin
+     * defs = buildJsonObject {
+     *     putJsonObject("Address") {
+     *         put("type", "object")
+     *         putJsonObject("properties") {
+     *             putJsonObject("street") {
+     *                 put("type", "string")
+     *             }
+     *         }
+     *     }
+     * }
+     * ```
+     */
+    public var defs: JsonObject? = null
+
+    @PublishedApi
+    internal fun build(): ToolSchema = ToolSchema(
+        properties = properties,
+        required = required,
+        defs = defs,
+    )
+}

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/tools.dsl.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/tools.dsl.kt
@@ -242,6 +242,16 @@ public inline fun buildCallToolResult(block: CallToolResultBuilder.() -> Unit): 
  * - [structuredContent] - Machine-readable structured output
  * - [meta] - Metadata for the response
  *
+ * ## Implementation Notes
+ *
+ * **Mutability:** This builder uses mutable collections during construction for efficient accumulation.
+ * The [build] method creates defensive copies (`.toList()`) to ensure the returned [CallToolResult]
+ * is immutable and safe to share.
+ *
+ * **Nullability:** Optional fields use nullable types (`Boolean?`, `JsonObject?`) rather than defaults
+ * to avoid serializing default values in the MCP protocol. When these fields are `null`, they are
+ * omitted from the JSON output, reducing message size and following protocol conventions.
+ *
  * @see buildCallToolResult
  * @see CallToolResult
  */
@@ -254,6 +264,10 @@ public class CallToolResultBuilder @PublishedApi internal constructor() : Result
      *
      * When true, the content should describe the error that occurred.
      * If not set, this is assumed to be false (success).
+     *
+     * **Design note:** This field is nullable rather than defaulting to `false` to avoid
+     * serializing the default value in the JSON protocol. When `null`, the field is omitted
+     * from the serialized output, reducing message size and following MCP protocol conventions.
      *
      * Example: `isError = true`
      */
@@ -333,15 +347,20 @@ public class CallToolResultBuilder @PublishedApi internal constructor() : Result
     /**
      * Sets structured content directly from a JsonObject.
      *
+     * **Note:** Prefer using the DSL lambda variant [structuredContent] for more idiomatic Kotlin code.
+     * This overload is provided for cases where you already have a constructed JsonObject.
+     *
      * Example:
      * ```kotlin
-     * structuredContent(buildJsonObject {
+     * val existingData = buildJsonObject {
      *     put("status", "success")
      *     put("recordsAffected", 5)
-     * })
+     * }
+     * structuredContent(existingData)
      * ```
      *
      * @param content The structured content as a JsonObject
+     * @see structuredContent
      */
     public fun structuredContent(content: JsonObject) {
         this.structuredContentValue = content
@@ -350,9 +369,12 @@ public class CallToolResultBuilder @PublishedApi internal constructor() : Result
     /**
      * Sets structured content using a DSL builder.
      *
+     * **This is the preferred way to set structured content.** The DSL syntax is more idiomatic
+     * and integrates better with Kotlin's type-safe builders.
+     *
      * Provides machine-readable output in addition to the human-readable content.
      *
-     * Example:
+     * Example (preferred):
      * ```kotlin
      * structuredContent {
      *     put("status", "success")

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/tools.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/tools.kt
@@ -84,7 +84,7 @@ public data class Tool(
 public data class ToolSchema(
     val properties: JsonObject? = null,
     val required: List<String>? = null,
-    @SerialName("\$defs")
+    @SerialName($$"$defs")
     val defs: JsonObject? = null,
 ) {
     @OptIn(ExperimentalSerializationApi::class)

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/dsl/CompletionResultDslTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/dsl/CompletionResultDslTest.kt
@@ -1,0 +1,150 @@
+package io.modelcontextprotocol.kotlin.sdk.types.dsl
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
+import io.modelcontextprotocol.kotlin.sdk.types.buildCompleteResult
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+
+/**
+ * Tests for CompleteResult DSL builder.
+ *
+ * Verifies CompleteResult can be constructed via DSL,
+ * covering minimal (required only), full (all fields), and edge cases.
+ */
+@OptIn(ExperimentalMcpApi::class)
+class CompletionResultDslTest {
+
+    @Test
+    fun `CompleteResult should build minimal with values only`() {
+        val result = buildCompleteResult {
+            values("user1", "user2", "user3")
+        }
+
+        result.completion.values shouldHaveSize 3
+        result.completion.values shouldBe listOf("user1", "user2", "user3")
+        result.completion.total.shouldBeNull()
+        result.completion.hasMore.shouldBeNull()
+        result.meta.shouldBeNull()
+    }
+
+    @Test
+    fun `CompleteResult should build full with all fields`() {
+        val result = buildCompleteResult {
+            values(listOf("admin", "moderator", "user", "guest"))
+            total = 42
+            hasMore = true
+
+            meta {
+                put("cached", true)
+                put("queryTime", 50)
+            }
+        }
+
+        result.completion.values shouldHaveSize 4
+        result.completion.total shouldBe 42
+        result.completion.hasMore shouldBe true
+
+        result.meta shouldNotBeNull {
+            get("cached")?.jsonPrimitive?.boolean shouldBe true
+            get("queryTime")?.jsonPrimitive?.int shouldBe 50
+        }
+    }
+
+    @Test
+    fun `CompleteResult should support values via vararg`() {
+        val result = buildCompleteResult {
+            values("a", "b", "c", "d", "e")
+        }
+
+        result.completion.values shouldHaveSize 5
+    }
+
+    @Test
+    fun `CompleteResult should support values via list`() {
+        val completions = listOf("option1", "option2", "option3")
+
+        val result = buildCompleteResult {
+            values(completions)
+        }
+
+        result.completion.values shouldBe completions
+    }
+
+    @Test
+    fun `CompleteResult should throw if no values provided`() {
+        shouldThrow<IllegalArgumentException> {
+            buildCompleteResult { }
+        }
+    }
+
+    @Test
+    fun `CompleteResult should throw if values exceed 100 items`() {
+        val tooManyValues = (1..101).map { "value$it" }
+
+        shouldThrow<IllegalArgumentException> {
+            buildCompleteResult {
+                values(tooManyValues)
+            }
+        }
+    }
+
+    @Test
+    fun `CompleteResult should support exactly 100 values`() {
+        val maxValues = (1..100).map { "value$it" }
+
+        val result = buildCompleteResult {
+            values(maxValues)
+        }
+
+        result.completion.values shouldHaveSize 100
+    }
+
+    @Test
+    fun `CompleteResult should support empty strings in values`() {
+        val result = buildCompleteResult {
+            values("", "non-empty", "")
+        }
+
+        result.completion.values shouldBe listOf("", "non-empty", "")
+    }
+
+    @Test
+    fun `CompleteResult should support unicode in values`() {
+        val result = buildCompleteResult {
+            values("Hello 🌍", "Ça va?", "北京", "مرحبا")
+        }
+
+        result.completion.values shouldHaveSize 4
+        result.completion.values[0] shouldBe "Hello 🌍"
+    }
+
+    @Test
+    fun `CompleteResult should support total without hasMore`() {
+        val result = buildCompleteResult {
+            values("a", "b", "c")
+            total = 10
+        }
+
+        result.completion.total shouldBe 10
+        result.completion.hasMore.shouldBeNull()
+    }
+
+    @Test
+    fun `CompleteResult should support hasMore without total`() {
+        val result = buildCompleteResult {
+            values("a", "b", "c")
+            hasMore = true
+        }
+
+        result.completion.hasMore shouldBe true
+        result.completion.total.shouldBeNull()
+    }
+}

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/dsl/ContentDslTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/dsl/ContentDslTest.kt
@@ -138,7 +138,7 @@ class ContentDslTest {
             messages {
                 assistantImage {
                     data =
-                        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+                        "iVBORw0KGgoggg=="
                     mimeType = "image/png"
                 }
             }
@@ -146,7 +146,7 @@ class ContentDslTest {
 
         (request.params.messages[0].content as ImageContent).shouldNotBeNull {
             data shouldBe
-                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+                "iVBORw0KGgoggg=="
             mimeType shouldBe "image/png"
             annotations.shouldBeNull()
             meta.shouldBeNull()

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/dsl/InitializeResultDslTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/dsl/InitializeResultDslTest.kt
@@ -1,0 +1,201 @@
+package io.modelcontextprotocol.kotlin.sdk.types.dsl
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
+import io.modelcontextprotocol.kotlin.sdk.types.EmptyJsonObject
+import io.modelcontextprotocol.kotlin.sdk.types.LATEST_PROTOCOL_VERSION
+import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
+import io.modelcontextprotocol.kotlin.sdk.types.buildInitializeResult
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+
+/**
+ * Tests for InitializeResult DSL builder.
+ *
+ * Verifies InitializeResult can be constructed via DSL,
+ * covering minimal (required only), full (all fields), and edge cases.
+ */
+@OptIn(ExperimentalMcpApi::class)
+class InitializeResultDslTest {
+
+    @Test
+    fun `InitializeResult should build minimal with default protocol version`() {
+        val result = buildInitializeResult {
+            capabilities(ServerCapabilities())
+            info("MyServer", "1.0.0")
+        }
+
+        result.protocolVersion shouldBe LATEST_PROTOCOL_VERSION
+        result.capabilities shouldNotBeNull {}
+        result.serverInfo shouldNotBeNull {
+            name shouldBe "MyServer"
+            version shouldBe "1.0.0"
+        }
+        result.instructions.shouldBeNull()
+        result.meta.shouldBeNull()
+    }
+
+    @Test
+    fun `InitializeResult should build full with all fields`() {
+        val result = buildInitializeResult {
+            protocolVersion = "2024-11-05"
+
+            capabilities(
+                ServerCapabilities(
+                    tools = ServerCapabilities.Tools(listChanged = true),
+                    resources = ServerCapabilities.Resources(listChanged = true, subscribe = true),
+                    prompts = ServerCapabilities.Prompts(listChanged = true),
+                    logging = EmptyJsonObject,
+                    completions = EmptyJsonObject,
+                ),
+            )
+
+            info(
+                name = "AdvancedServer",
+                version = "2.0.0",
+                title = "Advanced MCP Server",
+                websiteUrl = "https://example.com",
+            )
+
+            instructions = "Use this server for advanced operations. Available tools include..."
+
+            meta {
+                put("serverStartTime", 1707317000000L)
+                put("region", "us-west-1")
+                put("environment", "production")
+            }
+        }
+
+        result.protocolVersion shouldBe "2024-11-05"
+
+        result.capabilities shouldNotBeNull {
+            tools shouldNotBeNull {
+                listChanged shouldBe true
+            }
+            resources shouldNotBeNull {
+                listChanged shouldBe true
+                subscribe shouldBe true
+            }
+            prompts shouldNotBeNull {
+                listChanged shouldBe true
+            }
+            logging shouldNotBeNull {}
+            completions shouldNotBeNull {}
+        }
+
+        result.serverInfo shouldNotBeNull {
+            name shouldBe "AdvancedServer"
+            version shouldBe "2.0.0"
+            title shouldBe "Advanced MCP Server"
+            websiteUrl shouldBe "https://example.com"
+        }
+
+        result.instructions shouldBe "Use this server for advanced operations. Available tools include..."
+
+        result.meta shouldNotBeNull {
+            get("region")?.jsonPrimitive?.content shouldBe "us-west-1"
+            get("environment")?.jsonPrimitive?.content shouldBe "production"
+        }
+    }
+
+    @Test
+    fun `InitializeResult should support partial capabilities`() {
+        val result = buildInitializeResult {
+            capabilities(
+                ServerCapabilities(
+                    tools = ServerCapabilities.Tools(listChanged = true),
+                    // Other capabilities null
+                ),
+            )
+            info("SimpleServer", "1.0")
+        }
+
+        result.capabilities shouldNotBeNull {
+            tools shouldNotBeNull {}
+            resources.shouldBeNull()
+            prompts.shouldBeNull()
+            logging.shouldBeNull()
+            completions.shouldBeNull()
+        }
+    }
+
+    @Test
+    fun `InitializeResult should support capabilities with false flags`() {
+        val result = buildInitializeResult {
+            capabilities(
+                ServerCapabilities(
+                    tools = ServerCapabilities.Tools(listChanged = false),
+                    resources = ServerCapabilities.Resources(listChanged = false, subscribe = false),
+                ),
+            )
+            info("StaticServer", "1.0")
+        }
+
+        result.capabilities shouldNotBeNull {
+            tools shouldNotBeNull {
+                listChanged shouldBe false
+            }
+            resources shouldNotBeNull {
+                listChanged shouldBe false
+                subscribe shouldBe false
+            }
+        }
+    }
+
+    @Test
+    fun `InitializeResult should throw if capabilities missing`() {
+        shouldThrow<IllegalArgumentException> {
+            buildInitializeResult {
+                info("Server", "1.0")
+            }
+        }
+    }
+
+    @Test
+    fun `InitializeResult should throw if info missing`() {
+        shouldThrow<IllegalArgumentException> {
+            buildInitializeResult {
+                capabilities(ServerCapabilities())
+            }
+        }
+    }
+
+    @Test
+    fun `InitializeResult should support long instructions`() {
+        val longInstructions = "This is a very long instruction text. ".repeat(100)
+
+        val result = buildInitializeResult {
+            capabilities(ServerCapabilities())
+            info("Server", "1.0")
+            instructions = longInstructions
+        }
+
+        result.instructions shouldBe longInstructions
+    }
+
+    @Test
+    fun `InitializeResult should support custom protocol versions`() {
+        val result = buildInitializeResult {
+            protocolVersion = "2025-01-01"
+            capabilities(ServerCapabilities())
+            info("FutureServer", "3.0")
+        }
+
+        result.protocolVersion shouldBe "2025-01-01"
+    }
+
+    @Test
+    fun `InitializeResult should support unicode in instructions`() {
+        val result = buildInitializeResult {
+            capabilities(ServerCapabilities())
+            info("Server", "1.0")
+            instructions = "サーバーの使い方: 🚀 Start here! Ça va?"
+        }
+
+        result.instructions shouldBe "サーバーの使い方: 🚀 Start here! Ça va?"
+    }
+}

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/dsl/PromptsResultDslTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/dsl/PromptsResultDslTest.kt
@@ -1,0 +1,194 @@
+package io.modelcontextprotocol.kotlin.sdk.types.dsl
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
+import io.modelcontextprotocol.kotlin.sdk.types.PromptArgument
+import io.modelcontextprotocol.kotlin.sdk.types.Role
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import io.modelcontextprotocol.kotlin.sdk.types.buildGetPromptResult
+import io.modelcontextprotocol.kotlin.sdk.types.buildListPromptsResult
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+
+/**
+ * Tests for PromptsResult DSL builders.
+ *
+ * Verifies GetPromptResult and ListPromptsResult can be constructed via DSL,
+ * covering minimal (required only), full (all fields), and edge cases.
+ */
+@OptIn(ExperimentalMcpApi::class)
+class PromptsResultDslTest {
+
+    // ========================================================================
+    // GetPromptResult Tests
+    // ========================================================================
+
+    @Test
+    fun `GetPromptResult should build minimal with single message`() {
+        val result = buildGetPromptResult {
+            message(Role.User, TextContent("Hello, how can I help you?"))
+        }
+
+        result.messages shouldHaveSize 1
+        result.messages[0].role shouldBe Role.User
+        (result.messages[0].content as TextContent).text shouldBe "Hello, how can I help you?"
+        result.description.shouldBeNull()
+        result.meta.shouldBeNull()
+    }
+
+    @Test
+    fun `GetPromptResult should build full with multiple messages and description`() {
+        val result = buildGetPromptResult {
+            description = "A customer service greeting prompt with context"
+
+            message(Role.User, TextContent("You are a helpful customer service assistant."))
+            message(Role.User, TextContent("I need help with my order."))
+            message(Role.Assistant, TextContent("I'd be happy to help! Could you provide your order number?"))
+
+            meta {
+                put("category", "customer-service")
+                put("language", "en")
+                put("version", 2)
+            }
+        }
+
+        result.messages shouldHaveSize 3
+        result.messages[0].role shouldBe Role.User
+        result.messages[1].role shouldBe Role.User
+        result.messages[2].role shouldBe Role.Assistant
+
+        result.description shouldBe "A customer service greeting prompt with context"
+
+        result.meta shouldNotBeNull {
+            get("category")?.jsonPrimitive?.content shouldBe "customer-service"
+            get("language")?.jsonPrimitive?.content shouldBe "en"
+            get("version")?.jsonPrimitive?.content shouldBe "2"
+        }
+    }
+
+    @Test
+    fun `GetPromptResult should throw if no messages provided`() {
+        shouldThrow<IllegalArgumentException> {
+            buildGetPromptResult { }
+        }
+    }
+
+    // ========================================================================
+    // ListPromptsResult Tests
+    // ========================================================================
+
+    @Test
+    fun `ListPromptsResult should build minimal with single prompt`() {
+        val result = buildListPromptsResult {
+            prompt {
+                name = "greeting"
+            }
+        }
+
+        result.prompts shouldHaveSize 1
+        result.prompts[0].name shouldBe "greeting"
+        result.nextCursor.shouldBeNull()
+        result.meta.shouldBeNull()
+    }
+
+    @Test
+    fun `ListPromptsResult should build full with multiple prompts and pagination`() {
+        val result = buildListPromptsResult {
+            prompt {
+                name = "greeting"
+                description = "A friendly greeting prompt"
+                title = "Friendly Greeting"
+                arguments = listOf(
+                    PromptArgument(name = "userName", description = "The user's name", required = true),
+                    PromptArgument(name = "language", description = "Preferred language", required = false),
+                )
+                meta {
+                    put("category", "greetings")
+                }
+            }
+
+            prompt {
+                name = "farewell"
+                description = "A polite farewell prompt"
+                title = "Polite Farewell"
+            }
+
+            prompt {
+                name = "product-recommendation"
+                description = "Recommends products based on user preferences"
+                arguments = listOf(
+                    PromptArgument(name = "userId", required = true),
+                    PromptArgument(name = "category", required = false),
+                )
+            }
+
+            nextCursor = "eyJwYWdlIjogMn0="
+
+            meta {
+                put("serverVersion", "2.0")
+                put("totalPrompts", 50)
+            }
+        }
+
+        result.prompts shouldHaveSize 3
+
+        result.prompts[0].let { prompt ->
+            prompt.name shouldBe "greeting"
+            prompt.description shouldBe "A friendly greeting prompt"
+            prompt.title shouldBe "Friendly Greeting"
+            prompt.arguments?.let { args ->
+                args shouldHaveSize 2
+                args[0].name shouldBe "userName"
+                args[0].required shouldBe true
+                args[1].name shouldBe "language"
+                args[1].required shouldBe false
+            }
+        }
+
+        result.prompts[1].name shouldBe "farewell"
+        result.prompts[2].name shouldBe "product-recommendation"
+
+        result.nextCursor shouldBe "eyJwYWdlIjogMn0="
+
+        result.meta shouldNotBeNull {
+            get("serverVersion")?.jsonPrimitive?.content shouldBe "2.0"
+            get("totalPrompts")?.jsonPrimitive?.content shouldBe "50"
+        }
+    }
+
+    @Test
+    fun `ListPromptsResult should throw if no prompts provided`() {
+        shouldThrow<IllegalArgumentException> {
+            buildListPromptsResult { }
+        }
+    }
+
+    @Test
+    fun `ListPromptsResult should support prompt without arguments`() {
+        val result = buildListPromptsResult {
+            prompt {
+                name = "simplePrompt"
+                description = "A prompt with no arguments"
+            }
+        }
+
+        result.prompts[0].arguments.shouldBeNull()
+    }
+
+    @Test
+    fun `ListPromptsResult should support empty arguments list`() {
+        val result = buildListPromptsResult {
+            prompt {
+                name = "emptyArgs"
+                arguments = emptyList()
+            }
+        }
+
+        result.prompts[0].arguments?.let { it shouldHaveSize 0 }
+    }
+}

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/dsl/ResourcesResultDslTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/dsl/ResourcesResultDslTest.kt
@@ -1,0 +1,142 @@
+package io.modelcontextprotocol.kotlin.sdk.types.dsl
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
+import io.modelcontextprotocol.kotlin.sdk.types.Annotations
+import io.modelcontextprotocol.kotlin.sdk.types.BlobResourceContents
+import io.modelcontextprotocol.kotlin.sdk.types.Role
+import io.modelcontextprotocol.kotlin.sdk.types.TextResourceContents
+import io.modelcontextprotocol.kotlin.sdk.types.buildListResourceTemplatesResult
+import io.modelcontextprotocol.kotlin.sdk.types.buildListResourcesResult
+import io.modelcontextprotocol.kotlin.sdk.types.buildReadResourceResult
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+
+/**
+ * Tests for ResourcesResult DSL builders.
+ *
+ * Verifies resource result types can be constructed via DSL.
+ */
+@OptIn(ExperimentalMcpApi::class)
+class ResourcesResultDslTest {
+
+    @Test
+    fun `ListResourcesResult should build minimal with single resource`() {
+        val result = buildListResourcesResult {
+            resource {
+                uri = "file:///path/to/file.txt"
+                name = "file.txt"
+            }
+        }
+
+        result.resources shouldHaveSize 1
+        result.resources[0].uri shouldBe "file:///path/to/file.txt"
+        result.resources[0].name shouldBe "file.txt"
+    }
+
+    @Test
+    fun `ListResourcesResult should build full with multiple resources`() {
+        val result = buildListResourcesResult {
+            resource {
+                uri = "file:///docs/readme.md"
+                name = "readme.md"
+                description = "Project documentation"
+                mimeType = "text/markdown"
+                size = 2048
+                title = "README"
+                annotations = Annotations(
+                    audience = listOf(Role.User),
+                    priority = 0.9,
+                )
+            }
+
+            resource {
+                uri = "db://users/123"
+                name = "user-123"
+                description = "User profile data"
+                mimeType = "application/json"
+            }
+
+            nextCursor = "next-page"
+            meta {
+                put("cached", true)
+            }
+        }
+
+        result.resources shouldHaveSize 2
+        result.nextCursor shouldBe "next-page"
+    }
+
+    @Test
+    fun `ReadResourceResult should build with text content`() {
+        val result = buildReadResourceResult {
+            textContent(
+                uri = "file:///docs/readme.md",
+                text = "# Project README\n\nWelcome!",
+                mimeType = "text/markdown",
+            )
+        }
+
+        result.contents shouldHaveSize 1
+        (result.contents[0] as TextResourceContents).let {
+            it.uri shouldBe "file:///docs/readme.md"
+            it.text shouldBe "# Project README\n\nWelcome!"
+            it.mimeType shouldBe "text/markdown"
+        }
+    }
+
+    @Test
+    fun `ReadResourceResult should build with blob content`() {
+        val result = buildReadResourceResult {
+            blobContent(
+                uri = "file:///images/logo.png",
+                blob = "iVBORw0KGgoggg==",
+                mimeType = "image/png",
+            )
+        }
+
+        result.contents shouldHaveSize 1
+        (result.contents[0] as BlobResourceContents).let {
+            it.uri shouldBe "file:///images/logo.png"
+            it.mimeType shouldBe "image/png"
+        }
+    }
+
+    @Test
+    fun `ListResourceTemplatesResult should build with templates`() {
+        val result = buildListResourceTemplatesResult {
+            template {
+                uriTemplate = "file:///{path}"
+                name = "file-template"
+                description = "Access any file"
+                mimeType = "text/plain"
+            }
+
+            template {
+                uriTemplate = "db://users/{userId}"
+                name = "user-db-template"
+            }
+
+            nextCursor = "next"
+        }
+
+        result.resourceTemplates shouldHaveSize 2
+        result.resourceTemplates[0].uriTemplate shouldBe "file:///{path}"
+    }
+
+    @Test
+    fun `ListResourcesResult should throw if no resources`() {
+        shouldThrow<IllegalArgumentException> {
+            buildListResourcesResult { }
+        }
+    }
+
+    @Test
+    fun `ReadResourceResult should throw if no contents`() {
+        shouldThrow<IllegalArgumentException> {
+            buildReadResourceResult { }
+        }
+    }
+}

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/dsl/ResourcesResultDslTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/dsl/ResourcesResultDslTest.kt
@@ -2,6 +2,8 @@ package io.modelcontextprotocol.kotlin.sdk.types.dsl
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
 import io.modelcontextprotocol.kotlin.sdk.types.Annotations
@@ -11,6 +13,8 @@ import io.modelcontextprotocol.kotlin.sdk.types.TextResourceContents
 import io.modelcontextprotocol.kotlin.sdk.types.buildListResourceTemplatesResult
 import io.modelcontextprotocol.kotlin.sdk.types.buildListResourcesResult
 import io.modelcontextprotocol.kotlin.sdk.types.buildReadResourceResult
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import kotlin.test.Test
 
@@ -138,5 +142,149 @@ class ResourcesResultDslTest {
         shouldThrow<IllegalArgumentException> {
             buildReadResourceResult { }
         }
+    }
+
+    @Test
+    fun `ListResourcesResult should build full with all optional fields`() {
+        val result = buildListResourcesResult {
+            resource {
+                uri = "file:///docs/api.md"
+                name = "api-documentation"
+                description = "Complete API documentation"
+                mimeType = "text/markdown"
+                size = 4096
+                title = "API Reference"
+                annotations = Annotations(
+                    audience = listOf(Role.User, Role.Assistant),
+                    priority = 0.8,
+                )
+            }
+            nextCursor = "page-2"
+            meta {
+                put("totalResources", 150)
+                put("cached", true)
+            }
+        }
+
+        result.resources shouldHaveSize 1
+        result.resources[0].let { resource ->
+            resource.uri shouldBe "file:///docs/api.md"
+            resource.name shouldBe "api-documentation"
+            resource.description shouldBe "Complete API documentation"
+            resource.mimeType shouldBe "text/markdown"
+            resource.size shouldBe 4096
+            resource.title shouldBe "API Reference"
+            resource.annotations shouldNotBeNull {
+                audience shouldBe listOf(Role.User, Role.Assistant)
+                priority shouldBe 0.8
+            }
+        }
+        result.nextCursor shouldBe "page-2"
+        result.meta shouldNotBeNull {}
+    }
+
+    @Test
+    fun `ReadResourceResult should build with multiple content items`() {
+        val result = buildReadResourceResult {
+            textContent(
+                uri = "file:///docs/part1.md",
+                text = "# Part 1\n\nIntroduction",
+                mimeType = "text/markdown",
+            )
+            textContent(
+                uri = "file:///docs/part2.md",
+                text = "# Part 2\n\nDetails",
+                mimeType = "text/markdown",
+            )
+            blobContent(
+                uri = "file:///images/diagram.png",
+                blob = "iVBORw0KGgoggg==",
+                mimeType = "image/png",
+            )
+        }
+
+        result.contents shouldHaveSize 3
+        (result.contents[0] as TextResourceContents).uri shouldBe "file:///docs/part1.md"
+        (result.contents[1] as TextResourceContents).uri shouldBe "file:///docs/part2.md"
+        (result.contents[2] as BlobResourceContents).uri shouldBe "file:///images/diagram.png"
+    }
+
+    @Test
+    fun `ReadResourceResult should support meta field`() {
+        val result = buildReadResourceResult {
+            textContent(
+                uri = "file:///data.json",
+                text = """{"key": "value"}""",
+                mimeType = "application/json",
+            )
+            meta {
+                put("source", "database")
+                put("lastModified", 1707317000000L)
+                put("cached", false)
+            }
+        }
+
+        result.meta shouldNotBeNull {
+            get("source")?.jsonPrimitive?.content shouldBe "database"
+            get("cached")?.jsonPrimitive?.boolean shouldBe false
+        }
+    }
+
+    @Test
+    fun `ListResourceTemplatesResult should support pagination with nextCursor`() {
+        val result = buildListResourceTemplatesResult {
+            template {
+                uriTemplate = "db://users/{userId}"
+                name = "user-template"
+            }
+            template {
+                uriTemplate = "db://posts/{postId}"
+                name = "post-template"
+            }
+            nextCursor = "template-page-2"
+        }
+
+        result.resourceTemplates shouldHaveSize 2
+        result.nextCursor shouldBe "template-page-2"
+    }
+
+    @Test
+    fun `ListResourceTemplatesResult should support meta field`() {
+        val result = buildListResourceTemplatesResult {
+            template {
+                uriTemplate = "api://{endpoint}"
+                name = "api-template"
+            }
+            meta {
+                put("version", "2.0")
+                put("totalTemplates", 25)
+            }
+        }
+
+        result.meta shouldNotBeNull {
+            get("version")?.jsonPrimitive?.content shouldBe "2.0"
+        }
+    }
+
+    @Test
+    fun `ListResourcesResult should support resources with minimal and full fields together`() {
+        val result = buildListResourcesResult {
+            resource {
+                uri = "simple://resource1"
+                name = "minimal"
+            }
+            resource {
+                uri = "complex://resource2"
+                name = "complete"
+                description = "Full resource"
+                mimeType = "application/json"
+                size = 2048
+                title = "Complete Resource"
+            }
+        }
+
+        result.resources shouldHaveSize 2
+        result.resources[0].description.shouldBeNull()
+        result.resources[1].description shouldBe "Full resource"
     }
 }

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/dsl/ToolsResultDslTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/dsl/ToolsResultDslTest.kt
@@ -1,0 +1,292 @@
+package io.modelcontextprotocol.kotlin.sdk.types.dsl
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
+import io.modelcontextprotocol.kotlin.sdk.types.AudioContent
+import io.modelcontextprotocol.kotlin.sdk.types.ImageContent
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import io.modelcontextprotocol.kotlin.sdk.types.ToolAnnotations
+import io.modelcontextprotocol.kotlin.sdk.types.buildCallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.buildListToolsResult
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
+import kotlin.test.Test
+
+/**
+ * Tests for ToolsResult DSL builders.
+ *
+ * Verifies CallToolResult and ListToolsResult can be constructed via DSL,
+ * covering minimal (required only), full (all fields), and edge cases.
+ */
+@OptIn(ExperimentalMcpApi::class)
+class ToolsResultDslTest {
+
+    // ========================================================================
+    // CallToolResult Tests
+    // ========================================================================
+
+    @Test
+    fun `CallToolResult should build minimal with single text content`() {
+        val result = buildCallToolResult {
+            textContent("Operation successful")
+        }
+
+        result.content shouldHaveSize 1
+        (result.content[0] as TextContent).text shouldBe "Operation successful"
+        result.isError.shouldBeNull()
+        result.structuredContent.shouldBeNull()
+        result.meta.shouldBeNull()
+    }
+
+    @Test
+    fun `CallToolResult should build full with all content types and structured data`() {
+        val result = buildCallToolResult {
+            textContent("Database query completed")
+            @Suppress("MaxLineLength")
+            imageContent(
+                data =
+                "iVBORw0KGgoggg==",
+                mimeType = "image/png",
+            )
+            audioContent(
+                data = "UklGRiQAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAAABmYWN0BAAAAAAAAABkYXRhAAAAAA==",
+                mimeType = "audio/wav",
+            )
+            isError = false
+            structuredContent {
+                put("queryTime", 150)
+                put("recordsAffected", 42)
+                putJsonArray("columns") {
+                    add("id")
+                    add("name")
+                    add("email")
+                }
+            }
+            meta {
+                put("source", "postgres")
+                put("cached", true)
+            }
+        }
+
+        result.content shouldHaveSize 3
+        result.content[0].shouldBeInstanceOf<TextContent>()
+        result.content[1].shouldBeInstanceOf<ImageContent>()
+        result.content[2].shouldBeInstanceOf<AudioContent>()
+
+        result.isError shouldBe false
+
+        result.structuredContent shouldNotBeNull {
+            get("queryTime")?.jsonPrimitive?.int shouldBe 150
+            get("recordsAffected")?.jsonPrimitive?.int shouldBe 42
+            get("columns")?.jsonArray?.map { it.jsonPrimitive.content }
+                ?.let { it shouldContainAll listOf("id", "name", "email") }
+        }
+
+        result.meta shouldNotBeNull {
+            get("source")?.jsonPrimitive?.content shouldBe "postgres"
+            get("cached")?.jsonPrimitive?.boolean shouldBe true
+        }
+    }
+
+    @Test
+    fun `CallToolResult should support error status`() {
+        val result = buildCallToolResult {
+            textContent("Failed to connect to database")
+            isError = true
+        }
+
+        result.isError shouldBe true
+        (result.content[0] as TextContent).text shouldBe "Failed to connect to database"
+    }
+
+    @Test
+    fun `CallToolResult should throw if no content provided`() {
+        shouldThrow<IllegalArgumentException> {
+            buildCallToolResult { }
+        }
+    }
+
+    // ========================================================================
+    // ListToolsResult Tests
+    // ========================================================================
+
+    @Test
+    fun `ListToolsResult should build minimal with single tool`() {
+        val result = buildListToolsResult {
+            tool {
+                name = "getCurrentTime"
+                inputSchema {
+                    // Empty schema for no parameters
+                }
+            }
+        }
+
+        result.tools shouldHaveSize 1
+        result.tools[0].name shouldBe "getCurrentTime"
+        result.nextCursor.shouldBeNull()
+        result.meta.shouldBeNull()
+    }
+
+    @Test
+    @Suppress("LongMethod")
+    fun `ListToolsResult should build full with multiple tools and pagination`() {
+        val result = buildListToolsResult {
+            tool {
+                name = "searchDatabase"
+                description = "Search the database for records"
+                title = "Database Search"
+                inputSchema {
+                    properties = buildJsonObject {
+                        putJsonObject("query") {
+                            put("type", "string")
+                            put("description", "Search query")
+                        }
+                        putJsonObject("limit") {
+                            put("type", "integer")
+                            put("default", 10)
+                        }
+                    }
+                    required = listOf("query")
+                }
+                outputSchema {
+                    properties = buildJsonObject {
+                        putJsonObject("results") {
+                            put("type", "array")
+                        }
+                    }
+                }
+                annotations = ToolAnnotations(
+                    readOnlyHint = true,
+                    idempotentHint = true,
+                )
+            }
+
+            tool {
+                name = "updateRecord"
+                description = "Update a database record"
+                inputSchema {
+                    properties = buildJsonObject {
+                        putJsonObject("id") {
+                            put("type", "integer")
+                        }
+                        putJsonObject("data") {
+                            put("type", "object")
+                        }
+                    }
+                    required = listOf("id", "data")
+                }
+                annotations = ToolAnnotations(
+                    readOnlyHint = false,
+                    destructiveHint = false,
+                )
+            }
+
+            nextCursor = "eyJwYWdlIjogMn0="
+
+            meta {
+                put("serverVersion", "1.0.0")
+                put("cached", false)
+            }
+        }
+
+        result.tools shouldHaveSize 2
+
+        result.tools[0].let { tool ->
+            tool.name shouldBe "searchDatabase"
+            tool.description shouldBe "Search the database for records"
+            tool.title shouldBe "Database Search"
+            tool.inputSchema shouldNotBeNull {
+                required shouldBe listOf("query")
+            }
+            tool.annotations shouldNotBeNull {
+                readOnlyHint shouldBe true
+                idempotentHint shouldBe true
+            }
+        }
+
+        result.tools[1].let { tool ->
+            tool.name shouldBe "updateRecord"
+            tool.annotations shouldNotBeNull {
+                readOnlyHint shouldBe false
+                destructiveHint shouldBe false
+            }
+        }
+
+        result.nextCursor shouldBe "eyJwYWdlIjogMn0="
+
+        result.meta shouldNotBeNull {
+            get("serverVersion")?.jsonPrimitive?.content shouldBe "1.0.0"
+            get("cached")?.jsonPrimitive?.boolean shouldBe false
+        }
+    }
+
+    @Test
+    fun `ListToolsResult should support tool with defs in schema`() {
+        val result = buildListToolsResult {
+            tool {
+                name = "createUser"
+                inputSchema {
+                    properties = buildJsonObject {
+                        putJsonObject("user") {
+                            put("\$ref", "#/\$defs/User")
+                        }
+                    }
+                    defs = buildJsonObject {
+                        putJsonObject("User") {
+                            put("type", "object")
+                            putJsonObject("properties") {
+                                putJsonObject("name") {
+                                    put("type", "string")
+                                }
+                                putJsonObject("email") {
+                                    put("type", "string")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        result.tools[0].inputSchema.defs shouldNotBeNull {
+            get("User") shouldNotBeNull {}
+        }
+    }
+
+    @Test
+    fun `ListToolsResult should throw if no tools provided`() {
+        shouldThrow<IllegalArgumentException> {
+            buildListToolsResult { }
+        }
+    }
+
+    @Test
+    fun `ListToolsResult should support empty input schema`() {
+        val result = buildListToolsResult {
+            tool {
+                name = "noArgs"
+                inputSchema {
+                    // No properties, no required fields
+                }
+            }
+        }
+
+        result.tools[0].inputSchema shouldNotBeNull {
+            properties.shouldBeNull()
+            required.shouldBeNull()
+        }
+    }
+}

--- a/kotlin-sdk-server/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/StreamableHttpServerTransportTest.kt
+++ b/kotlin-sdk-server/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/StreamableHttpServerTransportTest.kt
@@ -21,6 +21,7 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
 import io.modelcontextprotocol.kotlin.sdk.types.ClientCapabilities
 import io.modelcontextprotocol.kotlin.sdk.types.EmptyResult
 import io.modelcontextprotocol.kotlin.sdk.types.Implementation
@@ -32,12 +33,10 @@ import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCRequest
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCResponse
 import io.modelcontextprotocol.kotlin.sdk.types.LATEST_PROTOCOL_VERSION
 import io.modelcontextprotocol.kotlin.sdk.types.ListResourcesResult
-import io.modelcontextprotocol.kotlin.sdk.types.ListToolsResult
 import io.modelcontextprotocol.kotlin.sdk.types.McpJson
 import io.modelcontextprotocol.kotlin.sdk.types.Method
 import io.modelcontextprotocol.kotlin.sdk.types.RequestId
-import io.modelcontextprotocol.kotlin.sdk.types.Tool
-import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import io.modelcontextprotocol.kotlin.sdk.types.buildListToolsResult
 import io.modelcontextprotocol.kotlin.sdk.types.toJSON
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.buildJsonObject
@@ -50,6 +49,7 @@ import kotlin.test.assertNotNull
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientContentNegotiation
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation as ServerContentNegotiation
 
+@OptIn(ExperimentalMcpApi::class)
 class StreamableHttpServerTransportTest {
     private val path = "/transport"
 
@@ -161,12 +161,15 @@ class StreamableHttpServerTransportTest {
         val firstRequest = JSONRPCRequest(id = RequestId("first"), method = Method.Defined.ToolsList.value)
         val secondRequest = JSONRPCRequest(id = RequestId("second"), method = Method.Defined.ResourcesList.value)
 
-        val firstResult = ListToolsResult(
-            tools = listOf(
-                Tool(name = "tool-1", inputSchema = ToolSchema()),
-            ),
-            meta = buildJsonObject { put("label", "first") },
-        )
+        val firstResult = buildListToolsResult {
+            tool {
+                name = "tool-1"
+                inputSchema { }
+            }
+            meta {
+                put("label", "first")
+            }
+        }
         val secondResult = ListResourcesResult(
             resources = emptyList(),
             meta = buildJsonObject { put("label", "second") },


### PR DESCRIPTION
# Add result DSL builders and tests

- Introduced `ToolsResultDslTest` and `PromptsResultDslTest` to test result builders for tool and prompt operations.
- Added `buildCompleteResult` and `buildInitializeResult` for server-side result creation.
- Updated API surface to include result DSL functionality.
- Added new test cases for `CallToolResult`, `ListResourcesResult`, and `ReadResourceResult` to validate error handling, structured content, and metadata processing.
- Improved coverage for resource and template handling with additional edge cases for mixed-field resources and pagination
- Updated integration tests to use the `buildCallToolResult` DSL for constructing results, improving clarity and reducing boilerplate. Added `@OptIn(ExperimentalMcpApi::class)` annotations to test files requiring experimental API.
- Refactored delay handling in tests to streamline coroutine usage.

## Motivation and Context

Build also results with DSL

## How Has This Been Tested?
Unit test

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Tests update
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
