### PR TITLE
fix: require status field to discriminate GetTaskResult from GetTaskPayloadResult

### DIFF
--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/serializers.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/serializers.kt
@@ -415,7 +415,11 @@ private fun selectClientResultDeserializer(element: JsonElement): Deserializatio
         "action" in jsonObject -> ElicitResult.serializer()
         "task" in jsonObject -> CreateTaskResult.serializer()
         "tasks" in jsonObject -> ListTasksResult.serializer()
-        "taskId" in jsonObject -> GetTaskResult.serializer()
+        // GetTaskResult always has both taskId and status. Matching on taskId alone
+        // would incorrectly capture GetTaskPayloadResult responses (tasks/result),
+        // which wrap arbitrary JSON and may not contain status.
+        // See https://github.com/modelcontextprotocol/kotlin-sdk/issues/601
+        "taskId" in jsonObject && "status" in jsonObject -> GetTaskResult.serializer()
         else -> null
     }
 }
@@ -438,7 +442,9 @@ private fun selectServerResultDeserializer(element: JsonElement): Deserializatio
         "content" in jsonObject -> CallToolResult.serializer()
         "task" in jsonObject -> CreateTaskResult.serializer()
         "tasks" in jsonObject -> ListTasksResult.serializer()
-        "taskId" in jsonObject -> GetTaskResult.serializer()
+        // Require status alongside taskId to distinguish GetTaskResult from
+        // GetTaskPayloadResult, which wraps arbitrary JSON.
+        "taskId" in jsonObject && "status" in jsonObject -> GetTaskResult.serializer()
         else -> null
     }
 }

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/TasksTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/TasksTest.kt
@@ -6,6 +6,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.modelcontextprotocol.kotlin.test.utils.verifyDeserialization
 import io.modelcontextprotocol.kotlin.test.utils.verifySerialization
+import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
@@ -775,6 +776,40 @@ class TasksTest {
         )
 
         meta.relatedTask.shouldBeNull()
+    }
+
+    @Test
+    fun `task payload result with content field is not deserialized as GetTaskResult`() {
+        // A tasks/result response wraps arbitrary JSON (e.g. a CallToolResult).
+        // It may contain "taskId" but will NOT contain "status".
+        // The deserializer must not match this as GetTaskResult.
+        val json = buildJsonObject {
+            put("content", kotlinx.serialization.json.buildJsonArray {
+                add(buildJsonObject {
+                    put("type", "text")
+                    put("text", "hello")
+                })
+            })
+        }
+
+        // Should not match GetTaskResult since there is no "status" field
+        val result = McpJson.decodeFromJsonElement(RequestResultPolymorphicSerializer, json)
+        result.shouldBeInstanceOf<CallToolResult>()
+    }
+
+    @Test
+    fun `task get result with status is correctly deserialized as GetTaskResult`() {
+        val json = buildJsonObject {
+            put("taskId", "task-1")
+            put("status", "working")
+            put("createdAt", "2025-01-01T00:00:00Z")
+            put("lastUpdatedAt", "2025-01-01T00:01:00Z")
+            put("ttl", 60000)
+        }
+
+        val result = McpJson.decodeFromJsonElement(RequestResultPolymorphicSerializer, json)
+        result.shouldBeInstanceOf<GetTaskResult>()
+        result.taskId shouldBe "task-1"
     }
 
     @Test


### PR DESCRIPTION
## Motivation and Context

Fixes #601

The content-based polymorphic deserializer in `selectClientResultDeserializer` and `selectServerResultDeserializer` matches `GetTaskResult` on the presence of `"taskId"` alone. This incorrectly captures `GetTaskPayloadResult` responses (`tasks/result`), which wrap arbitrary JSON and may also contain a `"taskId"` key but not a `"status"` key.

When `Protocol.request<GetTaskPayloadResult>()` receives a response that was deserialized as `GetTaskResult`, the unchecked `as T` cast at line 478 of Protocol.kt throws a `ClassCastException`.

## Fix

Tighten the discriminator in both `selectClientResultDeserializer` and `selectServerResultDeserializer` to require both `"taskId"` and `"status"`, since `GetTaskResult` always has both fields (status is required per the MCP task schema). `GetTaskPayloadResult` responses (which lack `"status"`) now correctly fall through to other deserializers or the empty result handler.

## How Has This Been Tested?

Added two test cases to `TasksTest`:

1. **`task payload result with content field is not deserialized as GetTaskResult`**: verifies that a `CallToolResult`-shaped JSON (with `"content"` but no `"status"`) is correctly deserialized as `CallToolResult`, not `GetTaskResult`
2. **`task get result with status is correctly deserialized as GetTaskResult`**: verifies that JSON with both `"taskId"` and `"status"` is still correctly deserialized as `GetTaskResult`

All 37 existing tests continue to pass.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling