### PR TITLE
feat(conformance): add `list` command to conformance test script

### DIFF
--- a/conformance-test/README.md
+++ b/conformance-test/README.md
@@ -24,12 +24,13 @@ Run **all** suites (server, client core, client auth) from the project root:
 ./conformance-test/run-conformance.sh <command> [extra-args...]
 ```
 
-| Command       | What it does                                                                        |
-|---------------|-------------------------------------------------------------------------------------|
-| `server`      | Starts the Ktor conformance server, runs the server test suite against it           |
-| `client`      | Runs the client test suite (`initialize`, `tools_call`, `elicitation`, `sse-retry`) |
-| `client-auth` | Runs the client auth test suite (20 OAuth scenarios)                                |
-| `all`         | Runs all three suites sequentially                                                  |
+| Command       | What it does                                                                         |
+|---------------|--------------------------------------------------------------------------------------|
+| `list`        | [List scenarios available in MCP Conformance Test Framework][list-scenarios-command] |
+| `server`      | Starts the Ktor conformance server, runs the server test suite against it            |
+| `client`      | Runs the client test suite (`initialize`, `tools_call`, `elicitation`, `sse-retry`)  |
+| `client-auth` | Runs the client auth test suite (20 OAuth scenarios)                                 |
+| `all`         | Runs all three suites sequentially                                                   |
 
 Any `[extra-args]` are forwarded to the conformance runner (e.g. `--verbose`).
 
@@ -126,3 +127,5 @@ Tests the conformance server against all server scenarios:
 | `sse-retry`                           | client | Transport does not respect the SSE `retry` field timing or send `Last-Event-ID` on reconnection                                                        |
 
 These failures reveal SDK gaps and are intentionally not fixed in this module.
+
+[list-scenarios-command]: https://github.com/modelcontextprotocol/conformance/tree/main?tab=readme-ov-file#list-available-scenarios

--- a/conformance-test/run-conformance.sh
+++ b/conformance-test/run-conformance.sh
@@ -64,6 +64,21 @@ stop_server() {
     fi
 }
 
+run_list_scenarios() {
+    local output_dir="$RESULTS_DIR/list"
+    mkdir -p "$output_dir"
+    echo ""
+    echo "=========================================="
+    echo "  List Available Scenarios"
+    echo "=========================================="
+    local rc=0
+    npx "@modelcontextprotocol/conformance@$CONFORMANCE_VERSION" list \
+        "$@" > "$output_dir/scenarios.txt" || rc=$?
+
+    cat "$output_dir/scenarios.txt"
+    return $rc
+}
+
 run_server_suite() {
     local output_dir="$RESULTS_DIR/server"
     mkdir -p "$output_dir"
@@ -138,7 +153,7 @@ shift 2>/dev/null || true
 
 if [ -z "$COMMAND" ]; then
     echo "Usage: $0 <command> [extra-args...]"
-    echo "Commands: server | client | client-auth | all"
+    echo "Commands: list | server | client | client-auth | all"
     exit 1
 fi
 
@@ -147,6 +162,9 @@ build
 EXIT_CODE=0
 
 case "$COMMAND" in
+    list)
+        run_list_scenarios "$@" || EXIT_CODE=1
+        ;;
     server)
         run_server_suite "$@" || EXIT_CODE=1
         ;;
@@ -163,7 +181,7 @@ case "$COMMAND" in
         ;;
     *)
         echo "Unknown command: $COMMAND"
-        echo "Commands: server | client | client-auth | all"
+        echo "Commands: list | server | client | client-auth | all"
         exit 1
         ;;
 esac


### PR DESCRIPTION
# add `list` command to conformance test script

- Introduced [`list`](https://github.com/modelcontextprotocol/conformance?tab=readme-ov-file#list-available-scenarios) command in `run-conformance.sh` to display available scenarios.
- Updated README with details about the new `list` command and its purpose.

## Motivation and Context

To see all available scenarios

## How Has This Been Tested?

Run the shell script locally:

```shell
./conformance-test/run-conformance.sh list
```

## Breaking Changes
No

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed
