### PR TITLE
ci: add Codecov coverage upload and XML report generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         include:
           - os: ubuntu-latest
             job-name: "Linux Tests"
-            gradle-tasks: "build ktlintCheck koverLog koverHtmlReport publishToMavenLocal -Pversion=1-SNAPSHOT"
+            gradle-tasks: "build ktlintCheck koverLog koverHtmlReport koverXmlReport publishToMavenLocal -Pversion=1-SNAPSHOT"
             max-workers: 3
 
           - os: windows-latest
@@ -106,6 +106,24 @@ jobs:
           include_time_in_summary: true
           report_paths: '**/test-results/**/TEST-*.xml'
           truncate_stack_traces: false
+
+      - name: Upload coverage reports to Codecov
+        if: matrix.os == 'ubuntu-latest'
+        uses: codecov/codecov-action@v5
+        with:
+          directory: ./build/reports/kover
+          files: report.xml
+
+      - name: Upload coverage reports to Codecov
+        if: ${{ !cancelled() && matrix.os == 'ubuntu-latest' }}
+        uses: codecov/codecov-action@v5
+        with:
+          directory: ./build/reports/kover
+          files: report.xml
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() && matrix.os == 'ubuntu-latest' }}
+        uses: codecov/test-results-action@v1
 
       - name: Archive Maven Local Repository
         if: ${{ success() && matrix.os == 'ubuntu-latest' }}

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Maven Central](https://img.shields.io/maven-central/v/io.modelcontextprotocol/kotlin-sdk.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/io.modelcontextprotocol/kotlin-sdk)
 [![Build](https://github.com/modelcontextprotocol/kotlin-sdk/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/modelcontextprotocol/kotlin-sdk/actions/workflows/build.yml)
 [![Conformance Tests](https://github.com/modelcontextprotocol/kotlin-sdk/actions/workflows/conformance.yml/badge.svg)](https://github.com/modelcontextprotocol/kotlin-sdk/actions/workflows/conformance.yml)
+[![codecov](https://codecov.io/github/modelcontextprotocol/kotlin-sdk/graph/badge.svg?token=O2CFHNSFYM)](https://codecov.io/github/modelcontextprotocol/kotlin-sdk)
+
 [![Kotlin](https://img.shields.io/badge/kotlin-2.2+-blueviolet.svg?logo=kotlin)](http://kotlinlang.org)
 [![Kotlin Multiplatform](https://img.shields.io/badge/Platforms-%20JVM%20%7C%20Wasm%2FJS%20%7C%20Native%20-blueviolet?logo=kotlin)](https://kotlinlang.org/docs/multiplatform.html)
 [![JVM](https://img.shields.io/badge/JVM-11+-red.svg?logo=jvm)](http://java.com)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,51 @@
+# Codecov configuration for Mokksy and AI-Mocks
+# https://docs.codecov.com/docs/codecov-yaml
+
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+
+comment:
+  layout: "header, diff, flags, components"
+  behavior: default
+  require_changes: true
+
+component_management:
+  default_rules:
+    statuses:
+      - type: project
+        target: auto
+  individual_components:
+
+    - component_id: kotlin-sdk-core
+      name: SDK Core
+      paths:
+        - kotlin-sdk-core/**
+
+    - component_id: kotlin-sdk-client
+      name: SDK Client
+      paths:
+        - kotlin-sdk-client/**
+
+    - component_id: kotlin-sdk-server
+      name: SDK Server
+      paths:
+        - kotlin-sdk-server/**
+
+    - component_id: kotlin-sdk-testing
+      name: SDK Testing
+      paths:
+        - kotlin-sdk-testing/**
+


### PR DESCRIPTION
## Add Codecov coverage upload and XML report generation

- Add `koverXmlReport` to Gradle tasks in Ubuntu workflow
- Configure Codecov action to upload coverage reports

Reports will be available on https://app.codecov.io/gh/modelcontextprotocol/kotlin-sdk

## Motivation and Context
To provide better test coverage visibility

## How Has This Been Tested?
CI

## Breaking Changes
No

## Types of changes
- [x] CI update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
