### PR TITLE
chore: drop deprecated watchosX64 and tvosX64 targets

### DIFF
--- a/kotlin-sdk-client/build.gradle.kts
+++ b/kotlin-sdk-client/build.gradle.kts
@@ -14,10 +14,8 @@ kotlin {
     iosArm64()
     iosX64()
     iosSimulatorArm64()
-    watchosX64()
     watchosArm64()
     watchosSimulatorArm64()
-    tvosX64()
     tvosArm64()
     tvosSimulatorArm64()
     js {

--- a/kotlin-sdk-core/build.gradle.kts
+++ b/kotlin-sdk-core/build.gradle.kts
@@ -35,10 +35,8 @@ kotlin {
     iosArm64()
     iosX64()
     iosSimulatorArm64()
-    watchosX64()
     watchosArm64()
     watchosSimulatorArm64()
-    tvosX64()
     tvosArm64()
     tvosSimulatorArm64()
     js {

--- a/kotlin-sdk-testing/build.gradle.kts
+++ b/kotlin-sdk-testing/build.gradle.kts
@@ -14,10 +14,8 @@ kotlin {
     iosArm64()
     iosX64()
     iosSimulatorArm64()
-    watchosX64()
     watchosArm64()
     watchosSimulatorArm64()
-    tvosX64()
     tvosArm64()
     tvosSimulatorArm64()
     js {

--- a/test-utils/build.gradle.kts
+++ b/test-utils/build.gradle.kts
@@ -11,10 +11,8 @@ kotlin {
     iosArm64()
     iosX64()
     iosSimulatorArm64()
-    watchosX64()
     watchosArm64()
     watchosSimulatorArm64()
-    tvosX64()
     tvosArm64()
     tvosSimulatorArm64()
     js {


### PR DESCRIPTION
Drop the deprecated `watchosX64` and `tvosX64`

## Breaking Changes
consumers that depended on `watchosX64` or `tvosX64` artifacts will need to migrate to the corresponding ARM/simulator targets.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
