### PR TITLE
refactor: replace flat parameter definitions with `StreamableHttpServerTransport.Configuration` in Application Ktor extensions

### DIFF
--- a/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/kotlin/AbstractResourceIntegrationTest.kt
+++ b/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/kotlin/AbstractResourceIntegrationTest.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.test.Ignore
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -165,7 +164,6 @@ abstract class AbstractResourceIntegrationTest : KotlinTestBase() {
         assertEquals(testResourceContent, content.text, "Resource content should match")
     }
 
-    @Ignore("Blocked by https://github.com/modelcontextprotocol/kotlin-sdk/issues/249")
     @Test
     fun testSubscribeAndUnsubscribe() {
         runBlocking(Dispatchers.IO) {

--- a/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/kotlin/KotlinTestBase.kt
+++ b/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/kotlin/KotlinTestBase.kt
@@ -148,7 +148,9 @@ abstract class KotlinTestBase {
                 // Create StreamableHTTP server transport
                 // Using JSON response mode for simpler testing (no SSE session required)
                 val transport = StreamableHttpServerTransport(
-                    enableJsonResponse = true, // Use JSON response mode for testing
+                    StreamableHttpServerTransport.Configuration(
+                        enableJsonResponse = true, // Use JSON response mode for testing
+                    ),
                 )
                 // Use stateless mode to skip session validation for simpler testing
                 transport.setSessionIdGenerator(null)

--- a/kotlin-sdk-server/api/kotlin-sdk-server.api
+++ b/kotlin-sdk-server/api/kotlin-sdk-server.api
@@ -38,10 +38,10 @@ public final class io/modelcontextprotocol/kotlin/sdk/server/KtorServerKt {
 	public static final fun mcp (Lio/ktor/server/application/Application;Lkotlin/jvm/functions/Function1;)V
 	public static final fun mcp (Lio/ktor/server/routing/Route;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public static final fun mcp (Lio/ktor/server/routing/Route;Lkotlin/jvm/functions/Function1;)V
-	public static final fun mcpStatelessStreamableHttp (Lio/ktor/server/application/Application;Ljava/lang/String;ZLjava/util/List;Ljava/util/List;Lio/modelcontextprotocol/kotlin/sdk/server/EventStore;Lkotlin/jvm/functions/Function1;)V
-	public static synthetic fun mcpStatelessStreamableHttp$default (Lio/ktor/server/application/Application;Ljava/lang/String;ZLjava/util/List;Ljava/util/List;Lio/modelcontextprotocol/kotlin/sdk/server/EventStore;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
-	public static final fun mcpStreamableHttp (Lio/ktor/server/application/Application;Ljava/lang/String;ZLjava/util/List;Ljava/util/List;Lio/modelcontextprotocol/kotlin/sdk/server/EventStore;Lkotlin/jvm/functions/Function1;)V
-	public static synthetic fun mcpStreamableHttp$default (Lio/ktor/server/application/Application;Ljava/lang/String;ZLjava/util/List;Ljava/util/List;Lio/modelcontextprotocol/kotlin/sdk/server/EventStore;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun mcpStatelessStreamableHttp (Lio/ktor/server/application/Application;Ljava/lang/String;Lio/modelcontextprotocol/kotlin/sdk/server/StreamableHttpServerTransport$Configuration;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun mcpStatelessStreamableHttp$default (Lio/ktor/server/application/Application;Ljava/lang/String;Lio/modelcontextprotocol/kotlin/sdk/server/StreamableHttpServerTransport$Configuration;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun mcpStreamableHttp (Lio/ktor/server/application/Application;Ljava/lang/String;Lio/modelcontextprotocol/kotlin/sdk/server/StreamableHttpServerTransport$Configuration;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun mcpStreamableHttp$default (Lio/ktor/server/application/Application;Ljava/lang/String;Lio/modelcontextprotocol/kotlin/sdk/server/StreamableHttpServerTransport$Configuration;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/server/RegisteredPrompt : io/modelcontextprotocol/kotlin/sdk/server/Feature {

--- a/kotlin-sdk-server/api/kotlin-sdk-server.api
+++ b/kotlin-sdk-server/api/kotlin-sdk-server.api
@@ -195,6 +195,8 @@ public final class io/modelcontextprotocol/kotlin/sdk/server/StdioServerTranspor
 public final class io/modelcontextprotocol/kotlin/sdk/server/StreamableHttpServerTransport : io/modelcontextprotocol/kotlin/sdk/shared/AbstractTransport {
 	public static final field STANDALONE_SSE_STREAM_ID Ljava/lang/String;
 	public fun <init> ()V
+	public fun <init> (Lio/modelcontextprotocol/kotlin/sdk/server/StreamableHttpServerTransport$Configuration;)V
+	public synthetic fun <init> (Lio/modelcontextprotocol/kotlin/sdk/server/StreamableHttpServerTransport$Configuration;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (ZZLjava/util/List;Ljava/util/List;Lio/modelcontextprotocol/kotlin/sdk/server/EventStore;Ljava/lang/Long;)V
 	public synthetic fun <init> (ZZLjava/util/List;Ljava/util/List;Lio/modelcontextprotocol/kotlin/sdk/server/EventStore;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -209,6 +211,22 @@ public final class io/modelcontextprotocol/kotlin/sdk/server/StreamableHttpServe
 	public final fun setOnSessionInitialized (Lkotlin/jvm/functions/Function1;)V
 	public final fun setSessionIdGenerator (Lkotlin/jvm/functions/Function0;)V
 	public fun start (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/modelcontextprotocol/kotlin/sdk/server/StreamableHttpServerTransport$Configuration {
+	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/server/StreamableHttpServerTransport$Configuration$Companion;
+	public synthetic fun <init> (ZZLjava/util/List;Ljava/util/List;Lio/modelcontextprotocol/kotlin/sdk/server/EventStore;Lkotlin/time/Duration;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ZZLjava/util/List;Ljava/util/List;Lio/modelcontextprotocol/kotlin/sdk/server/EventStore;Lkotlin/time/Duration;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAllowedHosts ()Ljava/util/List;
+	public final fun getAllowedOrigins ()Ljava/util/List;
+	public final fun getEnableDnsRebindingProtection ()Z
+	public final fun getEnableJsonResponse ()Z
+	public final fun getEventStore ()Lio/modelcontextprotocol/kotlin/sdk/server/EventStore;
+	public final fun getRetryInterval-FghU774 ()Lkotlin/time/Duration;
+}
+
+public final class io/modelcontextprotocol/kotlin/sdk/server/StreamableHttpServerTransport$Configuration$Companion {
+	public final fun getDefault ()Lio/modelcontextprotocol/kotlin/sdk/server/StreamableHttpServerTransport$Configuration;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/server/WebSocketMcpKtorServerExtensionsKt {

--- a/kotlin-sdk-server/api/kotlin-sdk-server.api
+++ b/kotlin-sdk-server/api/kotlin-sdk-server.api
@@ -194,9 +194,7 @@ public final class io/modelcontextprotocol/kotlin/sdk/server/StdioServerTranspor
 
 public final class io/modelcontextprotocol/kotlin/sdk/server/StreamableHttpServerTransport : io/modelcontextprotocol/kotlin/sdk/shared/AbstractTransport {
 	public static final field STANDALONE_SSE_STREAM_ID Ljava/lang/String;
-	public fun <init> ()V
 	public fun <init> (Lio/modelcontextprotocol/kotlin/sdk/server/StreamableHttpServerTransport$Configuration;)V
-	public synthetic fun <init> (Lio/modelcontextprotocol/kotlin/sdk/server/StreamableHttpServerTransport$Configuration;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (ZZLjava/util/List;Ljava/util/List;Lio/modelcontextprotocol/kotlin/sdk/server/EventStore;Ljava/lang/Long;)V
 	public synthetic fun <init> (ZZLjava/util/List;Ljava/util/List;Lio/modelcontextprotocol/kotlin/sdk/server/EventStore;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -214,7 +212,6 @@ public final class io/modelcontextprotocol/kotlin/sdk/server/StreamableHttpServe
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/server/StreamableHttpServerTransport$Configuration {
-	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/server/StreamableHttpServerTransport$Configuration$Companion;
 	public synthetic fun <init> (ZZLjava/util/List;Ljava/util/List;Lio/modelcontextprotocol/kotlin/sdk/server/EventStore;Lkotlin/time/Duration;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (ZZLjava/util/List;Ljava/util/List;Lio/modelcontextprotocol/kotlin/sdk/server/EventStore;Lkotlin/time/Duration;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAllowedHosts ()Ljava/util/List;
@@ -223,10 +220,6 @@ public final class io/modelcontextprotocol/kotlin/sdk/server/StreamableHttpServe
 	public final fun getEnableJsonResponse ()Z
 	public final fun getEventStore ()Lio/modelcontextprotocol/kotlin/sdk/server/EventStore;
 	public final fun getRetryInterval-FghU774 ()Lkotlin/time/Duration;
-}
-
-public final class io/modelcontextprotocol/kotlin/sdk/server/StreamableHttpServerTransport$Configuration$Companion {
-	public final fun getDefault ()Lio/modelcontextprotocol/kotlin/sdk/server/StreamableHttpServerTransport$Configuration;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/server/WebSocketMcpKtorServerExtensionsKt {

--- a/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/KtorServer.kt
+++ b/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/KtorServer.kt
@@ -225,11 +225,13 @@ private suspend fun RoutingContext.mcpStatelessStreamableHttpEndpoint(
     block: RoutingContext.() -> Server,
 ) {
     val transport = StreamableHttpServerTransport(
-        enableDnsRebindingProtection = enableDnsRebindingProtection,
-        allowedHosts = allowedHosts,
-        allowedOrigins = allowedOrigins,
-        eventStore = eventStore,
-        enableJsonResponse = true,
+        StreamableHttpServerTransport.Configuration(
+            enableDnsRebindingProtection = enableDnsRebindingProtection,
+            allowedHosts = allowedHosts,
+            allowedOrigins = allowedOrigins,
+            eventStore = eventStore,
+            enableJsonResponse = true,
+        ),
     ).also { it.setSessionIdGenerator(null) }
 
     logger.info { "New stateless StreamableHttp connection established without sessionId" }
@@ -305,11 +307,13 @@ private suspend fun RoutingContext.streamableTransport(
     }
 
     val transport = StreamableHttpServerTransport(
-        enableDnsRebindingProtection = enableDnsRebindingProtection,
-        allowedHosts = allowedHosts,
-        allowedOrigins = allowedOrigins,
-        eventStore = eventStore,
-        enableJsonResponse = true,
+        StreamableHttpServerTransport.Configuration(
+            enableDnsRebindingProtection = enableDnsRebindingProtection,
+            allowedHosts = allowedHosts,
+            allowedOrigins = allowedOrigins,
+            eventStore = eventStore,
+            enableJsonResponse = true,
+        ),
     )
 
     transport.setOnSessionInitialized { initializedSessionId ->

--- a/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/KtorServer.kt
+++ b/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/KtorServer.kt
@@ -228,7 +228,7 @@ private fun ServerSSESession.mcpSseTransport(
 }
 
 private suspend fun RoutingContext.mcpStatelessStreamableHttpEndpoint(
-    configuration: StreamableHttpServerTransport.Configuration,
+    configuration: StreamableHttpServerTransport.Configuration = StreamableHttpServerTransport.Configuration(),
     block: RoutingContext.() -> Server,
 ) {
     val transport = StreamableHttpServerTransport(

--- a/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/KtorServer.kt
+++ b/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/KtorServer.kt
@@ -92,6 +92,11 @@ public fun Route.mcp(block: ServerSSESession.() -> Server) {
     }
 }
 
+/**
+ * Configures the application to use Server-Sent Events (SSE) and sets up routing for the provided server logic.
+ *
+ * @param block A lambda function that defines the server logic within the context of a [ServerSSESession].
+ */
 @KtorDsl
 public fun Application.mcp(block: ServerSSESession.() -> Server) {
     install(SSE)
@@ -101,14 +106,20 @@ public fun Application.mcp(block: ServerSSESession.() -> Server) {
     }
 }
 
+/**
+ * Sets up HTTP endpoints for an application to support MCP streamable interactions
+ * using the Server-Sent Events (SSE) protocol and other HTTP methods.
+ *
+ * @param path The base URL path for the MCP streamable HTTP routes. Defaults to "/mcp".
+ * @param configuration An instance of `StreamableHttpServerTransport.Configuration` used to configure
+ * the behavior of the transport layer.
+ * @param block A lambda with a `RoutingContext` receiver, allowing the user to define server logic
+ * for handling streamable transport.
+ */
 @KtorDsl
-@Suppress("LongParameterList")
 public fun Application.mcpStreamableHttp(
     path: String = "/mcp",
-    enableDnsRebindingProtection: Boolean = false,
-    allowedHosts: List<String>? = null,
-    allowedOrigins: List<String>? = null,
-    eventStore: EventStore? = null,
+    configuration: StreamableHttpServerTransport.Configuration = StreamableHttpServerTransport.Configuration(),
     block: RoutingContext.() -> Server,
 ) {
     install(SSE)
@@ -125,10 +136,7 @@ public fun Application.mcpStreamableHttp(
             post {
                 val transport = streamableTransport(
                     transportManager = transportManager,
-                    enableDnsRebindingProtection = enableDnsRebindingProtection,
-                    allowedHosts = allowedHosts,
-                    allowedOrigins = allowedOrigins,
-                    eventStore = eventStore,
+                    configuration = configuration,
                     block = block,
                 )
                     ?: return@post
@@ -144,14 +152,19 @@ public fun Application.mcpStreamableHttp(
     }
 }
 
+/**
+ * Sets up a stateless and streamable HTTP endpoint within the application using the specified path and configuration.
+ * This method installs the SSE feature and defines specific routing behavior for HTTP methods.
+ *
+ * @param path The URL path where the endpoint will be accessible. Defaults to "/mcp".
+ * @param configuration The configuration object used to customize the behavior of the streamable HTTP server transport.
+ * @param block A lambda function that provides the routing context to define the server behavior.
+ */
 @KtorDsl
 @Suppress("LongParameterList")
 public fun Application.mcpStatelessStreamableHttp(
     path: String = "/mcp",
-    enableDnsRebindingProtection: Boolean = false,
-    allowedHosts: List<String>? = null,
-    allowedOrigins: List<String>? = null,
-    eventStore: EventStore? = null,
+    configuration: StreamableHttpServerTransport.Configuration = StreamableHttpServerTransport.Configuration(),
     block: RoutingContext.() -> Server,
 ) {
     install(SSE)
@@ -160,10 +173,7 @@ public fun Application.mcpStatelessStreamableHttp(
         route(path) {
             post {
                 mcpStatelessStreamableHttpEndpoint(
-                    enableDnsRebindingProtection = enableDnsRebindingProtection,
-                    allowedHosts = allowedHosts,
-                    allowedOrigins = allowedOrigins,
-                    eventStore = eventStore,
+                    configuration = configuration,
                     block = block,
                 )
             }
@@ -218,20 +228,11 @@ private fun ServerSSESession.mcpSseTransport(
 }
 
 private suspend fun RoutingContext.mcpStatelessStreamableHttpEndpoint(
-    enableDnsRebindingProtection: Boolean = false,
-    allowedHosts: List<String>? = null,
-    allowedOrigins: List<String>? = null,
-    eventStore: EventStore? = null,
+    configuration: StreamableHttpServerTransport.Configuration,
     block: RoutingContext.() -> Server,
 ) {
     val transport = StreamableHttpServerTransport(
-        StreamableHttpServerTransport.Configuration(
-            enableDnsRebindingProtection = enableDnsRebindingProtection,
-            allowedHosts = allowedHosts,
-            allowedOrigins = allowedOrigins,
-            eventStore = eventStore,
-            enableJsonResponse = true,
-        ),
+        configuration,
     ).also { it.setSessionIdGenerator(null) }
 
     logger.info { "New stateless StreamableHttp connection established without sessionId" }
@@ -294,10 +295,7 @@ private suspend fun existingStreamableTransport(
 
 private suspend fun RoutingContext.streamableTransport(
     transportManager: TransportManager,
-    enableDnsRebindingProtection: Boolean,
-    allowedHosts: List<String>?,
-    allowedOrigins: List<String>?,
-    eventStore: EventStore?,
+    configuration: StreamableHttpServerTransport.Configuration,
     block: RoutingContext.() -> Server,
 ): StreamableHttpServerTransport? {
     val sessionId = call.request.sessionId()
@@ -306,15 +304,7 @@ private suspend fun RoutingContext.streamableTransport(
         return transport ?: existingStreamableTransport(call, transportManager)
     }
 
-    val transport = StreamableHttpServerTransport(
-        StreamableHttpServerTransport.Configuration(
-            enableDnsRebindingProtection = enableDnsRebindingProtection,
-            allowedHosts = allowedHosts,
-            allowedOrigins = allowedOrigins,
-            eventStore = eventStore,
-            enableJsonResponse = true,
-        ),
-    )
+    val transport = StreamableHttpServerTransport(configuration)
 
     transport.setOnSessionInitialized { initializedSessionId ->
         transportManager.addTransport(initializedSessionId, transport)

--- a/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/StreamableHttpServerTransport.kt
+++ b/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/StreamableHttpServerTransport.kt
@@ -72,8 +72,7 @@ private data class SessionContext(val session: ServerSSESession?, val call: Appl
  */
 @OptIn(ExperimentalUuidApi::class, ExperimentalAtomicApi::class)
 @Suppress("TooManyFunctions")
-public class StreamableHttpServerTransport(private val configuration: Configuration = Configuration.Default) :
-    AbstractTransport() {
+public class StreamableHttpServerTransport(private val configuration: Configuration) : AbstractTransport() {
 
     /**
      * Secondary constructor for `StreamableHttpServerTransport` that simplifies initialization by directly taking the
@@ -142,11 +141,7 @@ public class StreamableHttpServerTransport(private val configuration: Configurat
         public val allowedOrigins: List<String>? = null,
         public val eventStore: EventStore? = null,
         public val retryInterval: Duration? = null,
-    ) {
-        public companion object {
-            public val Default: Configuration = Configuration()
-        }
-    }
+    )
 
     public var sessionId: String? = null
         private set


### PR DESCRIPTION
# refactor: replace flat parameter definitions with `StreamableHttpServerTransport.Configuration` in Application Ktor extensions

Simplified `Application.mcp*StreamableHttp`  functions by replacing individual parameters with the typed `StreamableHttpServerTransport.Configuration` for improved extensibility and performance.

Includes #560

## Motivation and Context
See #562, #560 see thr comment: https://github.com/modelcontextprotocol/kotlin-sdk/pull/560#discussion_r2841880854

## How Has This Been Tested?
Regression test

## Breaking Changes
No, it is safe. #562 was not shipped yet.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

