### PR TITLE
fix: fix SseTransport endpoint resolution (#329)

### DIFF
--- a/kotlin-sdk-client/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/client/sse/MockSseClientEngine.kt
+++ b/kotlin-sdk-client/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/client/sse/MockSseClientEngine.kt
@@ -50,7 +50,7 @@ internal open class MockSseClientEngine(
 
     override fun close() {
         channel.close()
-        job.complete()
+        job.cancel()
     }
 
     private fun responseContext(): CoroutineContext = dispatcher + Job()

--- a/kotlin-sdk-client/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/client/sse/SseClientTransportTest.kt
+++ b/kotlin-sdk-client/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/client/sse/SseClientTransportTest.kt
@@ -64,6 +64,32 @@ class SseClientTransportTest {
         engine.close()
     }
 
+    @Test
+    fun `full url endpoint is used as-is`() = runTest {
+        // Given
+        val sseUrl = "http://example.com/api/mcp/sse"
+
+        // And
+        val endpointEvent = "https://example.com/messages?sessionId=abc"
+
+        // And
+        val engine = CapturingSseClientEngine(endpoint = endpointEvent)
+        val transport = sseTransport(sseUrl, engine)
+
+        // When
+        transport.start()
+        transport.send(JSONRPCNotification(method = "test"))
+
+        // Then
+        val capturedPosts = engine.capturedPosts
+        capturedPosts shouldHaveSize 1
+        capturedPosts[0].url.toString() shouldBe "https://example.com/messages?sessionId=abc"
+
+        // Cleanup
+        transport.close()
+        engine.close()
+    }
+
     private fun sseTransport(sseUrl: String, engine: CapturingSseClientEngine) =
         SseClientTransport(HttpClient(engine) { install(SSE) }, sseUrl)
 


### PR DESCRIPTION
## Summary
Fix SSE endpoint resolution so absolute paths resolve against the origin, and add tests covering absolute vs relative endpoint events.

## Motivation and Context
The SSE transport currently resolves all endpoint events against the SSE URL’s base path. When the server sends an absolute endpoint (starting with `/`), the client incorrectly prefixes it with the SSE path. This change resolves absolute endpoints against the origin while keeping relative behavior unchanged.

addresses: https://github.com/modelcontextprotocol/kotlin-sdk/issues/329

## How Has This Been Tested?
Unit tests added in `SseClientTransportTest` for absolute and relative endpoint events.

## Breaking Changes
No.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
The endpoint resolution logic now treats paths starting with `/` as origin-relative. Relative paths continue to resolve against the SSE base URL.
