### PR TITLE
chore: remove redundant JUnit XML report configuration

### DIFF
--- a/buildSrc/src/main/kotlin/mcp.multiplatform.gradle.kts
+++ b/buildSrc/src/main/kotlin/mcp.multiplatform.gradle.kts
@@ -45,11 +45,6 @@ kotlin {
                 events("failed")
             }
             systemProperty("kotest.output.ansi", "true")
-            reports {
-                junitXml.required.set(true)
-                junitXml.includeSystemOutLog.set(true)
-                junitXml.includeSystemErrLog.set(true)
-            }
         }
     }
     macosArm64()


### PR DESCRIPTION
The `junitXml.required`, `includeSystemOutLog` and `includeSystemErrLog` properties all default to `true` in Gradle JUnitXmlReport, so setting them explicitly was a no-op. The latter two are also @Incubating API