### PR TITLE
fix(ci): add node setup in release workflow

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
 
+      - name: Check
+        run: ./gradlew check --no-configuration-cache
+
       - name: Publish to Maven Central Portal
         id: publish
         run: ./gradlew publishToMavenCentral --no-configuration-cache

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -24,11 +24,13 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22' # increase only after https://github.com/nodejs/node/issues/56645 will be fixed
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
-
-      - name: Build
-        run: ./gradlew build --rerun-tasks --max-workers 2 --continue
 
       - name: Publish to Maven Central Portal
         id: publish


### PR DESCRIPTION
- Added `setup-node` with Node.js 22 to the release workflow — without it, TypeScript integration tests fail because the macOS runner has an incompatible pre-installed Node.js version

