### PR TITLE
refactor: refactor Streamable HTTP ktor extensions (#562)

### DIFF
--- a/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/KtorServer.kt
+++ b/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/KtorServer.kt
@@ -98,16 +98,6 @@ public fun Application.mcp(block: ServerSSESession.() -> Server) {
     }
 }
 
-/**
- * Configures the Ktor Application to handle Model Context Protocol (MCP)
- * over [Streamable HTTP Transport](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#streamable-http)
- *
- * This method sets up server-sent events (SSE) along with HTTP POST and DELETE endpoints at the specified [path].
- *
- * @param path The base route path for the MCP Streamable HTTP endpoint. Defaults to "/mcp".
- * @param configuration The transport configuration for the streamable HTTP server.
- * @param block A handler block that provides the routing context to initialize the server.
- */
 private fun Application.mcpStreamableHttp(
     path: String = "/mcp",
     configuration: StreamableHttpServerTransport.Configuration,
@@ -182,18 +172,6 @@ public fun Application.mcpStreamableHttp(
     )
 }
 
-/**
- *  Configures the Ktor Application to handle Model Context Protocol (MCP)
- *  over _stateless_ [Streamable HTTP Transport](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#streamable-http)
-
- * This method sets up server-sent events (SSE) along with HTTP POST and DELETE endpoints at the specified [path].
- *
- * @param path The URL path where the MCP streamable HTTP endpoint will be available. Default is "/mcp".
- * @param configuration Configuration for the streamable HTTP server transport, including behavior and settings.
- * @param block A lambda expression that defines the server behavior in the context of the routing configuration.
- *
- * @see [Session Management](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#session-management)
- */
 private fun Application.mcpStatelessStreamableHttp(
     path: String = "/mcp",
     configuration: StreamableHttpServerTransport.Configuration,

--- a/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/TransportManager.kt
+++ b/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/TransportManager.kt
@@ -10,8 +10,6 @@ import kotlinx.collections.immutable.toPersistentMap
 internal class TransportManager<T : AbstractTransport> {
     private val transports: AtomicRef<PersistentMap<String, T>> = atomic(emptyMap<String, T>().toPersistentMap())
 
-    fun hasTransport(sessionId: String): Boolean = transports.value.containsKey(sessionId)
-
     fun getTransport(sessionId: String): T? = transports.value[sessionId]
 
     fun addTransport(sessionId: String, transport: T) {


### PR DESCRIPTION
- Extract TransportManager into its own file and introduce generics for improved type safety. Remove unused method `TransportManager.hasTransport` 
- Streamline MCP protocol configuration with `StreamableHttpServerTransport.Configuration`: refactored `mcpStatelessStreamableHttp` to use `StreamableHttpServerTransport.Configuration`; Introduced additional overloads of MCP routing functions.
- Added missing KDoc comments.

## Motivation and Context

Address the issue when StreamableHttpServerTransport.Configuration is created on every post invocation

## How Has This Been Tested?
Regression tests. No public api changes

## Breaking Changes
None

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

#521
