### PR TITLE
feat(server): expose client implementation and capabilities to handlers

### DIFF
--- a/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ClientConnectionTest.kt
+++ b/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ClientConnectionTest.kt
@@ -11,6 +11,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.ElicitationCompleteNotification
 import io.modelcontextprotocol.kotlin.sdk.types.ElicitationCompleteNotificationParams
 import io.modelcontextprotocol.kotlin.sdk.types.GetPromptRequest
 import io.modelcontextprotocol.kotlin.sdk.types.GetPromptRequestParams
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import io.modelcontextprotocol.kotlin.sdk.types.ListRootsRequest
 import io.modelcontextprotocol.kotlin.sdk.types.ListRootsResult
 import io.modelcontextprotocol.kotlin.sdk.types.LoggingLevel
@@ -70,6 +71,8 @@ class ClientConnectionTest : AbstractServerFeaturesTest() {
         val pingComplete = CompletableDeferred<Unit>()
         val rootsResult = CompletableDeferred<ListRootsResult>()
         val sessionId = CompletableDeferred<String>()
+        val clientImplementation = CompletableDeferred<Implementation?>()
+        val clientCapabilities = CompletableDeferred<ClientCapabilities?>()
         val toolListChanged =
             onClientNotification<ToolListChangedNotification>(Method.Defined.NotificationsToolsListChanged)
         val resourceListChanged =
@@ -120,6 +123,12 @@ class ClientConnectionTest : AbstractServerFeaturesTest() {
                     elicitationComplete.await().params.elicitationId shouldBe "elicit-123"
                 }
                 capturedSessionId.shouldNotBeBlank()
+                withClue("clientImplementation should expose the connected client's name and version") {
+                    clientImplementation.await() shouldBe Implementation(name = "test client", version = "1.0")
+                }
+                withClue("clientCapabilities should expose what the client advertised at initialize") {
+                    clientCapabilities.await() shouldBe getClientCapabilities()
+                }
             }
         }
     }
@@ -142,6 +151,8 @@ class ClientConnectionTest : AbstractServerFeaturesTest() {
             ElicitationCompleteNotification(ElicitationCompleteNotificationParams(elicitationId = "elicit-123")),
         )
         cap.sessionId.complete(sessionId)
+        cap.clientImplementation.complete(clientImplementation)
+        cap.clientCapabilities.complete(clientCapabilities)
     }
 
     @Test

--- a/kotlin-sdk-server/api/kotlin-sdk-server.api
+++ b/kotlin-sdk-server/api/kotlin-sdk-server.api
@@ -7,6 +7,8 @@ public abstract interface class io/modelcontextprotocol/kotlin/sdk/server/Client
 	public static synthetic fun createElicitation$default (Lio/modelcontextprotocol/kotlin/sdk/server/ClientConnection;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/modelcontextprotocol/kotlin/sdk/shared/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public abstract fun createMessage (Lio/modelcontextprotocol/kotlin/sdk/types/CreateMessageRequest;Lio/modelcontextprotocol/kotlin/sdk/shared/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun createMessage$default (Lio/modelcontextprotocol/kotlin/sdk/server/ClientConnection;Lio/modelcontextprotocol/kotlin/sdk/types/CreateMessageRequest;Lio/modelcontextprotocol/kotlin/sdk/shared/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun getClientCapabilities ()Lio/modelcontextprotocol/kotlin/sdk/types/ClientCapabilities;
+	public abstract fun getClientImplementation ()Lio/modelcontextprotocol/kotlin/sdk/types/Implementation;
 	public abstract fun getSessionId ()Ljava/lang/String;
 	public abstract fun listRoots (Lio/modelcontextprotocol/kotlin/sdk/types/ListRootsRequest;Lio/modelcontextprotocol/kotlin/sdk/shared/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun listRoots$default (Lio/modelcontextprotocol/kotlin/sdk/server/ClientConnection;Lio/modelcontextprotocol/kotlin/sdk/types/ListRootsRequest;Lio/modelcontextprotocol/kotlin/sdk/shared/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;

--- a/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ClientConnection.kt
+++ b/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ClientConnection.kt
@@ -2,6 +2,7 @@ package io.modelcontextprotocol.kotlin.sdk.server
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.modelcontextprotocol.kotlin.sdk.shared.RequestOptions
+import io.modelcontextprotocol.kotlin.sdk.types.ClientCapabilities
 import io.modelcontextprotocol.kotlin.sdk.types.CreateMessageRequest
 import io.modelcontextprotocol.kotlin.sdk.types.CreateMessageResult
 import io.modelcontextprotocol.kotlin.sdk.types.ElicitRequest
@@ -11,6 +12,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.ElicitRequestURLParams
 import io.modelcontextprotocol.kotlin.sdk.types.ElicitResult
 import io.modelcontextprotocol.kotlin.sdk.types.ElicitationCompleteNotification
 import io.modelcontextprotocol.kotlin.sdk.types.EmptyResult
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import io.modelcontextprotocol.kotlin.sdk.types.IncludeContext
 import io.modelcontextprotocol.kotlin.sdk.types.ListRootsRequest
 import io.modelcontextprotocol.kotlin.sdk.types.ListRootsResult
@@ -40,6 +42,19 @@ public interface ClientConnection {
      * Has no inherent meaning.
      */
     public val sessionId: String
+
+    /**
+     * The client's reported [Implementation] (name and version) after initialization.
+     */
+    public val clientImplementation: Implementation?
+
+    /**
+     * The client's reported [ClientCapabilities] after initialization.
+     *
+     * Consult before invoking [createMessage], [listRoots], or [createElicitation]
+     * to fall back gracefully when a capability is not advertised.
+     */
+    public val clientCapabilities: ClientCapabilities?
 
     /**
      * Sends a server-side notification to the client.
@@ -178,6 +193,10 @@ public interface ClientConnection {
 internal class ClientConnectionImpl(private val session: ServerSession) : ClientConnection {
 
     override val sessionId: String get() = session.sessionId
+
+    override val clientImplementation: Implementation? get() = session.clientVersion
+
+    override val clientCapabilities: ClientCapabilities? get() = session.clientCapabilities
 
     private suspend fun <T : RequestResult> request(request: Request, options: RequestOptions? = null): T {
         logger.trace { "Sending request to client for session $sessionId: $request" }


### PR DESCRIPTION
Adds `clientImplementation` and `clientCapabilities` properties on `ClientConnection`, delegating to what `ServerSession` already tracks during the initialize handshake.

closes #552

## Motivation and Context
Server handlers (tools, prompts, resources) currently have no first-class way to read the connected client's name/version or advertised capabilities. The only workaround is to extract the full `ServerSession` from the `Server` instance via `sessionId` — awkward, and easy to get wrong. This blocks two real use cases:

- Adapting handler behavior for known client-side quirks
- Gracefully falling back when a capability (sampling, roots, elicitation) is not advertised, instead of letting `createMessage`/`listRoots`/`createElicitation` fail with a non-specific `IllegalStateException`

## How Has This Been Tested?
Integration tests in `ClientConnectionTest` assert both properties are populated inside tool, prompt, and resource handlers (matching the existing `callAllMethods` pattern that exercises every `ClientConnection` member).

```
./gradlew :integration-test:jvmTest --tests "*ClientConnectionTest"
./gradlew :kotlin-sdk-server:apiCheck
./gradlew :kotlin-sdk-server:detekt :integration-test:detekt
./gradlew :integration-test:ktlintCheck
```

## Breaking Changes
None for consumers. Adds two abstract members to `ClientConnection`, which would require any external implementer to recompile — but `ClientConnectionImpl` is the only implementation and is `internal`.

A small naming note: `clientImplementation` matches the MCP spec's `clientInfo: Implementation` field as suggested in the issue. This creates temporary dual naming with the existing `ServerSession.clientVersion` (also an `Implementation`). Renaming `ServerSession.clientVersion` is a wider public-API change, so I left it as a follow-up unless maintainers want it bundled here.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed