### PR TITLE
fix(stdio): #573, #574 customize dispatchers & scope for stdio server transport configuration

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -14,6 +14,10 @@ complexity:
   LongMethod:
     excludes: *testFolders
 
+coroutines:
+  InjectDispatcher:
+    excludes: *testFolders
+
 empty-blocks:
   EmptyFunctionBlock:
     excludes: *testFolders

--- a/integration-test/detekt-baseline-test.xml
+++ b/integration-test/detekt-baseline-test.xml
@@ -8,17 +8,6 @@
     <ID>AbstractClassCanBeConcreteClass:BaseTransportTest.kt:BaseTransportTest$BaseTransportTest</ID>
     <ID>CyclomaticComplexMethod:AbstractToolIntegrationTest.kt:AbstractToolIntegrationTest$private fun setupCalculatorTool</ID>
     <ID>ForbiddenComment:StdioClientTransportTest.kt:StdioClientTransportTest$// TODO: fix running on windows</ID>
-    <ID>InjectDispatcher:AbstractKotlinClientTsServerTest.kt:AbstractKotlinClientTsServerTest$IO</ID>
-    <ID>InjectDispatcher:AbstractPromptIntegrationTest.kt:AbstractPromptIntegrationTest$IO</ID>
-    <ID>InjectDispatcher:AbstractResourceIntegrationTest.kt:AbstractResourceIntegrationTest$IO</ID>
-    <ID>InjectDispatcher:AbstractToolIntegrationTest.kt:AbstractToolIntegrationTest$IO</ID>
-    <ID>InjectDispatcher:KotlinClientTsServerEdgeCasesTestSse.kt:KotlinClientTsServerEdgeCasesTestSse$IO</ID>
-    <ID>InjectDispatcher:KotlinClientTsServerEdgeCasesTestStdio.kt:KotlinClientTsServerEdgeCasesTestStdio$IO</ID>
-    <ID>InjectDispatcher:SseIntegrationTest.kt:SseIntegrationTest$IO</ID>
-    <ID>InjectDispatcher:StdioClientTransportTest.kt:StdioClientTransportTest$IO</ID>
-    <ID>InjectDispatcher:StreamableHttpIntegrationTest.kt:StreamableHttpIntegrationTest$IO</ID>
-    <ID>InjectDispatcher:TsEdgeCasesTestSse.kt:TsEdgeCasesTestSse$IO</ID>
-    <ID>InjectDispatcher:WebSocketIntegrationTest.kt:WebSocketIntegrationTest$IO</ID>
     <ID>MatchingDeclarationName:PromptIntegrationTestSse.kt:SchemaPromptIntegrationTestSse : AbstractPromptIntegrationTest</ID>
     <ID>SleepInsteadOfDelay:KotlinServerForTsClientSse.kt:KotlinServerForTsClient$sleep(500)</ID>
     <ID>ThrowsCount:AbstractPromptIntegrationTest.kt:AbstractPromptIntegrationTest$override fun configureServer</ID>

--- a/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/AbstractAuthenticationTest.kt
+++ b/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/AbstractAuthenticationTest.kt
@@ -42,7 +42,6 @@ import io.ktor.server.sse.SSE as ServerSSE
 /**
  * Base class for MCP authentication integration tests.
  */
-@Suppress("InjectDispatcher")
 abstract class AbstractAuthenticationTest {
 
     protected companion object {

--- a/kotlin-sdk-client/detekt-baseline-test.xml
+++ b/kotlin-sdk-client/detekt-baseline-test.xml
@@ -4,8 +4,6 @@
   <CurrentIssues>
     <ID>AbstractClassCanBeConcreteClass:AbstractStreamableHttpClientTest.kt:AbstractStreamableHttpClientTest$AbstractStreamableHttpClientTest</ID>
     <ID>ForbiddenComment:StreamableHttpClientTest.kt:StreamableHttpClientTest$// TODO: how to get notifications via Client API?</ID>
-    <ID>InjectDispatcher:StdioClientTransportErrorHandlingTest.kt:StdioClientTransportErrorHandlingTest$IO</ID>
-    <ID>InjectDispatcher:StreamableHttpClientTransportTest.kt:StreamableHttpClientTransportTest$Default</ID>
     <ID>LongParameterList:MockMcp.kt:MockMcp$fun handleJSONRPCRequest</ID>
     <ID>LongParameterList:MockMcp.kt:MockMcp$fun handleWithResult</ID>
     <ID>LongParameterList:MockMcp.kt:MockMcp$fun onInitialize</ID>

--- a/kotlin-sdk-server/api/kotlin-sdk-server.api
+++ b/kotlin-sdk-server/api/kotlin-sdk-server.api
@@ -186,33 +186,12 @@ public final class io/modelcontextprotocol/kotlin/sdk/server/SseServerTransport 
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/server/StdioServerTransport : io/modelcontextprotocol/kotlin/sdk/shared/AbstractTransport {
-	public fun <init> (Lkotlin/jvm/functions/Function1;)V
 	public fun <init> (Lkotlinx/io/Source;Lkotlinx/io/Sink;)V
+	public fun <init> (Lkotlinx/io/Source;Lkotlinx/io/Sink;JLkotlinx/coroutines/channels/Channel;Lkotlinx/coroutines/channels/Channel;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlinx/coroutines/CoroutineScope;)V
+	public synthetic fun <init> (Lkotlinx/io/Source;Lkotlinx/io/Sink;JLkotlinx/coroutines/channels/Channel;Lkotlinx/coroutines/channels/Channel;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun send (Lio/modelcontextprotocol/kotlin/sdk/types/JSONRPCMessage;Lio/modelcontextprotocol/kotlin/sdk/shared/TransportSendOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun start (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public final class io/modelcontextprotocol/kotlin/sdk/server/StdioServerTransport$Configuration {
-	public fun <init> ()V
-	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
-	public final fun getProcessingJobDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
-	public final fun getReadBufferSize ()J
-	public final fun getReadChannelBufferSize ()I
-	public final fun getReadingJobDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
-	public final fun getSink ()Lkotlinx/io/Sink;
-	public final fun getSource ()Lkotlinx/io/Source;
-	public final fun getWriteChannelBufferSize ()I
-	public final fun getWritingJobDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
-	public final fun setCoroutineScope (Lkotlinx/coroutines/CoroutineScope;)V
-	public final fun setProcessingJobDispatcher (Lkotlinx/coroutines/CoroutineDispatcher;)V
-	public final fun setReadBufferSize (J)V
-	public final fun setReadChannelBufferSize (I)V
-	public final fun setReadingJobDispatcher (Lkotlinx/coroutines/CoroutineDispatcher;)V
-	public final fun setSink (Lkotlinx/io/Sink;)V
-	public final fun setSource (Lkotlinx/io/Source;)V
-	public final fun setWriteChannelBufferSize (I)V
-	public final fun setWritingJobDispatcher (Lkotlinx/coroutines/CoroutineDispatcher;)V
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/server/StreamableHttpServerTransport : io/modelcontextprotocol/kotlin/sdk/shared/AbstractTransport {

--- a/kotlin-sdk-server/api/kotlin-sdk-server.api
+++ b/kotlin-sdk-server/api/kotlin-sdk-server.api
@@ -186,10 +186,33 @@ public final class io/modelcontextprotocol/kotlin/sdk/server/SseServerTransport 
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/server/StdioServerTransport : io/modelcontextprotocol/kotlin/sdk/shared/AbstractTransport {
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
 	public fun <init> (Lkotlinx/io/Source;Lkotlinx/io/Sink;)V
 	public fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun send (Lio/modelcontextprotocol/kotlin/sdk/types/JSONRPCMessage;Lio/modelcontextprotocol/kotlin/sdk/shared/TransportSendOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun start (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/modelcontextprotocol/kotlin/sdk/server/StdioServerTransport$Configuration {
+	public fun <init> ()V
+	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
+	public final fun getProcessingJobDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
+	public final fun getReadBufferSize ()J
+	public final fun getReadChannelBufferSize ()I
+	public final fun getReadingJobDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
+	public final fun getSink ()Lkotlinx/io/Sink;
+	public final fun getSource ()Lkotlinx/io/Source;
+	public final fun getWriteChannelBufferSize ()I
+	public final fun getWritingJobDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
+	public final fun setCoroutineScope (Lkotlinx/coroutines/CoroutineScope;)V
+	public final fun setProcessingJobDispatcher (Lkotlinx/coroutines/CoroutineDispatcher;)V
+	public final fun setReadBufferSize (J)V
+	public final fun setReadChannelBufferSize (I)V
+	public final fun setReadingJobDispatcher (Lkotlinx/coroutines/CoroutineDispatcher;)V
+	public final fun setSink (Lkotlinx/io/Sink;)V
+	public final fun setSource (Lkotlinx/io/Source;)V
+	public final fun setWriteChannelBufferSize (I)V
+	public final fun setWritingJobDispatcher (Lkotlinx/coroutines/CoroutineDispatcher;)V
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/server/StreamableHttpServerTransport : io/modelcontextprotocol/kotlin/sdk/shared/AbstractTransport {

--- a/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/StdioServerTransport.kt
+++ b/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/StdioServerTransport.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -25,7 +25,6 @@ import kotlinx.io.Source
 import kotlinx.io.buffered
 import kotlinx.io.readByteArray
 import kotlinx.io.writeString
-import kotlin.concurrent.Volatile
 import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
@@ -34,101 +33,66 @@ private const val READ_BUFFER_SIZE = 8192L
 /**
  * A server transport that communicates with a client via standard I/O.
  *
- * Reads from input [Source] and writes to output [Sink].
+ * [StdioServerTransport] manages the communication between a JSON-RPC server and its clients
+ * by reading incoming messages from the specified [Source] (input stream) and writing outgoing
+ * messages to the [Sink] (output stream).
  *
  * Example:
  * ```kotlin
- * val transport = StdioServerTransport {
- *   source = System.`in`.asInput(),
- *   sink =  System.out.asSink(),
- * }
+ * val transport = StdioServerTransport(
+ *   source = System.`in`.asInput()
+ *   sink =  System.out.asSink()
+ * )
  * ```
  *
- * @constructor Initializes the transport using the provided block for [Configuration].
- * The configuration includes specifying the input and output streams, buffer sizes,
- * and dispatchers for I/O and processing tasks and coroutine scope.
+ * @constructor Creates an instance of [StdioServerTransport] with the specified parameters.
+ * @property source The source for reading incoming messages (e.g., stdin or other readable stream).
+ * @param sink The sink for writing outgoing messages (e.g., stdout or other writable stream).
+ * @property readBufferSize The maximum size of the read buffer, defaults to a pre-configured constant.
+ * @property readChannel The channel for receiving raw byte arrays from the input stream.
+ * @property writeChannel The channel for sending serialized JSON-RPC messages to the output stream.
+ * @property readingJobDispatcher The dispatcher to use for the message-reading coroutine.
+ * @property writingJobDispatcher The dispatcher to use for the message-writing coroutine.
+ * @property processingJobDispatcher The dispatcher to handle processing of read messages.
+ * @param coroutineScope Optional coroutine scope to use for managing internal jobs. A new scope
+ *              will be created if not provided.
  */
 @OptIn(ExperimentalAtomicApi::class)
-public class StdioServerTransport(block: Configuration.() -> Unit) : AbstractTransport() {
+@Suppress("LongParameterList")
+public class StdioServerTransport(
+    private val source: Source,
+    sink: Sink,
+    private val readBufferSize: Long = READ_BUFFER_SIZE,
+    private val readChannel: Channel<ByteArray> = Channel(Channel.UNLIMITED),
+    private val writeChannel: Channel<JSONRPCMessage> = Channel(Channel.UNLIMITED),
+    private var readingJobDispatcher: CoroutineDispatcher = IODispatcher,
+    private var writingJobDispatcher: CoroutineDispatcher = IODispatcher,
+    private var processingJobDispatcher: CoroutineDispatcher = Dispatchers.Default,
+    coroutineScope: CoroutineScope? = null,
+) : AbstractTransport() {
 
-    /**
-     * Configuration for [StdioServerTransport].
-     *
-     * @property source The input [Source] used to receive data.
-     * @property sink The output [Sink] used to send data.
-     * @property readBufferSize The buffer size for the read channel.
-     * @property readingJobDispatcher The [CoroutineDispatcher] used for reading jobs.
-     *      Defaults to [IODispatcher].
-     * @property writingJobDispatcher The [CoroutineDispatcher] used for writing jobs.
-     *      Defaults to [IODispatcher].
-     * @property processingJobDispatcher The [CoroutineDispatcher] used for processing jobs.
-     *      Defaults to [Dispatchers.Default].
-     * @property readChannelBufferSize The buffer size for the read channel.
-     * @property writeChannelBufferSize The buffer size for the write channel.
-     * @property coroutineScope The [CoroutineScope] used for managing coroutines.
-     */
-    @Suppress("LongParameterList")
-    public class Configuration internal constructor(
-        public var source: Source? = null,
-        public var sink: Sink? = null,
-        public var readBufferSize: Long = READ_BUFFER_SIZE,
-        public var readingJobDispatcher: CoroutineDispatcher = IODispatcher,
-        public var writingJobDispatcher: CoroutineDispatcher = IODispatcher,
-        public var processingJobDispatcher: CoroutineDispatcher = Dispatchers.Default,
-        public var readChannelBufferSize: Int = Channel.UNLIMITED,
-        public var writeChannelBufferSize: Int = Channel.UNLIMITED,
-        public var coroutineScope: CoroutineScope? = null,
-    )
-
-    private val source: Source
-    private val sink: Sink
-    private val processingJobDispatcher: CoroutineDispatcher
-    private val readingJobDispatcher: CoroutineDispatcher
-    private val writingJobDispatcher: CoroutineDispatcher
     private val scope: CoroutineScope
-    private val readBufferSize: Long
-    private val readChannel: Channel<ByteArray>
-    private val writeChannel: Channel<JSONRPCMessage>
+    private val sink: Sink
 
     init {
-        val config = Configuration().apply(block)
-        val input = requireNotNull(config.source) { "source is required" }
-        val output = requireNotNull(config.sink) { "sink is required" }
-        require(config.readBufferSize > 0) { "readBufferSize must be > 0" }
-
-        source = input
-        processingJobDispatcher = config.processingJobDispatcher
-        readingJobDispatcher = config.readingJobDispatcher
-        writingJobDispatcher = config.writingJobDispatcher
-        val parentJob = config.coroutineScope?.coroutineContext?.get(Job)
+        require(readBufferSize > 0) { "readBufferSize must be > 0" }
+        val parentJob = coroutineScope?.coroutineContext?.get(Job)
         scope = CoroutineScope(SupervisorJob(parentJob))
-        readBufferSize = config.readBufferSize
-        readChannel = Channel(config.readChannelBufferSize)
-        writeChannel = Channel(config.writeChannelBufferSize)
-        sink = output.buffered()
+        this.sink = sink.buffered()
     }
 
     /**
      * Creates a new instance of [StdioServerTransport]
      * with the given [inputStream] [Source] and [outputStream] [Sink].
      */
-    public constructor(inputStream: Source, outputStream: Sink) : this({
-        source = inputStream
-        sink = outputStream
-    })
+    public constructor(inputStream: Source, outputStream: Sink) : this(
+        source = inputStream,
+        sink = outputStream,
+    )
 
     private val logger = KotlinLogging.logger {}
     private val readBuffer = ReadBuffer()
     private val initialized: AtomicBoolean = AtomicBoolean(false)
-
-    @Volatile
-    private var readingJob: Job? = null
-
-    @Volatile
-    private var sendingJob: Job? = null
-
-    @Volatile
-    private var processingJob: Job? = null
 
     override suspend fun start() {
         if (!initialized.compareAndSet(expectedValue = false, newValue = true)) {
@@ -136,13 +100,13 @@ public class StdioServerTransport(block: Configuration.() -> Unit) : AbstractTra
         }
 
         // Launch a coroutine to read from stdin
-        readingJob = launchReadingJob()
+        launchReadingJob()
 
         // Launch a coroutine to process messages from readChannel
-        processingJob = launchProcessingJob()
+        launchProcessingJob()
 
         // Launch a coroutine to handle message sending
-        sendingJob = launchSendingJob()
+        launchSendingJob()
     }
 
     private fun launchReadingJob(): Job = scope.launch(readingJobDispatcher) {
@@ -186,7 +150,9 @@ public class StdioServerTransport(block: Configuration.() -> Unit) : AbstractTra
             _onError.invoke(e)
         }
     }.apply {
-        invokeOnCompletion { logJobCompletion("Processing", it) }
+        invokeOnCompletion { cause ->
+            logJobCompletion("Processing", cause)
+        }
     }
 
     private fun launchSendingJob(): Job = scope.launch(writingJobDispatcher) {
@@ -207,7 +173,7 @@ public class StdioServerTransport(block: Configuration.() -> Unit) : AbstractTra
         invokeOnCompletion { cause ->
             logJobCompletion("Message sending", cause)
             if (cause is CancellationException) {
-                readingJob?.cancel(cause)
+                readChannel.cancel(cause)
             }
         }
     }
@@ -255,22 +221,21 @@ public class StdioServerTransport(block: Configuration.() -> Unit) : AbstractTra
 
         withContext(NonCancellable) {
             writeChannel.close()
-            sendingJob?.cancelAndJoin()
 
             runCatching {
                 source.close()
             }.onFailure { logger.warn(it) { "Failed to close stdin" } }
 
-            readingJob?.cancel()
             readChannel.close()
-
-            processingJob?.cancelAndJoin()
 
             readBuffer.clear()
             runCatching {
                 sink.flush()
                 sink.close()
             }.onFailure { logger.warn(it) { "Failed to close stdout" } }
+
+            scope.cancel()
+            scope.coroutineContext[Job]?.join()
 
             invokeOnCloseCallback()
         }

--- a/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/StdioServerTransport.kt
+++ b/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/StdioServerTransport.kt
@@ -8,7 +8,9 @@ import io.modelcontextprotocol.kotlin.sdk.shared.TransportSendOptions
 import io.modelcontextprotocol.kotlin.sdk.shared.serializeMessage
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCMessage
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
@@ -23,9 +25,9 @@ import kotlinx.io.Source
 import kotlinx.io.buffered
 import kotlinx.io.readByteArray
 import kotlinx.io.writeString
+import kotlin.concurrent.Volatile
 import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
-import kotlin.coroutines.CoroutineContext
 
 private const val READ_BUFFER_SIZE = 8192L
 
@@ -34,25 +36,99 @@ private const val READ_BUFFER_SIZE = 8192L
  *
  * Reads from input [Source] and writes to output [Sink].
  *
- * @constructor Creates a new instance of [StdioServerTransport].
- * @param inputStream The input [Source] used to receive data.
- * @param outputStream The output [Sink] used to send data.
+ * Example:
+ * ```kotlin
+ * val transport = StdioServerTransport {
+ *   source = System.`in`.asInput(),
+ *   sink =  System.out.asSink(),
+ * }
+ * ```
+ *
+ * @constructor Initializes the transport using the provided block for [Configuration].
+ * The configuration includes specifying the input and output streams, buffer sizes,
+ * and dispatchers for I/O and processing tasks and coroutine scope.
  */
 @OptIn(ExperimentalAtomicApi::class)
-public class StdioServerTransport(private val inputStream: Source, outputStream: Sink) : AbstractTransport() {
+public class StdioServerTransport(block: Configuration.() -> Unit) : AbstractTransport() {
+
+    /**
+     * Configuration for [StdioServerTransport].
+     *
+     * @property source The input [Source] used to receive data.
+     * @property sink The output [Sink] used to send data.
+     * @property readBufferSize The buffer size for the read channel.
+     * @property readingJobDispatcher The [CoroutineDispatcher] used for reading jobs.
+     *      Defaults to [IODispatcher].
+     * @property writingJobDispatcher The [CoroutineDispatcher] used for writing jobs.
+     *      Defaults to [IODispatcher].
+     * @property processingJobDispatcher The [CoroutineDispatcher] used for processing jobs.
+     *      Defaults to [Dispatchers.Default].
+     * @property readChannelBufferSize The buffer size for the read channel.
+     * @property writeChannelBufferSize The buffer size for the write channel.
+     * @property coroutineScope The [CoroutineScope] used for managing coroutines.
+     */
+    @Suppress("LongParameterList")
+    public class Configuration internal constructor(
+        public var source: Source? = null,
+        public var sink: Sink? = null,
+        public var readBufferSize: Long = READ_BUFFER_SIZE,
+        public var readingJobDispatcher: CoroutineDispatcher = IODispatcher,
+        public var writingJobDispatcher: CoroutineDispatcher = IODispatcher,
+        public var processingJobDispatcher: CoroutineDispatcher = Dispatchers.Default,
+        public var readChannelBufferSize: Int = Channel.UNLIMITED,
+        public var writeChannelBufferSize: Int = Channel.UNLIMITED,
+        public var coroutineScope: CoroutineScope? = null,
+    )
+
+    private val source: Source
+    private val sink: Sink
+    private val processingJobDispatcher: CoroutineDispatcher
+    private val readingJobDispatcher: CoroutineDispatcher
+    private val writingJobDispatcher: CoroutineDispatcher
+    private val scope: CoroutineScope
+    private val readBufferSize: Long
+    private val readChannel: Channel<ByteArray>
+    private val writeChannel: Channel<JSONRPCMessage>
+
+    init {
+        val config = Configuration().apply(block)
+        val input = requireNotNull(config.source) { "source is required" }
+        val output = requireNotNull(config.sink) { "sink is required" }
+        require(config.readBufferSize > 0) { "readBufferSize must be > 0" }
+
+        source = input
+        processingJobDispatcher = config.processingJobDispatcher
+        readingJobDispatcher = config.readingJobDispatcher
+        writingJobDispatcher = config.writingJobDispatcher
+        val parentJob = config.coroutineScope?.coroutineContext?.get(Job)
+        scope = CoroutineScope(SupervisorJob(parentJob))
+        readBufferSize = config.readBufferSize
+        readChannel = Channel(config.readChannelBufferSize)
+        writeChannel = Channel(config.writeChannelBufferSize)
+        sink = output.buffered()
+    }
+
+    /**
+     * Creates a new instance of [StdioServerTransport]
+     * with the given [inputStream] [Source] and [outputStream] [Sink].
+     */
+    public constructor(inputStream: Source, outputStream: Sink) : this({
+        source = inputStream
+        sink = outputStream
+    })
 
     private val logger = KotlinLogging.logger {}
     private val readBuffer = ReadBuffer()
     private val initialized: AtomicBoolean = AtomicBoolean(false)
-    private var readingJob: Job? = null
-    private var sendingJob: Job? = null
-    private var processingJob: Job? = null
 
-    private val coroutineContext: CoroutineContext = IODispatcher + SupervisorJob()
-    private val scope = CoroutineScope(coroutineContext)
-    private val readChannel = Channel<ByteArray>(Channel.UNLIMITED)
-    private val writeChannel = Channel<JSONRPCMessage>(Channel.UNLIMITED)
-    private val outputSink = outputStream.buffered()
+    @Volatile
+    private var readingJob: Job? = null
+
+    @Volatile
+    private var sendingJob: Job? = null
+
+    @Volatile
+    private var processingJob: Job? = null
 
     override suspend fun start() {
         if (!initialized.compareAndSet(expectedValue = false, newValue = true)) {
@@ -69,81 +145,71 @@ public class StdioServerTransport(private val inputStream: Source, outputStream:
         sendingJob = launchSendingJob()
     }
 
-    private fun launchReadingJob(): Job {
-        val job = scope.launch {
-            val buf = Buffer()
-            @Suppress("TooGenericExceptionCaught")
-            try {
-                while (isActive) {
-                    val bytesRead = inputStream.readAtMostTo(buf, READ_BUFFER_SIZE)
-                    if (bytesRead == -1L) {
-                        // EOF reached
-                        break
-                    }
-                    if (bytesRead > 0) {
-                        val chunk = buf.readByteArray()
-                        readChannel.send(chunk)
-                    }
+    private fun launchReadingJob(): Job = scope.launch(readingJobDispatcher) {
+        val buf = Buffer()
+        @Suppress("TooGenericExceptionCaught")
+        try {
+            while (isActive) {
+                val bytesRead = source.readAtMostTo(buf, readBufferSize)
+                if (bytesRead == -1L) {
+                    // EOF reached
+                    break
                 }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Throwable) {
-                logger.error(e) { "Error reading from stdin" }
-                _onError.invoke(e)
-            } finally {
-                // Reached EOF or error, close connection
-                close()
+                if (bytesRead > 0) {
+                    val chunk = buf.readByteArray()
+                    readChannel.send(chunk)
+                }
             }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            logger.error(e) { "Error reading from stdin" }
+            _onError.invoke(e)
+        } finally {
+            // Reached EOF or error, close connection
+            close()
         }
-        job.invokeOnCompletion { cause ->
-            logJobCompletion("Message reading", cause)
-        }
-        return job
+    }.apply {
+        invokeOnCompletion { logJobCompletion("Message reading", it) }
     }
 
-    private fun launchProcessingJob(): Job {
-        val job = scope.launch {
-            @Suppress("TooGenericExceptionCaught")
-            try {
-                for (chunk in readChannel) {
-                    readBuffer.append(chunk)
-                    processReadBuffer()
-                }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Throwable) {
-                _onError.invoke(e)
+    private fun launchProcessingJob(): Job = scope.launch(processingJobDispatcher) {
+        @Suppress("TooGenericExceptionCaught")
+        try {
+            for (chunk in readChannel) {
+                readBuffer.append(chunk)
+                processReadBuffer()
             }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            _onError.invoke(e)
         }
-        job.invokeOnCompletion { cause ->
-            logJobCompletion("Processing", cause)
-        }
-        return job
+    }.apply {
+        invokeOnCompletion { logJobCompletion("Processing", it) }
     }
 
-    private fun launchSendingJob(): Job {
-        val job = scope.launch {
-            @Suppress("TooGenericExceptionCaught")
-            try {
-                for (message in writeChannel) {
-                    val json = serializeMessage(message)
-                    outputSink.writeString(json)
-                    outputSink.flush()
-                }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Throwable) {
-                logger.error(e) { "Error writing to stdout" }
-                _onError.invoke(e)
+    private fun launchSendingJob(): Job = scope.launch(writingJobDispatcher) {
+        @Suppress("TooGenericExceptionCaught")
+        try {
+            for (message in writeChannel) {
+                val json = serializeMessage(message)
+                sink.writeString(json)
+                sink.flush()
             }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            logger.error(e) { "Error writing to stdout" }
+            _onError.invoke(e)
         }
-        job.invokeOnCompletion { cause ->
+    }.apply {
+        invokeOnCompletion { cause ->
             logJobCompletion("Message sending", cause)
             if (cause is CancellationException) {
                 readingJob?.cancel(cause)
             }
         }
-        return job
     }
 
     private suspend fun processReadBuffer() {
@@ -192,7 +258,7 @@ public class StdioServerTransport(private val inputStream: Source, outputStream:
             sendingJob?.cancelAndJoin()
 
             runCatching {
-                inputStream.close()
+                source.close()
             }.onFailure { logger.warn(it) { "Failed to close stdin" } }
 
             readingJob?.cancel()
@@ -201,10 +267,9 @@ public class StdioServerTransport(private val inputStream: Source, outputStream:
             processingJob?.cancelAndJoin()
 
             readBuffer.clear()
-
             runCatching {
-                outputSink.flush()
-                outputSink.close()
+                sink.flush()
+                sink.close()
             }.onFailure { logger.warn(it) { "Failed to close stdout" } }
 
             invokeOnCloseCallback()

--- a/kotlin-sdk-server/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/StdioServerTransportTest.kt
+++ b/kotlin-sdk-server/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/StdioServerTransportTest.kt
@@ -5,8 +5,6 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.assertions.withClue
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
-import io.ktor.client.utils.clientDispatcher
-import io.ktor.utils.io.InternalAPI
 import io.modelcontextprotocol.kotlin.sdk.shared.ReadBuffer
 import io.modelcontextprotocol.kotlin.sdk.shared.serializeMessage
 import io.modelcontextprotocol.kotlin.sdk.types.InitializedNotification
@@ -19,6 +17,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.withTimeout
 import kotlinx.io.Buffer
@@ -74,26 +73,23 @@ class StdioServerTransportTest {
         printOutput = output.asSink().buffered()
     }
 
-    @OptIn(InternalAPI::class)
     @Test
     fun `should construct with builder`() = runIntegrationTest {
         val received = CompletableDeferred<JSONRPCMessage>()
 
-        val ioDispatcher = Dispatchers.IO.limitedParallelism(4)
-
         // Set every configuration parameter explicitly with non-default values,
         // then verify a message round-trips correctly.
-        val server = StdioServerTransport {
-            source = bufferedInput
-            sink = printOutput
-            readBufferSize = 16L // non-default: smaller read chunk
-            readingJobDispatcher = ioDispatcher // non-default: limited parallelism
-            writingJobDispatcher = ioDispatcher // non-default: limited parallelism
-            processingJobDispatcher = Dispatchers.clientDispatcher(2, "Worker") // non-default
-            readChannelBufferSize = Channel.BUFFERED // non-default: bounded
-            writeChannelBufferSize = Channel.BUFFERED // non-default: bounded
-            coroutineScope = CoroutineScope(Dispatchers.Default) // non-default: parent scope provided
-        }
+        val server = StdioServerTransport(
+            source = bufferedInput,
+            sink = printOutput,
+            readBufferSize = 16L, // non-default: smaller read chunk
+            readingJobDispatcher = Dispatchers.IO.limitedParallelism(4, "Read"), // non-default: limited parallelism
+            writingJobDispatcher = Dispatchers.IO.limitedParallelism(4, "Write"), // non-default: limited parallelism
+            processingJobDispatcher = Dispatchers.IO.limitedParallelism(2, name = "Worker"), // non-default
+            readChannel = Channel(capacity = 8, onBufferOverflow = BufferOverflow.SUSPEND), // non-default: bounded
+            writeChannel = Channel(capacity = 16, onBufferOverflow = BufferOverflow.SUSPEND), // non-default: bounded
+            coroutineScope = CoroutineScope(Dispatchers.Default), // non-default: parent scope provided
+        )
         server.onError { throw it }
         server.onMessage { received.complete(it) }
 

--- a/kotlin-sdk-server/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/StdioServerTransportTest.kt
+++ b/kotlin-sdk-server/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/StdioServerTransportTest.kt
@@ -5,6 +5,8 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.assertions.withClue
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
+import io.ktor.client.utils.clientDispatcher
+import io.ktor.utils.io.InternalAPI
 import io.modelcontextprotocol.kotlin.sdk.shared.ReadBuffer
 import io.modelcontextprotocol.kotlin.sdk.shared.serializeMessage
 import io.modelcontextprotocol.kotlin.sdk.types.InitializedNotification
@@ -14,7 +16,10 @@ import io.modelcontextprotocol.kotlin.sdk.types.toJSON
 import io.modelcontextprotocol.kotlin.test.utils.runIntegrationTest
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.withTimeout
 import kotlinx.io.Buffer
 import kotlinx.io.RawSink
@@ -67,6 +72,40 @@ class StdioServerTransportTest {
 
         bufferedInput = input.asSource().buffered()
         printOutput = output.asSink().buffered()
+    }
+
+    @OptIn(InternalAPI::class)
+    @Test
+    fun `should construct with builder`() = runIntegrationTest {
+        val received = CompletableDeferred<JSONRPCMessage>()
+
+        val ioDispatcher = Dispatchers.IO.limitedParallelism(4)
+
+        // Set every configuration parameter explicitly with non-default values,
+        // then verify a message round-trips correctly.
+        val server = StdioServerTransport {
+            source = bufferedInput
+            sink = printOutput
+            readBufferSize = 16L // non-default: smaller read chunk
+            readingJobDispatcher = ioDispatcher // non-default: limited parallelism
+            writingJobDispatcher = ioDispatcher // non-default: limited parallelism
+            processingJobDispatcher = Dispatchers.clientDispatcher(2, "Worker") // non-default
+            readChannelBufferSize = Channel.BUFFERED // non-default: bounded
+            writeChannelBufferSize = Channel.BUFFERED // non-default: bounded
+            coroutineScope = CoroutineScope(Dispatchers.Default) // non-default: parent scope provided
+        }
+        server.onError { throw it }
+        server.onMessage { received.complete(it) }
+
+        server.start()
+
+        val message = PingRequest().toJSON()
+        inputWriter.write(serializeMessage(message))
+        inputWriter.flush()
+
+        received.await() shouldBe message
+
+        server.close()
     }
 
     @Test


### PR DESCRIPTION
1. Add a customizable builder to StdioServerTransport

    Scope lifecycle is fixed (#574 resolved), processing dispatcher defaults to `Dispatchers.Default` (#573 resolved), scope context is clean (no spurious dispatcher stacking), and `@Volatile` on the three job vars addresses the visibility race.

    - Introduce a `Configuration` class for `StdioServerTransport` to improve API flexibility and readability. Now one can provide a dispatcher for IO running on Virtual Threads
    - Updated transport initialization to use a builder block for configuring parameters such as I/O streams, buffer sizes, dispatchers, and parent coroutine scope.

    - Added integration test validating the builder functionality.

2. Added `InjectDispatcher` rule to detekt exclusions for test folders in `detekt.yml`. Removed `InjectDispatcher` issues from detekt baseline files.

**NB!** This PR doesn't fully resolve race conditions on close(). It will be resolved in the course of #518

## Motivation and Context
#573, #574

## How Has This Been Tested?

Integration test / regression tests

## Breaking Changes
No, only API is only extended

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
