### PR TITLE
ci: update Codecov configuration for test and coverage upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,22 +108,21 @@ jobs:
           truncate_stack_traces: false
 
       - name: Upload coverage reports to Codecov
-        if: matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v5
-        with:
-          directory: ./build/reports/kover
-          files: report.xml
-
-      - name: Upload coverage reports to Codecov
         if: ${{ !cancelled() && matrix.os == 'ubuntu-latest' }}
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          report_type: coverage
           directory: ./build/reports/kover
           files: report.xml
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() && matrix.os == 'ubuntu-latest' }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          report_type: test_results
+
 
       - name: Archive Maven Local Repository
         if: ${{ success() && matrix.os == 'ubuntu-latest' }}


### PR DESCRIPTION
ci: update Codecov configuration for test and coverage upload

- Unified usage of `codecov/codecov-action@v5` for both test results and coverage upload.
- Added `CODECOV_TOKEN` and `report_type` parameters for improved configuration.

## Motivation and Context

Actually, CODECOV_TOKEN is required, even though the CodeCov banner previously said the project can upload without a token.

## How Has This Been Tested?
CI

## Breaking Changes
No

## Types of changes

- [x] CI fix 

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
