### PR TITLE
Fix response buffering in StreamableHttpClientTransport

### DIFF
--- a/kotlin-sdk-client/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/client/StreamableHttpClientTransport.kt
+++ b/kotlin-sdk-client/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/client/StreamableHttpClientTransport.kt
@@ -10,7 +10,7 @@ import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.accept
 import io.ktor.client.request.delete
 import io.ktor.client.request.headers
-import io.ktor.client.request.post
+import io.ktor.client.request.preparePost
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsChannel
@@ -131,60 +131,60 @@ public class StreamableHttpClientTransport(
         }
 
         val jsonBody = McpJson.encodeToString(message)
-        val response = client.post(url) {
+        client.preparePost(url) {
             applyCommonHeaders(this)
             headers.append(HttpHeaders.Accept, "${ContentType.Application.Json}, ${ContentType.Text.EventStream}")
             contentType(ContentType.Application.Json)
             setBody(jsonBody)
             requestBuilder()
-        }
+        }.execute { response ->
+            response.headers[MCP_SESSION_ID_HEADER]?.let { sessionId = it }
 
-        response.headers[MCP_SESSION_ID_HEADER]?.let { sessionId = it }
-
-        if (response.status == HttpStatusCode.Accepted) {
-            if (message is JSONRPCNotification && message.method == "notifications/initialized") {
-                startSseSession(onResumptionToken = options?.onResumptionToken)
-            }
-            return
-        }
-
-        if (!response.status.isSuccess()) {
-            val error = StreamableHttpError(response.status.value, response.bodyAsText())
-            _onError(error)
-            throw error
-        }
-
-        when (response.contentType()?.withoutParameters()) {
-            ContentType.Application.Json -> response.bodyAsText().takeIf { it.isNotEmpty() }?.let { json ->
-                runCatching { McpJson.decodeFromString<JSONRPCMessage>(json) }
-                    .onSuccess { _onMessage(it) }
-                    .onFailure {
-                        _onError(it)
-                        throw it
-                    }
-            }
-
-            ContentType.Text.EventStream -> {
-                val replayMessageId = if (message is JSONRPCRequest) message.id else null
-                val result = handleInlineSse(response, replayMessageId, options?.onResumptionToken)
-                if (result.hasPrimingEvent && !result.receivedResponse) {
-                    startSseSession(
-                        resumptionToken = result.lastEventId,
-                        replayMessageId = replayMessageId,
-                        onResumptionToken = options?.onResumptionToken,
-                        initialServerRetryDelay = result.serverRetryDelay,
-                    )
+            if (response.status == HttpStatusCode.Accepted) {
+                if (message is JSONRPCNotification && message.method == "notifications/initialized") {
+                    startSseSession(onResumptionToken = options?.onResumptionToken)
                 }
+                return@execute
             }
 
-            else -> {
-                val body = response.bodyAsText()
-                if (response.contentType() == null && body.isBlank()) return
-
-                val ct = response.contentType()?.toString() ?: "<none>"
-                val error = StreamableHttpError(-1, "Unexpected content type: $ct")
+            if (!response.status.isSuccess()) {
+                val error = StreamableHttpError(response.status.value, response.bodyAsText())
                 _onError(error)
                 throw error
+            }
+
+            when (response.contentType()?.withoutParameters()) {
+                ContentType.Application.Json -> response.bodyAsText().takeIf { it.isNotEmpty() }?.let { json ->
+                    runCatching { McpJson.decodeFromString<JSONRPCMessage>(json) }
+                        .onSuccess { _onMessage(it) }
+                        .onFailure {
+                            _onError(it)
+                            throw it
+                        }
+                }
+
+                ContentType.Text.EventStream -> {
+                    val replayMessageId = if (message is JSONRPCRequest) message.id else null
+                    val result = handleInlineSse(response, replayMessageId, options?.onResumptionToken)
+                    if (result.hasPrimingEvent && !result.receivedResponse) {
+                        startSseSession(
+                            resumptionToken = result.lastEventId,
+                            replayMessageId = replayMessageId,
+                            onResumptionToken = options?.onResumptionToken,
+                            initialServerRetryDelay = result.serverRetryDelay,
+                        )
+                    }
+                }
+
+                else -> {
+                    val body = response.bodyAsText()
+                    if (response.contentType() == null && body.isBlank()) return@execute
+
+                    val ct = response.contentType()?.toString() ?: "<none>"
+                    val error = StreamableHttpError(-1, "Unexpected content type: $ct")
+                    _onError(error)
+                    throw error
+                }
             }
         }
     }

--- a/kotlin-sdk-client/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/client/streamable/http/StreamableHttpClientTransportTest.kt
+++ b/kotlin-sdk-client/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/client/streamable/http/StreamableHttpClientTransportTest.kt
@@ -16,7 +16,9 @@ import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.content.TextContent
 import io.ktor.http.headersOf
+import io.ktor.utils.io.ByteChannel
 import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.writeStringUtf8
 import io.modelcontextprotocol.kotlin.sdk.client.Client
 import io.modelcontextprotocol.kotlin.sdk.client.StreamableHttpClientTransport
 import io.modelcontextprotocol.kotlin.sdk.types.Implementation
@@ -31,6 +33,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.RequestId
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
@@ -547,6 +550,85 @@ class StreamableHttpClientTransportTest {
 
         transport.close()
     }
+
+
+    @Test
+    fun testInlineSSEEventsDeliveredIncrementally() = runTest {
+        val channel = ByteChannel(autoFlush = true)
+
+        val transport = createTransport { request ->
+            if (request.method == HttpMethod.Post) {
+                respond(
+                    content = channel,
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(
+                        HttpHeaders.ContentType,
+                        ContentType.Text.EventStream.toString(),
+                    ),
+                )
+            } else {
+                respond("", HttpStatusCode.OK)
+            }
+        }
+
+        val receivedMessages = mutableListOf<JSONRPCMessage>()
+        val firstMessageReceived = CompletableDeferred<Unit>()
+
+        transport.onMessage { message ->
+            receivedMessages.add(message)
+            if (receivedMessages.size == 1 && !firstMessageReceived.isCompleted) {
+                firstMessageReceived.complete(Unit)
+            }
+        }
+
+        transport.start()
+
+        val sendJob = launch(Dispatchers.Default) {
+            transport.send(
+                JSONRPCRequest(
+                    id = "stream-test",
+                    method = "test",
+                    params = buildJsonObject { },
+                ),
+            )
+        }
+
+        withContext(Dispatchers.Default) {
+            channel.writeStringUtf8(
+                buildSseMessage(
+                    id = "1",
+                    method = "notifications/progress",
+                    params = """{"progressToken":"t1","progress":50,"total":100}""",
+                ),
+            )
+            withTimeout(5.seconds) { firstMessageReceived.await() }
+            channel.writeStringUtf8(
+                buildSseMessage(
+                    id = "2",
+                    method = "notifications/progress",
+                    params = """{"progressToken":"t1","progress":100,"total":100}""",
+                ),
+            )
+            channel.close()
+        }
+
+        sendJob.join()
+
+        receivedMessages shouldHaveSize 2
+
+        val firstNotification = receivedMessages[0] as JSONRPCNotification
+        firstNotification.method shouldBe "notifications/progress"
+        val firstParams = firstNotification.params as JsonObject
+        (firstParams["progress"] as JsonPrimitive).content.toInt() shouldBe 50
+
+        val secondNotification = receivedMessages[1] as JSONRPCNotification
+        secondNotification.method shouldBe "notifications/progress"
+        val secondParams = secondNotification.params as JsonObject
+        (secondParams["progress"] as JsonPrimitive).content.toInt() shouldBe 100
+
+        transport.close()
+    }
+
 
     @Test
     fun testErrorInSSEResponse() = runTest {


### PR DESCRIPTION
In StreamableHttpClientTransport, use client.preparePost instead of client.post() to avoid buffering the response body.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
