### PR TITLE
feat(core): Implement RFC-6570 URI template matching and expansion utils (#502)

### DIFF
--- a/kotlin-sdk-core/api/kotlin-sdk-core.api
+++ b/kotlin-sdk-core/api/kotlin-sdk-core.api
@@ -4731,3 +4731,42 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/WithMeta$DefaultImpl
 	public static fun get_meta (Lio/modelcontextprotocol/kotlin/sdk/types/WithMeta;)Lkotlinx/serialization/json/JsonObject;
 }
 
+public final class io/modelcontextprotocol/kotlin/sdk/utils/MatchResult {
+	public fun <init> (Ljava/util/Map;I)V
+	public final fun component1 ()Ljava/util/Map;
+	public final fun component2 ()I
+	public final fun copy (Ljava/util/Map;I)Lio/modelcontextprotocol/kotlin/sdk/utils/MatchResult;
+	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/utils/MatchResult;Ljava/util/Map;IILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/utils/MatchResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun get (Ljava/lang/String;)Ljava/lang/String;
+	public final fun getScore ()I
+	public final fun getVariables ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/modelcontextprotocol/kotlin/sdk/utils/UriTemplate {
+	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/utils/UriTemplate$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun expand (Ljava/lang/String;Ljava/util/Map;)Ljava/lang/String;
+	public final fun expand (Ljava/util/Map;)Ljava/lang/String;
+	public final fun getLiteralLength ()I
+	public final fun getTemplate ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun match (Ljava/lang/String;)Lio/modelcontextprotocol/kotlin/sdk/utils/MatchResult;
+	public final fun matcher ()Lio/modelcontextprotocol/kotlin/sdk/utils/UriTemplateMatcher;
+	public static final fun matches (Ljava/lang/String;Ljava/lang/String;)Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/modelcontextprotocol/kotlin/sdk/utils/UriTemplate$Companion {
+	public final fun expand (Ljava/lang/String;Ljava/util/Map;)Ljava/lang/String;
+	public final fun matches (Ljava/lang/String;Ljava/lang/String;)Z
+}
+
+public final class io/modelcontextprotocol/kotlin/sdk/utils/UriTemplateMatcher {
+	public final fun match (Ljava/lang/String;)Lio/modelcontextprotocol/kotlin/sdk/utils/MatchResult;
+	public final fun matches (Ljava/lang/String;)Z
+}
+

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/utils/UriTemplate.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/utils/UriTemplate.kt
@@ -1,0 +1,300 @@
+package io.modelcontextprotocol.kotlin.sdk.utils
+
+import io.modelcontextprotocol.kotlin.sdk.utils.UriTemplateParser.Modifier
+import io.modelcontextprotocol.kotlin.sdk.utils.UriTemplateParser.OpInfo
+import io.modelcontextprotocol.kotlin.sdk.utils.UriTemplateParser.Part
+import io.modelcontextprotocol.kotlin.sdk.utils.UriTemplateParser.VarSpec
+import kotlin.jvm.JvmInline
+import kotlin.jvm.JvmStatic
+
+/**
+ * Result of matching a URI against a [UriTemplate].
+ *
+ * @property variables Variable values extracted from the URI, keyed by variable name.
+ *   All variables from every expression are captured, including multi-variable expressions
+ *   like `{x,y}` or `{?x,y}`. Values are the raw (pct-encoded) substrings from the URI.
+ * @property score Specificity score — total literal character count of the matched template.
+ *   Higher scores indicate more specific templates. Use this to resolve ambiguity when
+ *   multiple templates match the same URI.
+ *
+ * Example: selecting the most specific match
+ * ```
+ * val templates = listOf(
+ *     UriTemplate("users/{id}"),         // score = 6  ("users/")
+ *     UriTemplate("users/profile"),      // score = 13 ("users/profile")
+ * )
+ * val best = templates
+ *     .mapNotNull { t -> t.match(uri)?.let { t to it } }
+ *     .maxByOrNull { (_, result) -> result.score }
+ * ```
+ */
+public data class MatchResult(val variables: Map<String, String>, val score: Int) {
+    /** Returns the value of variable [name], or `null` if it was not captured. */
+    public operator fun get(name: String): String? = variables[name]
+}
+
+/**
+ * RFC 6570 URI Template implementation.
+ *
+ * Supports all four levels of URI template expansion:
+ * - **Level 1** – Simple string expansion: `{var}`
+ * - **Level 2** – Reserved (`{+var}`) and fragment (`{#var}`) expansion
+ * - **Level 3** – Label (`{.var}`), path (`{/var}`), path-parameter (`{;var}`),
+ *   query (`{?var}`), and query-continuation (`{&var}`) expansion with multiple variables
+ * - **Level 4** – Prefix modifiers (`{var:3}`) and explode modifiers (`{var*}`)
+ *
+ * The template string is parsed eagerly on construction.
+ *
+ * Variable values supplied to [expand] may be:
+ * - `null` or absent key → undefined (skipped in expansion)
+ * - [String] → simple string value
+ * - [List] of [String] → list value (an empty list is treated as undefined)
+ * - [Map] of [String] to [String] → associative array (an empty map is treated as undefined)
+ *
+ * @param template The URI template string.
+ * @throws IllegalArgumentException if the template is malformed.
+ * @see [RFC 6570](https://www.rfc-editor.org/rfc/rfc6570)
+ */
+@Suppress("TooManyFunctions")
+public class UriTemplate(public val template: String) {
+
+    //region Typed variable value (expansion-only) ─────────────────────────────
+
+    private sealed interface VarValue {
+        @JvmInline
+        value class Str(val value: String) : VarValue
+        data class Lst(val values: List<String>) : VarValue
+        data class Assoc(val pairs: List<Pair<String, String>>) : VarValue
+    }
+
+    //endregion
+    //region Parsed model ───────────────────────────────────────────────────────
+
+    private val parts: List<Part> = UriTemplateParser.parse(template)
+
+    /**
+     * The total number of encoded literal characters in this template.
+     *
+     * This value equals [MatchResult.score] when this template successfully matches a URI,
+     * making it useful for pre-ranking templates before matching.
+     */
+    public val literalLength: Int = parts.sumOf { if (it is Part.Literal) it.text.length else 0 }
+
+    //endregion
+    //region Public API ─────────────────────────────────────────────────────────
+
+    /**
+     * Expands the URI template with the given [variables].
+     *
+     * @return The expanded URI string.
+     */
+    public fun expand(variables: Map<String, Any?>): String = buildString {
+        for (part in parts) {
+            when (part) {
+                is Part.Literal -> append(part.text)
+                is Part.Expression -> append(expandExpression(part, variables))
+            }
+        }
+    }
+
+    /**
+     * Returns a compiled [UriTemplateMatcher] for this template (cached lazily).
+     * Use [match] for one-off checks; use [matcher] when matching against many URIs.
+     */
+    public fun matcher(): UriTemplateMatcher = _matcher
+
+    private val _matcher: UriTemplateMatcher by lazy {
+        UriTemplateMatcher.build(parts, literalLength)
+    }
+
+    /**
+     * Matches [uri] against this template and returns extracted variables plus a
+     * specificity [MatchResult.score], or `null` if the URI does not match.
+     *
+     * Example:
+     * ```
+     * UriTemplate("https://api.example.com/users/{id}/posts/{postId}")
+     *     .match("https://api.example.com/users/alice/posts/99")
+     * // MatchResult(variables = {"id": "alice", "postId": "99"}, score = 36)
+     * ```
+     */
+    public fun match(uri: String): MatchResult? = _matcher.match(uri)
+
+    /**
+     * Compares this instance of [UriTemplate] with another object for equality.
+     *
+     * @param other The object to compare with this instance. It may be `null` or of any type.
+     * @return `true` if the given object is a [UriTemplate] and its `template` property is equal
+     *         to that of this instance, otherwise `false`.
+     */
+    override fun equals(other: Any?): Boolean = other is UriTemplate && template == other.template
+
+    /**
+     * Returns a hash code value for this instance.
+     *
+     * The hash code is based on the `template` property.
+     */
+    override fun hashCode(): Int = template.hashCode()
+
+    /**
+     * Returns a string representation of this instance.
+     *
+     * The string representation is in the format `UriTemplate(template)`.
+     */
+    override fun toString(): String = "UriTemplate($template)"
+
+    public companion object {
+        /**
+         * Expands [template] with [variables] in a single call.
+         *
+         * Equivalent to `UriTemplate(template).expand(variables)`. The template is parsed on
+         * every call without caching. Prefer constructing a [UriTemplate] instance when the
+         * same template is expanded repeatedly.
+         *
+         * Particularly useful from Java, where it is available as a static method.
+         */
+        @JvmStatic
+        public fun expand(template: String, variables: Map<String, Any?>): String =
+            UriTemplate(template).expand(variables)
+
+        /**
+         * Returns `true` if [uri] matches [template], without retaining a [UriTemplateMatcher] instance.
+         * Equivalent to `UriTemplate(template).matcher().matches(uri)`.
+         */
+        @JvmStatic
+        public fun matches(template: String, uri: String): Boolean = UriTemplate(template).matcher().matches(uri)
+    }
+
+    //endregion
+    //region Expression expansion ───────────────────────────────────────────────
+
+    private fun expandExpression(part: Part.Expression, variables: Map<String, Any?>): String {
+        if (part.varSpecs.isEmpty()) return "{}"
+        val op = part.op
+        return buildString {
+            var firstItem = true
+            for (varSpec in part.varSpecs) {
+                val value = resolveValue(variables[varSpec.name]) ?: continue
+                for (item in itemsForVar(varSpec, value, op)) {
+                    append(if (firstItem) op.first else op.sep)
+                    firstItem = false
+                    append(item)
+                }
+            }
+        }
+    }
+
+    private fun itemsForVar(spec: VarSpec, value: VarValue, op: OpInfo): List<String> = when (value) {
+        is VarValue.Str -> listOf(expandStr(spec, value.value, op))
+        is VarValue.Lst -> expandList(spec, value.values, op)
+        is VarValue.Assoc -> expandAssoc(spec, value.pairs, op)
+    }
+
+    //endregion
+    //region String expansion ───────────────────────────────────────────────────
+
+    private fun expandStr(spec: VarSpec, raw: String, op: OpInfo): String = buildString {
+        if (op.named) {
+            append(UriTemplateParser.pctEncodeUnreserved(spec.name))
+            if (raw.isEmpty()) {
+                append(op.ifemp)
+                return@buildString
+            }
+            append('=')
+        }
+        val encoded = when (val mod = spec.modifier) {
+            is Modifier.Prefix -> UriTemplateParser.pctEncode(
+                UriTemplateParser.truncateCodePoints(raw, mod.length),
+                op.allowReserved,
+            )
+
+            else -> UriTemplateParser.pctEncode(raw, op.allowReserved)
+        }
+        append(encoded)
+    }
+
+    //endregion
+    //region List expansion ─────────────────────────────────────────────────────
+
+    private fun expandList(spec: VarSpec, values: List<String>, op: OpInfo): List<String> = when (spec.modifier) {
+        Modifier.Explode -> values.map { v ->
+            if (op.named) {
+                val name = UriTemplateParser.pctEncodeUnreserved(spec.name)
+                if (v.isEmpty()) {
+                    "$name${op.ifemp}"
+                } else {
+                    "$name=${UriTemplateParser.pctEncode(v, op.allowReserved)}"
+                }
+            } else {
+                UriTemplateParser.pctEncode(v, op.allowReserved)
+            }
+        }
+
+        else -> listOf(
+            buildString {
+                if (op.named) {
+                    append(UriTemplateParser.pctEncodeUnreserved(spec.name))
+                    append('=')
+                }
+                append(values.joinToString(",") { UriTemplateParser.pctEncode(it, op.allowReserved) })
+            },
+        )
+    }
+
+    //endregion
+    //region Associative-array expansion ────────────────────────────────────────
+
+    private fun expandAssoc(spec: VarSpec, pairs: List<Pair<String, String>>, op: OpInfo): List<String> =
+        when (spec.modifier) {
+            Modifier.Explode -> pairs.map { (k, v) ->
+                val encK = UriTemplateParser.pctEncode(k, op.allowReserved)
+                if (v.isEmpty()) {
+                    "$encK${op.ifemp}"
+                } else {
+                    "$encK=${UriTemplateParser.pctEncode(v, op.allowReserved)}"
+                }
+            }
+
+            else -> listOf(
+                buildString {
+                    if (op.named) {
+                        append(UriTemplateParser.pctEncodeUnreserved(spec.name))
+                        append('=')
+                    }
+                    append(
+                        pairs.joinToString(",") { (k, v) ->
+                            "${UriTemplateParser.pctEncode(k, op.allowReserved)},${
+                                UriTemplateParser.pctEncode(
+                                    v,
+                                    op.allowReserved,
+                                )
+                            }"
+                        },
+                    )
+                },
+            )
+        }
+
+    //endregion
+    //region Value resolution ───────────────────────────────────────────────────
+
+    private fun resolveValue(raw: Any?): VarValue? = when (raw) {
+        null -> null
+
+        is String -> VarValue.Str(raw)
+
+        is List<*> -> {
+            val strs = raw.filterNotNull().map { it.toString() }
+            if (strs.isEmpty()) null else VarValue.Lst(strs)
+        }
+
+        is Map<*, *> -> {
+            val pairs = raw.entries
+                .mapNotNull { (k, v) -> if (k != null && v != null) k.toString() to v.toString() else null }
+            if (pairs.isEmpty()) null else VarValue.Assoc(pairs)
+        }
+
+        else -> VarValue.Str(raw.toString())
+    }
+    //endregion
+}

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/utils/UriTemplateMatcher.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/utils/UriTemplateMatcher.kt
@@ -1,0 +1,120 @@
+package io.modelcontextprotocol.kotlin.sdk.utils
+
+import io.modelcontextprotocol.kotlin.sdk.utils.UriTemplateParser.Part
+
+/**
+ * Compiled regex-based matcher for an RFC 6570 URI template.
+ *
+ * Created via [UriTemplate.matcher]. Each instance holds a pre-compiled [Regex] and
+ * the ordered list of captured variable names, so repeated matching is allocation-cheap.
+ *
+ * All variables in every expression are captured, including multi-variable expressions
+ * like `{x,y}` or `{?x,y}`.
+ *
+ * Example:
+ * ```
+ * val matcher = UriTemplate("users/{userId}/posts/{postId}").matcher()
+ * val result = matcher.match("users/alice/posts/99")
+ * // MatchResult(variables={"userId":"alice","postId":"99"}, score=12)
+ * ```
+ */
+public class UriTemplateMatcher internal constructor(
+    private val regex: Regex,
+    private val variableNames: List<String>,
+    private val score: Int,
+) {
+    /**
+     * Matches [uri] against the compiled template regex.
+     *
+     * @return a [MatchResult] with extracted variables and score, or `null` if [uri] does not match.
+     */
+    @Suppress("ReturnCount")
+    public fun match(uri: String): MatchResult? {
+        if (variableNames.isEmpty()) {
+            return if (regex.matches(uri)) MatchResult(emptyMap(), score) else null
+        }
+        val matchResult = regex.matchEntire(uri) ?: return null
+        val variables = variableNames.mapIndexed { idx, name ->
+            name to matchResult.groupValues[idx + 1]
+        }.toMap()
+        return MatchResult(variables = variables, score = score)
+    }
+
+    /** Returns `true` if [uri] fully matches this template pattern. */
+    public fun matches(uri: String): Boolean = regex.matches(uri)
+
+    internal companion object {
+        /**
+         * Builds a [UriTemplateMatcher] from pre-parsed template [parts] and the template's [score].
+         *
+         * All variables in each expression are registered as capture groups.
+         * The `+` and `#` operators allow slashes and reserved characters; all others stop at
+         * URI delimiters (`/`, `?`, `#`, `,`).
+         */
+        @Suppress("CyclomaticComplexMethod")
+        internal fun build(parts: List<Part>, score: Int): UriTemplateMatcher {
+            val variableNames = mutableListOf<String>()
+            val pattern = buildString {
+                append('^')
+                for (part in parts) {
+                    when (part) {
+                        is Part.Literal -> append(Regex.escape(part.text))
+
+                        is Part.Expression -> {
+                            val op = part.op
+                            if (part.varSpecs.isEmpty()) continue
+
+                            var firstVar = true
+                            for (varSpec in part.varSpecs) {
+                                val name = varSpec.name
+                                variableNames.add(name)
+
+                                // Emit the operator prefix (first var) or separator (subsequent vars).
+                                if (firstVar) {
+                                    // For named operators the prefix includes the variable name.
+                                    val prefix = when (op.char) {
+                                        ';', '?', '&' -> "${op.first}$name="
+                                        else -> op.first // NUL/+: "", #: "#", .: ".", /: "/"
+                                    }
+                                    if (prefix.isNotEmpty()) append(Regex.escape(prefix))
+                                    firstVar = false
+                                } else {
+                                    // For named operators the separator includes the variable name.
+                                    val sep = if (op.named) "${op.sep}$name=" else op.sep
+                                    append(Regex.escape(sep))
+                                }
+
+                                // Each operator restricts which characters a value may contain.
+                                // The capture pattern uses the tightest stop-char set per RFC 6570.
+                                val capture = when (op.char) {
+                                    // '+' and '#' allow reserved chars (including ',') in values
+                                    // per RFC 6570 §3.2.3–3.2.4, so comma-containing values
+                                    // cannot be reverse-matched correctly.
+                                    // RFC 6570 §1.4 acknowledges this: "Variable matching only works well
+                                    // if the template expressions are delimited by characters
+                                    // that cannot be part of the expansion."
+                                    '+', '#' -> "([^,]*)"
+
+                                    // path operators: stop at all URI path and query delimiters
+                                    '.', '/' -> "([^/?#,;=&]*)"
+
+                                    // path-parameter: stop at ';' (next param) and query delimiters
+                                    ';' -> "([^/?#,;=&]*)"
+
+                                    // query operators: stop at '&' (next pair) too
+                                    '?', '&' -> "([^/?#,;&=]*)"
+
+                                    // NUL: unreserved characters only
+                                    else -> "([^/?#,;=&]*)"
+                                }
+                                append(capture)
+                            }
+                        }
+                    }
+                }
+                append('$')
+            }
+            return UriTemplateMatcher(Regex(pattern), variableNames, score)
+        }
+    }
+}

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/utils/UriTemplateParser.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/utils/UriTemplateParser.kt
@@ -1,0 +1,225 @@
+package io.modelcontextprotocol.kotlin.sdk.utils
+
+/**
+ * Internal parser for RFC 6570 URI Templates.
+ *
+ * Parses a template string into a structured [Part] list and provides helpers
+ * for PCT-encoding values during expansion.
+ */
+@Suppress("TooManyFunctions")
+internal object UriTemplateParser {
+
+    //region Model types ────────────────────────────────────────────────────────
+
+    internal data class OpInfo(
+        val char: Char?,
+        val first: String,
+        val sep: String,
+        val named: Boolean,
+        val ifemp: String,
+        val allowReserved: Boolean,
+    )
+
+    internal sealed interface Modifier {
+        data object None : Modifier
+        data object Explode : Modifier
+        data class Prefix(val length: Int) : Modifier
+    }
+
+    internal data class VarSpec(val name: String, val modifier: Modifier)
+
+    /** A parsed segment of a URI template. */
+    internal sealed interface Part {
+        /** Literal text, already pct-encoded for direct output. */
+        data class Literal(val text: String) : Part
+
+        /** An expression `{…}` with its operator metadata and variable list. */
+        data class Expression(val op: OpInfo, val varSpecs: List<VarSpec>) : Part
+    }
+
+    //endregion
+    //region Operator constants ─────────────────────────────────────────────────
+    // Pre-allocated singletons — one per object, shared across all parse calls.
+
+    private const val HEX_CHARS = "0123456789ABCDEF"
+
+    internal val NUL_OP = OpInfo(null, "", ",", named = false, ifemp = "", allowReserved = false)
+    private val PLUS_OP = OpInfo('+', "", ",", named = false, ifemp = "", allowReserved = true)
+    private val HASH_OP = OpInfo('#', "#", ",", named = false, ifemp = "", allowReserved = true)
+    private val DOT_OP = OpInfo('.', ".", ".", named = false, ifemp = "", allowReserved = false)
+    private val SLASH_OP = OpInfo('/', "/", "/", named = false, ifemp = "", allowReserved = false)
+    private val SEMI_OP = OpInfo(';', ";", ";", named = true, ifemp = "", allowReserved = false)
+    private val QUERY_OP = OpInfo('?', "?", "&", named = true, ifemp = "=", allowReserved = false)
+    private val AMP_OP = OpInfo('&', "&", "&", named = true, ifemp = "=", allowReserved = false)
+
+    //endregion
+    //region parsing entry point ─────────────────────────────────────────
+
+    /**
+     * Parses [template] into an ordered list of [Part]s.
+     *
+     * @throws IllegalArgumentException if the template contains an unclosed brace.
+     */
+    internal fun parse(template: String): List<Part> {
+        val result = mutableListOf<Part>()
+        val literalBuf = StringBuilder()
+        var i = 0
+
+        fun flushLiteral() {
+            if (literalBuf.isNotEmpty()) {
+                result.add(Part.Literal(literalBuf.toString()))
+                literalBuf.clear()
+            }
+        }
+
+        @Suppress("LoopWithTooManyJumpStatements")
+        while (i < template.length) {
+            if (template[i] != '{') {
+                literalBuf.append(encodeLiteralChar(template[i]))
+                i++
+                continue
+            }
+            val end = template.indexOf('}', i + 1)
+            require(end != -1) {
+                "Unclosed brace at index $i in URI template: \"$template\""
+            }
+            flushLiteral()
+            result.add(parseExpression(template.substring(i + 1, end)))
+            i = end + 1
+        }
+        flushLiteral()
+        return result
+    }
+
+    //endregion
+    //region PCT-encoding helpers (used by UriTemplate expand logic) ───────────
+
+    /** PCT-encodes [s], passing reserved characters through when [allowReserved] is true. */
+    internal fun pctEncode(s: String, allowReserved: Boolean): String {
+        val sb = StringBuilder(s.length)
+        var i = 0
+        while (i < s.length) {
+            val c = s[i]
+            when {
+                isUnreserved(c) -> sb.append(c)
+
+                allowReserved && isReserved(c) -> sb.append(c)
+
+                // Preserve existing pct-encoded triplets in reserved/fragment mode.
+                allowReserved &&
+                    c == '%' &&
+                    i + 2 < s.length &&
+                    isHexDigit(s[i + 1]) &&
+                    isHexDigit(s[i + 2]) -> {
+                    sb.append(c).append(s[i + 1]).append(s[i + 2])
+                    i += 2
+                }
+
+                // Surrogate pair — encode the full code point as UTF-8.
+                c.isHighSurrogate() && i + 1 < s.length && s[i + 1].isLowSurrogate() -> {
+                    pctEncodeBytes(sb, s.substring(i, i + 2).encodeToByteArray())
+                    i++ // skip low surrogate; outer increment follows
+                }
+
+                else -> pctEncodeBytes(sb, c.toString().encodeToByteArray())
+            }
+            i++
+        }
+        return sb.toString()
+    }
+
+    internal fun pctEncodeUnreserved(s: String): String = pctEncode(s, allowReserved = false)
+
+    /**
+     * Truncates [s] to at most [n] Unicode code points.
+     * Surrogate pairs count as a single code point.
+     */
+    internal fun truncateCodePoints(s: String, n: Int): String {
+        var count = 0
+        var i = 0
+        while (i < s.length && count < n) {
+            if (s[i].isHighSurrogate() && i + 1 < s.length && s[i + 1].isLowSurrogate()) i++
+            i++
+            count++
+        }
+        return s.substring(0, i)
+    }
+
+    //endregion
+    //region Private parsing helpers ────────────────────────────────────────────
+
+    private fun parseExpression(expression: String): Part.Expression {
+        if (expression.isEmpty()) return Part.Expression(NUL_OP, emptyList())
+        val (opInfo, varListStr) = detectOperator(expression)
+        val varSpecs = if (varListStr.isEmpty()) emptyList() else parseVarList(varListStr)
+        return Part.Expression(opInfo, varSpecs)
+    }
+
+    private fun detectOperator(expression: String): Pair<OpInfo, String> {
+        val op = when (expression.firstOrNull()) {
+            '+' -> PLUS_OP
+            '#' -> HASH_OP
+            '.' -> DOT_OP
+            '/' -> SLASH_OP
+            ';' -> SEMI_OP
+            '?' -> QUERY_OP
+            '&' -> AMP_OP
+            else -> return Pair(NUL_OP, expression)
+        }
+        return Pair(op, expression.substring(1))
+    }
+
+    private fun parseVarList(varListStr: String): List<VarSpec> =
+        varListStr.split(',').mapNotNull { parseVarSpec(it.trim()) }
+
+    @Suppress("ReturnCount")
+    private fun parseVarSpec(raw: String): VarSpec? {
+        if (raw.isEmpty()) return null
+        if (raw.endsWith('*')) return VarSpec(raw.dropLast(1), Modifier.Explode)
+        val colon = raw.indexOf(':')
+        if (colon > 0) {
+            val len = raw.substring(colon + 1).toIntOrNull()
+            if (len != null && len > 0) return VarSpec(raw.substring(0, colon), Modifier.Prefix(len))
+        }
+        return VarSpec(raw, Modifier.None)
+    }
+
+    //endregion
+    //region Private encoding helpers ───────────────────────────────────────────
+
+    /**
+     * Encodes a single literal template character.
+     * Unreserved, reserved, and `%` characters are passed through unchanged;
+     * everything else is PCT-encoded as UTF-8.
+     */
+    private fun encodeLiteralChar(c: Char): String = if (isUnreserved(c) || isReserved(c) || c == '%') {
+        c.toString()
+    } else {
+        buildString { pctEncodeBytes(this, c.toString().encodeToByteArray()) }
+    }
+
+    @Suppress("MagicNumber")
+    private fun pctEncodeBytes(sb: StringBuilder, bytes: ByteArray) {
+        for (b in bytes) {
+            val n = b.toInt() and 0xFF
+            sb.append('%')
+            sb.append(HEX_CHARS[n ushr 4])
+            sb.append(HEX_CHARS[n and 0xF])
+        }
+    }
+
+    private fun isUnreserved(c: Char): Boolean =
+        c in 'A'..'Z' || c in 'a'..'z' || c in '0'..'9' || c == '-' || c == '.' || c == '_' || c == '~'
+
+    /**
+     * Returns `true` for reserved characters (gen-delims | sub-delims) per RFC 3986.
+     *
+     * gen-delims: `:/?#[]@`
+     * sub-delims: `!$&'()*+,;=`
+     */
+    private fun isReserved(c: Char): Boolean = c in ":/?#[]@!$&'()*+,;="
+
+    private fun isHexDigit(c: Char): Boolean = c in '0'..'9' || c in 'A'..'F' || c in 'a'..'f'
+
+    //endregion
+}

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/utils/UriTemplateExpansionTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/utils/UriTemplateExpansionTest.kt
@@ -1,0 +1,436 @@
+package io.modelcontextprotocol.kotlin.sdk.utils
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+/**
+ * Unit tests for [UriTemplate] covering all RFC 6570 levels and operators.
+ *
+ * Variable definitions follow Appendix A of RFC 6570:
+ *   count  = ("one", "two", "three")
+ *   dom    = ("example", "com")
+ *   dub    = "me/too"
+ *   hello  = "Hello World!"
+ *   half   = "50%"
+ *   var    = "value"
+ *   who    = "fred"
+ *   base   = "http://example.com/home/"
+ *   path   = "/foo/bar"
+ *   list   = ("red", "green", "blue")
+ *   keys   = [("semi",";"), ("dot","."), ("comma",",")]
+ *   v      = "6"
+ *   x      = "1024"
+ *   y      = "768"
+ *   empty  = ""
+ *   empty_keys = []
+ *   undef  = null
+ */
+class UriTemplateExpansionTest {
+
+    //region Shared variable set ────────────────────────────────────────────────
+
+    private val vars: Map<String, Any?> = mapOf(
+        "count" to listOf("one", "two", "three"),
+        "dom" to listOf("example", "com"),
+        "dub" to "me/too",
+        "hello" to "Hello World!",
+        "half" to "50%",
+        "var" to "value",
+        "who" to "fred",
+        "base" to "http://example.com/home/",
+        "path" to "/foo/bar",
+        "list" to listOf("red", "green", "blue"),
+        "keys" to mapOf("semi" to ";", "dot" to ".", "comma" to ","),
+        "v" to "6",
+        "x" to "1024",
+        "y" to "768",
+        "empty" to "",
+        "empty_keys" to emptyMap<String, String>(),
+        "undef" to null,
+    )
+
+    private fun expand(template: String): String = UriTemplate.expand(template, vars)
+
+    //endregion
+    //region Level 1: Simple string expansion {var} ─────────────────────────────
+
+    @Test
+    fun `level 1 - simple variable expansion`() {
+        expand("{var}") shouldBe "value"
+        expand("{hello}") shouldBe "Hello%20World%21"
+        expand("{half}") shouldBe "50%25"
+    }
+
+    @Test
+    fun `level 1 - undefined and empty variables`() {
+        expand("O{empty}X") shouldBe "OX"
+        expand("O{undef}X") shouldBe "OX"
+    }
+
+    @Test
+    fun `level 1 - multiple variables in expression`() {
+        expand("{x,y}") shouldBe "1024,768"
+        expand("{x,hello,y}") shouldBe "1024,Hello%20World%21,768"
+        expand("?{x,empty}") shouldBe "?1024,"
+        expand("?{x,undef}") shouldBe "?1024"
+        expand("?{undef,y}") shouldBe "?768"
+    }
+
+    //endregion
+    //region Level 1: Prefix modifier {var:N} ──────────────────────────────────
+
+    @Test
+    fun `level 1 - prefix modifier on simple string`() {
+        expand("{var:3}") shouldBe "val"
+        expand("{var:30}") shouldBe "value"
+    }
+
+    //endregion
+    //region Level 1: List and map without explode ──────────────────────────────
+
+    @Test
+    fun `level 1 - list expansion without explode`() {
+        expand("{list}") shouldBe "red,green,blue"
+        expand("{list*}") shouldBe "red,green,blue"
+    }
+
+    @Test
+    fun `level 1 - map expansion without explode`() {
+        expand("{keys}") shouldBe "semi,%3B,dot,.,comma,%2C"
+        expand("{keys*}") shouldBe "semi=%3B,dot=.,comma=%2C"
+    }
+
+    //endregion
+    //region Level 2: Reserved expansion {+var} ────────────────────────────────
+
+    @Test
+    fun `reserved expansion - basic`() {
+        expand("{+var}") shouldBe "value"
+        expand("{+hello}") shouldBe "Hello%20World!"
+        expand("{+half}") shouldBe "50%25"
+    }
+
+    @Test
+    fun `reserved expansion - allows reserved chars and pct-encoded passthrough`() {
+        expand("{base}index") shouldBe "http%3A%2F%2Fexample.com%2Fhome%2Findex"
+        expand("{+base}index") shouldBe "http://example.com/home/index"
+        expand("O{+empty}X") shouldBe "OX"
+        expand("O{+undef}X") shouldBe "OX"
+    }
+
+    @Test
+    fun `reserved expansion - path variable`() {
+        expand("{+path}/here") shouldBe "/foo/bar/here"
+        expand("here?ref={+path}") shouldBe "here?ref=/foo/bar"
+        expand("up{+path}{var}/here") shouldBe "up/foo/barvalue/here"
+    }
+
+    @Test
+    fun `reserved expansion - multiple variables`() {
+        expand("{+x,hello,y}") shouldBe "1024,Hello%20World!,768"
+        expand("{+path,x}/here") shouldBe "/foo/bar,1024/here"
+    }
+
+    @Test
+    fun `reserved expansion - prefix modifier`() {
+        expand("{+path:6}/here") shouldBe "/foo/b/here"
+    }
+
+    @Test
+    fun `reserved expansion - list and map`() {
+        expand("{+list}") shouldBe "red,green,blue"
+        expand("{+list*}") shouldBe "red,green,blue"
+        expand("{+keys}") shouldBe "semi,;,dot,.,comma,,"
+        expand("{+keys*}") shouldBe "semi=;,dot=.,comma=,"
+    }
+
+    //endregion
+    //region Level 2: Fragment expansion {#var} ────────────────────────────────
+
+    @Test
+    fun `fragment expansion - basic`() {
+        expand("{#var}") shouldBe "#value"
+        expand("{#hello}") shouldBe "#Hello%20World!"
+        expand("{#half}") shouldBe "#50%25"
+        expand("foo{#empty}") shouldBe "foo#"
+        expand("foo{#undef}") shouldBe "foo"
+    }
+
+    @Test
+    fun `fragment expansion - multiple variables`() {
+        expand("{#x,hello,y}") shouldBe "#1024,Hello%20World!,768"
+        expand("{#path,x}/here") shouldBe "#/foo/bar,1024/here"
+    }
+
+    @Test
+    fun `fragment expansion - prefix modifier and composites`() {
+        expand("{#path:6}/here") shouldBe "#/foo/b/here"
+        expand("{#list}") shouldBe "#red,green,blue"
+        expand("{#list*}") shouldBe "#red,green,blue"
+        expand("{#keys}") shouldBe "#semi,;,dot,.,comma,,"
+        expand("{#keys*}") shouldBe "#semi=;,dot=.,comma=,"
+    }
+
+    //endregion
+    //region Level 3: Label expansion {.var} ────────────────────────────────────
+
+    @Test
+    fun `label expansion - basic`() {
+        expand("{.who}") shouldBe ".fred"
+        expand("{.who,who}") shouldBe ".fred.fred"
+        expand("{.half,who}") shouldBe ".50%25.fred"
+        expand("www{.dom*}") shouldBe "www.example.com"
+        expand("X{.var}") shouldBe "X.value"
+        expand("X{.empty}") shouldBe "X."
+        expand("X{.undef}") shouldBe "X"
+    }
+
+    @Test
+    fun `label expansion - prefix modifier`() {
+        expand("X{.var:3}") shouldBe "X.val"
+    }
+
+    @Test
+    fun `label expansion - composites`() {
+        expand("X{.list}") shouldBe "X.red,green,blue"
+        expand("X{.list*}") shouldBe "X.red.green.blue"
+        expand("X{.keys}") shouldBe "X.semi,%3B,dot,.,comma,%2C"
+        expand("X{.keys*}") shouldBe "X.semi=%3B.dot=..comma=%2C"
+        expand("X{.empty_keys}") shouldBe "X"
+        expand("X{.empty_keys*}") shouldBe "X"
+    }
+
+    //endregion
+    //region Level 3: Path segment expansion {/var} ─────────────────────────────
+
+    @Test
+    fun `path segment expansion - basic`() {
+        expand("{/who}") shouldBe "/fred"
+        expand("{/who,who}") shouldBe "/fred/fred"
+        expand("{/half,who}") shouldBe "/50%25/fred"
+        expand("{/who,dub}") shouldBe "/fred/me%2Ftoo"
+        expand("{/var}") shouldBe "/value"
+        expand("{/var,empty}") shouldBe "/value/"
+        expand("{/var,undef}") shouldBe "/value"
+        expand("{/var,x}/here") shouldBe "/value/1024/here"
+    }
+
+    @Test
+    fun `path segment expansion - prefix modifier`() {
+        expand("{/var:1,var}") shouldBe "/v/value"
+    }
+
+    @Test
+    fun `path segment expansion - composites`() {
+        expand("{/list}") shouldBe "/red,green,blue"
+        expand("{/list*}") shouldBe "/red/green/blue"
+        expand("{/list*,path:4}") shouldBe "/red/green/blue/%2Ffoo"
+        expand("{/keys}") shouldBe "/semi,%3B,dot,.,comma,%2C"
+        expand("{/keys*}") shouldBe "/semi=%3B/dot=./comma=%2C"
+    }
+
+    //endregion
+    //region Level 3: Path-style parameter expansion {;var} ─────────────────────
+
+    @Test
+    fun `path parameter expansion - basic`() {
+        expand("{;who}") shouldBe ";who=fred"
+        expand("{;half}") shouldBe ";half=50%25"
+        expand("{;empty}") shouldBe ";empty"
+        expand("{;v,empty,who}") shouldBe ";v=6;empty;who=fred"
+        expand("{;v,bar,who}") shouldBe ";v=6;who=fred"
+        expand("{;x,y}") shouldBe ";x=1024;y=768"
+        expand("{;x,y,empty}") shouldBe ";x=1024;y=768;empty"
+        expand("{;x,y,undef}") shouldBe ";x=1024;y=768"
+    }
+
+    @Test
+    fun `path parameter expansion - prefix modifier`() {
+        expand("{;hello:5}") shouldBe ";hello=Hello"
+    }
+
+    @Test
+    fun `path parameter expansion - composites`() {
+        expand("{;list}") shouldBe ";list=red,green,blue"
+        expand("{;list*}") shouldBe ";list=red;list=green;list=blue"
+        expand("{;keys}") shouldBe ";keys=semi,%3B,dot,.,comma,%2C"
+        expand("{;keys*}") shouldBe ";semi=%3B;dot=.;comma=%2C"
+    }
+
+    //endregion
+    //region Level 3: Form-style query expansion {?var} ─────────────────────────
+
+    @Test
+    fun `query expansion - basic`() {
+        expand("{?who}") shouldBe "?who=fred"
+        expand("{?half}") shouldBe "?half=50%25"
+        expand("{?x,y}") shouldBe "?x=1024&y=768"
+        expand("{?x,y,empty}") shouldBe "?x=1024&y=768&empty="
+        expand("{?x,y,undef}") shouldBe "?x=1024&y=768"
+    }
+
+    @Test
+    fun `query expansion - prefix modifier`() {
+        expand("{?var:3}") shouldBe "?var=val"
+    }
+
+    @Test
+    fun `query expansion - composites`() {
+        expand("{?list}") shouldBe "?list=red,green,blue"
+        expand("{?list*}") shouldBe "?list=red&list=green&list=blue"
+        expand("{?keys}") shouldBe "?keys=semi,%3B,dot,.,comma,%2C"
+        expand("{?keys*}") shouldBe "?semi=%3B&dot=.&comma=%2C"
+    }
+
+    //endregion
+    //region Level 3: Form-style query continuation {&var} ──────────────────────
+
+    @Test
+    fun `query continuation - basic`() {
+        expand("{&who}") shouldBe "&who=fred"
+        expand("{&half}") shouldBe "&half=50%25"
+        expand("?fixed=yes{&x}") shouldBe "?fixed=yes&x=1024"
+        expand("{&x,y,empty}") shouldBe "&x=1024&y=768&empty="
+        expand("{&x,y,undef}") shouldBe "&x=1024&y=768"
+    }
+
+    @Test
+    fun `query continuation - prefix modifier`() {
+        expand("{&var:3}") shouldBe "&var=val"
+    }
+
+    @Test
+    fun `query continuation - composites`() {
+        expand("{&list}") shouldBe "&list=red,green,blue"
+        expand("{&list*}") shouldBe "&list=red&list=green&list=blue"
+        expand("{&keys}") shouldBe "&keys=semi,%3B,dot,.,comma,%2C"
+        expand("{&keys*}") shouldBe "&semi=%3B&dot=.&comma=%2C"
+    }
+
+    //endregion
+    //region List operator behaviour (Section 3.2.1) ────────────────────────────
+
+    @Test
+    fun `list expansion across operators`() {
+        expand("{count}") shouldBe "one,two,three"
+        expand("{count*}") shouldBe "one,two,three"
+        expand("{/count}") shouldBe "/one,two,three"
+        expand("{/count*}") shouldBe "/one/two/three"
+        expand("{;count}") shouldBe ";count=one,two,three"
+        expand("{;count*}") shouldBe ";count=one;count=two;count=three"
+        expand("{?count}") shouldBe "?count=one,two,three"
+        expand("{?count*}") shouldBe "?count=one&count=two&count=three"
+        expand("{&count*}") shouldBe "&count=one&count=two&count=three"
+    }
+
+    //endregion
+    //region Literal-only templates ─────────────────────────────────────────────
+
+    @Test
+    fun `literal template without expressions is returned verbatim`() {
+        expand("https://example.com/api/v1") shouldBe "https://example.com/api/v1"
+    }
+
+    @Test
+    fun `literal characters outside expressions pass through or get encoded`() {
+        // Unreserved and reserved chars are allowed in literals
+        expand("http://example.com/~user") shouldBe "http://example.com/~user"
+        // Space in literal gets pct-encoded
+        expand("hello world") shouldBe "hello%20world"
+    }
+
+    //endregion
+    //region Empty and undefined edge-cases ─────────────────────────────────────
+
+    @Test
+    fun `all variables undefined yields empty string for expression`() {
+        // RFC 6570 §3.2.1: when all variables are undefined the expression expands to ""
+        // and operator prefix/first characters are NOT emitted — verified for all 8 operators
+        UriTemplate.expand("{undef}", mapOf("undef" to null)) shouldBe ""
+        UriTemplate.expand("{+undef}", mapOf("undef" to null)) shouldBe ""
+        UriTemplate.expand("{#undef}", mapOf("undef" to null)) shouldBe ""
+        UriTemplate.expand("{.undef}", mapOf("undef" to null)) shouldBe ""
+        UriTemplate.expand("{/undef}", mapOf("undef" to null)) shouldBe ""
+        UriTemplate.expand("{;undef}", mapOf("undef" to null)) shouldBe ""
+        UriTemplate.expand("{?undef}", mapOf("undef" to null)) shouldBe ""
+        UriTemplate.expand("{&undef}", mapOf("undef" to null)) shouldBe ""
+    }
+
+    @Test
+    fun `empty list and empty map are treated as undefined`() {
+        UriTemplate.expand("{list}", mapOf("list" to emptyList<String>())) shouldBe ""
+        UriTemplate.expand("{keys}", mapOf("keys" to emptyMap<String, String>())) shouldBe ""
+    }
+
+    @Test
+    fun `empty expression braces return malformed marker`() {
+        expand("{}") shouldBe "{}"
+    }
+
+    @Test
+    fun `template with unclosed brace throws IllegalArgumentException`() {
+        shouldThrow<IllegalArgumentException> { UriTemplate("{unclosed") }
+    }
+
+    //endregion
+    //region Companion function ─────────────────────────────────────────────────
+
+    @Test
+    fun `companion expand delegates to instance expand`() {
+        UriTemplate.expand("http://example.com/{path}", mapOf("path" to "home")) shouldBe
+            "http://example.com/home"
+    }
+
+    //endregion
+    //region Prefix modifier clamping ───────────────────────────────────────────
+
+    @Test
+    fun `prefix longer than value uses full value`() {
+        UriTemplate.expand("{var:30}", mapOf("var" to "short")) shouldBe "short"
+    }
+
+    @Test
+    fun `prefix of zero is treated as positive constraint clamped to empty`() {
+        // :0 is not valid per the spec (max-length = %x31-39 0*3DIGIT), but we handle it gracefully.
+        UriTemplate.expand("{var:0}", mapOf("var" to "value")) shouldBe ""
+    }
+
+    //endregion
+    //region Non-String variable values ─────────────────────────────────────────
+
+    @Test
+    fun `map entries with null values are filtered out in expansion`() {
+        // resolveValue Map branch: entries where value is null are dropped via mapNotNull
+        val result = UriTemplate.expand("{keys}", mapOf("keys" to mapOf("a" to "1", "b" to null, "c" to "3")))
+        result shouldBe "a,1,c,3"
+    }
+
+    @Test
+    fun `non-String non-List non-Map value is converted via toString`() {
+        // resolveValue's else branch: Int, Boolean, etc. are coerced to String
+        UriTemplate.expand("{n}", mapOf("n" to 42)) shouldBe "42"
+        UriTemplate.expand("{flag}", mapOf("flag" to true)) shouldBe "true"
+    }
+
+    //endregion
+    //region Empty-string element in exploded named-operator list ───────────────
+
+    @Test
+    fun `exploded list with empty-string element uses ifemp for named operators`() {
+        // {;list*} where one element is "" → ;list instead of ;list=
+        UriTemplate.expand("{;list*}", mapOf("list" to listOf("a", "", "b"))) shouldBe ";list=a;list;list=b"
+        // {?list*} where one element is "" → ?list=&... (ifemp = "=")
+        UriTemplate.expand("{?list*}", mapOf("list" to listOf("a", "", "b"))) shouldBe "?list=a&list=&list=b"
+    }
+
+    @Test
+    fun `exploded assoc with empty-string value uses ifemp for named operators`() {
+        // {;keys*} where a value is "" → ;key instead of ;key=
+        UriTemplate.expand("{;keys*}", mapOf("keys" to mapOf("a" to "1", "b" to "", "c" to "3"))) shouldBe
+            ";a=1;b;c=3"
+        // {?keys*} where a value is "" → ?a=1&b=&c=3 (ifemp = "=")
+        UriTemplate.expand("{?keys*}", mapOf("keys" to mapOf("a" to "1", "b" to "", "c" to "3"))) shouldBe
+            "?a=1&b=&c=3"
+    }
+}

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/utils/UriTemplateMatcherTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/utils/UriTemplateMatcherTest.kt
@@ -1,0 +1,173 @@
+package io.modelcontextprotocol.kotlin.sdk.utils
+
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+/**
+ * Unit tests for [UriTemplateMatcher] and [UriTemplate.match] / [UriTemplate.matcher].
+ */
+class UriTemplateMatcherTest {
+
+    //region match() – variable extraction ─────────────────────────────────────
+
+    @Test
+    fun `match returns variable values for simple template`() {
+        val result = UriTemplate("https://example.com/users/{id}").match("https://example.com/users/42")
+        result shouldNotBeNull {
+            variables shouldBe mapOf("id" to "42")
+        }
+    }
+
+    @Test
+    fun `match returns multiple variables`() {
+        val result = UriTemplate("https://api.example.com/users/{userId}/posts/{postId}")
+            .match("https://api.example.com/users/alice/posts/99")
+        result shouldNotBeNull {
+            variables shouldBe mapOf("userId" to "alice", "postId" to "99")
+        }
+    }
+
+    @Test
+    fun `match returns null when URI does not match template`() {
+        UriTemplate("https://example.com/items/{id}").match("https://example.com/other/42") shouldBe null
+    }
+
+    @Test
+    fun `match works with custom scheme template`() {
+        val result = UriTemplate("test://template/{id}/data").match("test://template/abc123/data")
+        result shouldNotBeNull {
+            variables shouldBe mapOf("id" to "abc123")
+        }
+    }
+
+    @Test
+    fun `match returns empty variables for literal-only template`() {
+        val result = UriTemplate("https://example.com/static").match("https://example.com/static")
+        result shouldNotBeNull {
+            variables shouldBe emptyMap()
+        }
+    }
+
+    @Test
+    fun `match returns null when URI is shorter than template`() {
+        UriTemplate("https://example.com/a/{id}/b").match("https://example.com/a/") shouldBe null
+    }
+
+    @Test
+    fun `match operator get returns extracted variable value`() {
+        val result = UriTemplate("{id}").match("42")
+        result shouldNotBeNull {
+            get("id") shouldBe "42"
+            get("missing") shouldBe null
+        }
+    }
+
+    //endregion
+    //region UriTemplate.matches() companion ───────────────────────────────────
+
+    @Test
+    fun `companion matches returns true when URI fits template`() {
+        UriTemplate.matches("test://items/{id}", "test://items/42") shouldBe true
+    }
+
+    @Test
+    fun `companion matches returns false when URI does not fit template`() {
+        UriTemplate.matches("test://items/{id}", "test://other/42") shouldBe false
+    }
+
+    //endregion
+    //region matcher() ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `matcher returns a UriTemplateMatcher consistent with match`() {
+        val tmpl = UriTemplate("test://items/{id}")
+        val matcher = tmpl.matcher()
+        matcher.match("test://items/42") shouldBe tmpl.match("test://items/42")
+    }
+
+    @Test
+    fun `matcher is cached - same instance on repeated calls`() {
+        val tmpl = UriTemplate("test://items/{id}")
+        tmpl.matcher() shouldBe tmpl.matcher()
+    }
+
+    @Test
+    fun `match score equals template literalLength`() {
+        val tmpl = UriTemplate("https://example.com/users/{id}")
+        tmpl.match("https://example.com/users/42")!!.score shouldBe tmpl.literalLength
+    }
+
+    @Test
+    fun `matches returns true for matching URI and false otherwise`() {
+        val matcher = UriTemplate("test://items/{id}").matcher()
+        matcher.matches("test://items/42") shouldBe true
+        matcher.matches("test://other/42") shouldBe false
+    }
+
+    @Test
+    fun `matches returns false when URI has extra path segments beyond template`() {
+        // Verifies the regex is anchored end-to-end; a prefix match must not be accepted
+        val matcher = UriTemplate("test://items/{id}").matcher()
+        matcher.matches("test://items/42/extra") shouldBe false
+        matcher.matches("test://items/42?query=1") shouldBe false
+    }
+
+    //endregion
+    //region multi-variable expression matching ────────────────────────────────
+
+    @Test
+    fun `match extracts all variables from multi-variable query expression`() {
+        val result = UriTemplate("test://search{?x,y}").match("test://search?x=1024&y=768")
+        result shouldNotBeNull {
+            variables shouldBe mapOf("x" to "1024", "y" to "768")
+        }
+    }
+
+    @Test
+    fun `match extracts all variables from multi-variable path expression`() {
+        val result = UriTemplate("test://items/{a},{b}").match("test://items/foo,bar")
+        result shouldNotBeNull {
+            variables shouldBe mapOf("a" to "foo", "b" to "bar")
+        }
+    }
+
+    //endregion
+    //region literalLength / score ──────────────────────────────────────────────
+
+    @Test
+    fun `literalLength counts only literal characters`() {
+        // "https://example.com/users/" = 26 chars
+        UriTemplate("https://example.com/users/{id}").literalLength shouldBe 26
+    }
+
+    @Test
+    fun `more specific template has higher score than generic one`() {
+        val generic = UriTemplate("test://items/{id}")
+        val specific = UriTemplate("test://items/special")
+
+        val uri = "test://items/special"
+        val genericResult = generic.match(uri)
+        val specificResult = specific.match(uri)
+
+        genericResult.shouldNotBeNull()
+        specificResult.shouldNotBeNull()
+        (specificResult.score > genericResult.score) shouldBe true
+    }
+
+    @Test
+    fun `selecting most specific template via score`() {
+        val templates = listOf(
+            UriTemplate("test://items/{id}"),
+            UriTemplate("test://items/{id}/details"),
+            UriTemplate("test://items/special/details"),
+        )
+        val uri = "test://items/special/details"
+        val best = templates.mapNotNull { it.match(uri) }.maxByOrNull { it.score }
+
+        best.shouldNotBeNull()
+        best.score shouldBe "test://items/special/details".length
+    }
+
+    //endregion
+}

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/utils/UriTemplateParsingTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/utils/UriTemplateParsingTest.kt
@@ -1,0 +1,338 @@
+package io.modelcontextprotocol.kotlin.sdk.utils
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.modelcontextprotocol.kotlin.sdk.utils.UriTemplateParser.Modifier
+import io.modelcontextprotocol.kotlin.sdk.utils.UriTemplateParser.Part
+import io.modelcontextprotocol.kotlin.sdk.utils.UriTemplateParser.VarSpec
+import kotlin.test.Test
+
+/**
+ * Unit tests for [UriTemplateParser] — verifies the parsed [Part] model,
+ * operator properties, modifier detection, literal encoding, and encoding
+ * helpers. These test the intermediate representation, not just the final
+ * expanded string.
+ */
+class UriTemplateParsingTest {
+
+    //region parse() — structural model ─────────────────────────────────────────
+
+    @Test
+    fun `empty template produces no parts`() {
+        UriTemplateParser.parse("") shouldBe emptyList()
+    }
+
+    @Test
+    fun `literal-only template produces a single Literal part`() {
+        UriTemplateParser.parse("hello/world") shouldBe listOf(Part.Literal("hello/world"))
+    }
+
+    @Test
+    fun `single expression produces an Expression part with NUL operator`() {
+        val parts = UriTemplateParser.parse("{var}")
+        parts.size shouldBe 1
+        val expr = parts[0] as Part.Expression
+        expr.op shouldBe UriTemplateParser.NUL_OP
+        expr.varSpecs shouldBe listOf(VarSpec("var", Modifier.None))
+    }
+
+    @Test
+    fun `mixed literal and expression produces two parts in order`() {
+        val parts = UriTemplateParser.parse("users/{id}")
+        parts shouldBe listOf(
+            Part.Literal("users/"),
+            Part.Expression(UriTemplateParser.NUL_OP, listOf(VarSpec("id", Modifier.None))),
+        )
+    }
+
+    @Test
+    fun `adjacent expressions with no literal produce two Expression parts`() {
+        val parts = UriTemplateParser.parse("{a}{b}")
+        parts.size shouldBe 2
+        (parts[0] as Part.Expression).varSpecs[0].name shouldBe "a"
+        (parts[1] as Part.Expression).varSpecs[0].name shouldBe "b"
+    }
+
+    @Test
+    fun `expression surrounded by literals produces three parts`() {
+        val parts = UriTemplateParser.parse("prefix/{id}/suffix")
+        parts shouldBe listOf(
+            Part.Literal("prefix/"),
+            Part.Expression(UriTemplateParser.NUL_OP, listOf(VarSpec("id", Modifier.None))),
+            Part.Literal("/suffix"),
+        )
+    }
+
+    //endregion
+    //region Operator detection ─────────────────────────────────────────────────
+
+    @Test
+    fun `all seven operator chars are parsed correctly`() {
+        val cases = mapOf(
+            "{+var}" to '+',
+            "{#var}" to '#',
+            "{.var}" to '.',
+            "{/var}" to '/',
+            "{;var}" to ';',
+            "{?var}" to '?',
+            "{&var}" to '&',
+        )
+        for ((template, expectedChar) in cases) {
+            val op = (UriTemplateParser.parse(template)[0] as Part.Expression).op
+            op.char shouldBe expectedChar
+        }
+    }
+
+    @Test
+    fun `only plus and hash operators allow reserved characters`() {
+        val allowReserved = setOf('+', '#')
+        val allOps = listOf("+", "#", ".", "/", ";", "?", "&", "")
+        for (prefix in allOps) {
+            val op = (UriTemplateParser.parse("{${prefix}var}")[0] as Part.Expression).op
+            op.allowReserved shouldBe (op.char in allowReserved)
+        }
+    }
+
+    @Test
+    fun `named operators are semicolon question mark and ampersand`() {
+        val namedOps = setOf(';', '?', '&')
+        val allOps = listOf("+", "#", ".", "/", ";", "?", "&", "")
+        for (prefix in allOps) {
+            val op = (UriTemplateParser.parse("{${prefix}var}")[0] as Part.Expression).op
+            op.named shouldBe (op.char in namedOps)
+        }
+    }
+
+    @Test
+    fun `ifemp is = for query operators and empty for others`() {
+        val queryOps = setOf('?', '&')
+        val allOps = listOf("+", "#", ".", "/", ";", "?", "&", "")
+        for (prefix in allOps) {
+            val op = (UriTemplateParser.parse("{${prefix}var}")[0] as Part.Expression).op
+            op.ifemp shouldBe (if (op.char in queryOps) "=" else "")
+        }
+    }
+
+    @Test
+    fun `operator first and sep strings match RFC 6570 Appendix A table`() {
+        // RFC 6570 Appendix A value table (first, sep per operator):
+        //   NUL  ""   ","  |  +   ""   ","  |  #   "#"  ","
+        //   .    "."  "."  |  /   "/"  "/"  |  ;   ";"  ";"
+        //   ?    "?"  "&"  |  &   "&"  "&"
+        val expected = mapOf(
+            "" to ("" to ","),
+            "+" to ("" to ","),
+            "#" to ("#" to ","),
+            "." to ("." to "."),
+            "/" to ("/" to "/"),
+            ";" to (";" to ";"),
+            "?" to ("?" to "&"),
+            "&" to ("&" to "&"),
+        )
+        for ((prefix, firstSep) in expected) {
+            val op = (UriTemplateParser.parse("{${prefix}var}")[0] as Part.Expression).op
+            val (expectedFirst, expectedSep) = firstSep
+            op.first shouldBe expectedFirst
+            op.sep shouldBe expectedSep
+        }
+    }
+
+    //endregion
+    //region VarSpec modifier detection ─────────────────────────────────────────
+
+    @Test
+    fun `no modifier produces Modifier None`() {
+        val spec = (UriTemplateParser.parse("{var}")[0] as Part.Expression).varSpecs[0]
+        spec.modifier shouldBe Modifier.None
+    }
+
+    @Test
+    fun `trailing asterisk produces Modifier Explode`() {
+        val spec = (UriTemplateParser.parse("{list*}")[0] as Part.Expression).varSpecs[0]
+        spec.name shouldBe "list"
+        spec.modifier shouldBe Modifier.Explode
+    }
+
+    @Test
+    fun `colon-integer produces Modifier Prefix with correct length`() {
+        (UriTemplateParser.parse("{var:3}")[0] as Part.Expression).varSpecs[0].modifier shouldBe Modifier.Prefix(3)
+        (UriTemplateParser.parse("{var:30}")[0] as Part.Expression).varSpecs[0].modifier shouldBe Modifier.Prefix(30)
+        (UriTemplateParser.parse("{var:1000}")[0] as Part.Expression).varSpecs[0].modifier shouldBe
+            Modifier.Prefix(1000)
+    }
+
+    @Test
+    fun `prefix length of zero is not valid and falls back to None`() {
+        // RFC 6570: max-length = %x31-39 0*3DIGIT (must start with 1-9)
+        val spec = (UriTemplateParser.parse("{var:0}")[0] as Part.Expression).varSpecs[0]
+        spec.modifier shouldBe Modifier.None
+    }
+
+    @Test
+    fun `non-numeric prefix falls back to None modifier`() {
+        val spec = (UriTemplateParser.parse("{var:abc}")[0] as Part.Expression).varSpecs[0]
+        spec.modifier shouldBe Modifier.None
+    }
+
+    @Test
+    fun `multiple variables in one expression are all parsed`() {
+        val specs = (UriTemplateParser.parse("{x,y,z}")[0] as Part.Expression).varSpecs
+        specs.map { it.name } shouldBe listOf("x", "y", "z")
+        specs.all { it.modifier == Modifier.None } shouldBe true
+    }
+
+    @Test
+    fun `mixed modifiers in multi-variable expression`() {
+        val specs = (UriTemplateParser.parse("{var:3,list*,plain}")[0] as Part.Expression).varSpecs
+        specs[0] shouldBe VarSpec("var", Modifier.Prefix(3))
+        specs[1] shouldBe VarSpec("list", Modifier.Explode)
+        specs[2] shouldBe VarSpec("plain", Modifier.None)
+    }
+
+    //endregion
+    //region Empty expression ───────────────────────────────────────────────────
+
+    @Test
+    fun `empty braces produce Expression with NUL_OP and no varSpecs`() {
+        val expr = UriTemplateParser.parse("{}")[0] as Part.Expression
+        expr.op shouldBe UriTemplateParser.NUL_OP
+        expr.varSpecs shouldBe emptyList()
+    }
+
+    //endregion
+    //region Malformed templates ────────────────────────────────────────────────
+
+    @Test
+    fun `unclosed brace throws IllegalArgumentException`() {
+        shouldThrow<IllegalArgumentException> {
+            UriTemplateParser.parse("{unclosed")
+        }.message shouldContain "Unclosed brace"
+    }
+
+    @Test
+    fun `unclosed brace mid-template throws IllegalArgumentException`() {
+        shouldThrow<IllegalArgumentException> {
+            UriTemplateParser.parse("foo/{unclosed")
+        }.message shouldContain "Unclosed brace"
+    }
+
+    @Test
+    fun `unclosed brace at end of otherwise valid template throws`() {
+        shouldThrow<IllegalArgumentException> {
+            UriTemplateParser.parse("users/{id}/posts/{")
+        }.message shouldContain "Unclosed brace"
+    }
+
+    @Test
+    fun `error message includes the offending template string`() {
+        val template = "bad/{template"
+        shouldThrow<IllegalArgumentException> {
+            UriTemplateParser.parse(template)
+        }.message shouldContain template
+    }
+
+    //endregion
+    //region Literal PCT-encoding ───────────────────────────────────────────────
+
+    @Test
+    fun `space in literal is pct-encoded to space`() {
+        UriTemplateParser.parse("hello world") shouldBe listOf(Part.Literal("hello%20world"))
+    }
+
+    @Test
+    fun `percent sign in literal passes through unchanged`() {
+        // % is allowed verbatim in literals (already pct-encoded in source)
+        UriTemplateParser.parse("50%25") shouldBe listOf(Part.Literal("50%25"))
+    }
+
+    @Test
+    fun `reserved characters in literals pass through unchanged`() {
+        // All of :/?#[]@!$&'()*+,;= are allowed verbatim in URI template literals
+        UriTemplateParser.parse("https://host/path?q=1&r=2") shouldBe
+            listOf(Part.Literal("https://host/path?q=1&r=2"))
+    }
+
+    @Test
+    fun `non-ascii character in literal is pct-encoded as utf-8`() {
+        // é (U+00E9) → UTF-8 0xC3 0xA9 → %C3%A9
+        UriTemplateParser.parse("caf\u00E9") shouldBe listOf(Part.Literal("caf%C3%A9"))
+    }
+
+    //endregion
+    //region pctEncode ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `pctEncode leaves unreserved characters unchanged`() {
+        val unreserved = "abcxyzABCXYZ0189-._~"
+        UriTemplateParser.pctEncode(unreserved, allowReserved = false) shouldBe unreserved
+        UriTemplateParser.pctEncode(unreserved, allowReserved = true) shouldBe unreserved
+    }
+
+    @Test
+    fun `pctEncode encodes space in both modes`() {
+        UriTemplateParser.pctEncode(" ", allowReserved = false) shouldBe "%20"
+        UriTemplateParser.pctEncode(" ", allowReserved = true) shouldBe "%20"
+    }
+
+    @Test
+    fun `pctEncode passes reserved chars through only when allowReserved is true`() {
+        UriTemplateParser.pctEncode(":/", allowReserved = true) shouldBe ":/"
+        UriTemplateParser.pctEncode(":/", allowReserved = false) shouldBe "%3A%2F"
+    }
+
+    @Test
+    fun `pctEncode preserves existing pct-triplets only when allowReserved is true`() {
+        UriTemplateParser.pctEncode("50%25", allowReserved = true) shouldBe "50%25"
+        // When allowReserved is false, % itself is encoded
+        UriTemplateParser.pctEncode("50%25", allowReserved = false) shouldBe "50%2525"
+    }
+
+    @Test
+    fun `pctEncode encodes non-ascii as utf-8 pct-triplets`() {
+        // é (U+00E9) → UTF-8 0xC3 0xA9 → %C3%A9
+        UriTemplateParser.pctEncode("\u00E9", allowReserved = false) shouldBe "%C3%A9"
+    }
+
+    //endregion
+    //region truncateCodePoints ─────────────────────────────────────────────────
+
+    @Test
+    fun `truncateCodePoints truncates ascii strings by code point count`() {
+        UriTemplateParser.truncateCodePoints("hello", 3) shouldBe "hel"
+        UriTemplateParser.truncateCodePoints("hello", 10) shouldBe "hello"
+        UriTemplateParser.truncateCodePoints("hello", 0) shouldBe ""
+    }
+
+    @Test
+    fun `truncateCodePoints treats each BMP character as one code point`() {
+        // é (U+00E9) is a BMP character — one Char, one code point
+        UriTemplateParser.truncateCodePoints("caf\u00E9", 3) shouldBe "caf"
+        UriTemplateParser.truncateCodePoints("caf\u00E9", 4) shouldBe "caf\u00E9"
+    }
+
+    @Test
+    fun `truncateCodePoints counts a surrogate pair as one code point`() {
+        // 😀 U+1F600 → surrogate pair \uD83D\uDE00 (two Chars, one code point)
+        val emoji = "\uD83D\uDE00"
+        UriTemplateParser.truncateCodePoints("a${emoji}b", 1) shouldBe "a"
+        UriTemplateParser.truncateCodePoints("a${emoji}b", 2) shouldBe "a$emoji"
+        UriTemplateParser.truncateCodePoints("a${emoji}b", 3) shouldBe "a${emoji}b"
+    }
+
+    @Test
+    fun `pctEncode encodes surrogate pair as utf-8 pct-triplets`() {
+        // 😀 U+1F600 → UTF-8 F0 9F 98 80 → %F0%9F%98%80
+        val emoji = "\uD83D\uDE00"
+        UriTemplateParser.pctEncode(emoji, allowReserved = false) shouldBe "%F0%9F%98%80"
+        UriTemplateParser.pctEncode(emoji, allowReserved = true) shouldBe "%F0%9F%98%80"
+    }
+
+    @Test
+    fun `pctEncode recognises lowercase hex digits in pct-triplets when allowReserved is true`() {
+        // %2f uses lowercase hex — must be preserved as-is, not re-encoded
+        UriTemplateParser.pctEncode("a%2fb", allowReserved = true) shouldBe "a%2fb"
+        // Lowercase that isn't a valid triplet gets encoded normally
+        UriTemplateParser.pctEncode("a%gg", allowReserved = true) shouldBe "a%25gg"
+    }
+}

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/utils/UriTemplateTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/utils/UriTemplateTest.kt
@@ -1,0 +1,42 @@
+package io.modelcontextprotocol.kotlin.sdk.utils
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class UriTemplateTest {
+
+    @Test
+    fun `equal template strings produce equal UriTemplate instances`() {
+        UriTemplate("test://items/{id}") shouldBe UriTemplate("test://items/{id}")
+    }
+
+    @Test
+    fun `different template strings produce unequal UriTemplate instances`() {
+        val a = UriTemplate("test://items/{id}")
+        val b = UriTemplate("test://items/{name}")
+        (a == b) shouldBe false
+    }
+
+    @Test
+    fun `hashCode is consistent with equals`() {
+        val a = UriTemplate("test://items/{id}")
+        val b = UriTemplate("test://items/{id}")
+        a.hashCode() shouldBe b.hashCode()
+    }
+
+    @Test
+    fun `toString includes the template string`() {
+        UriTemplate("test://items/{id}").toString() shouldBe "UriTemplate(test://items/{id})"
+    }
+
+    @Test
+    fun `constructor throws IllegalArgumentException for unclosed brace`() {
+        shouldThrow<IllegalArgumentException> { UriTemplate("test://items/{id") }
+    }
+
+    @Test
+    fun `constructor throws IllegalArgumentException for unclosed brace mid-template`() {
+        shouldThrow<IllegalArgumentException> { UriTemplate("users/{id}/posts/{") }
+    }
+}


### PR DESCRIPTION
Implements [RFC-6570](https://www.rfc-editor.org/rfc/rfc6570.txt) URI Templates (`UriTemplate`, `UriTemplateMatcher`, `UriTemplateParser`) in `kotlin-sdk-core` with full Level 1–4 expansion and regex-based reverse matching.                                
   
  - **Expansion** — all 8 operators (`{var}`, `{+var}`, `{#var}`, `{.var}`, `{/var}`, `{;var}`, `{?var}`, `{&var}`), prefix modifiers (`{var:3}`), and explode modifiers (`{var*}`) for string, list, and associative-array values.                                  
  - **Matching** — `UriTemplate.match(uri)` extracts all variables from every expression (including multi-variable `{?x,y}`) and returns a specificity `score` (literal character count) for disambiguating overlapping templates.                                                                                                                                                                                            
  - **Performance** — template parsed eagerly on construction; compiled `Regex` cached lazily via `matcher()` (only when matching is needed); pre-allocated `OpInfo` singletons for all 8 operators; literal-only templates skip variable extraction entirely.   

## Motivation and Context

Prerequisite for #502, see [resource-templates](https://modelcontextprotocol.io/specification/2025-11-25/server/resources#resource-templates)

## How Has This Been Tested?

Implemented unit tests for conformance with all expansion levels and path operators.

## Breaking Changes
No

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
