### PR TITLE
fix(stdio): process messages concurrently to prevent deadlocks

### DIFF
--- a/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/StdioServerTransport.kt
+++ b/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/StdioServerTransport.kt
@@ -153,14 +153,19 @@ public class StdioServerTransport(private val inputStream: Source, outputStream:
             }
 
             if (message == null) break
-            // Async invocation broke delivery order
-            try {
-                _onMessage.invoke(message)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Throwable) {
-                logger.error(e) { "Error processing message" }
-                _onError.invoke(e)
+            // Launch each message handler concurrently so long-running
+            // request handlers (e.g. tool calls) do not block processing
+            // of subsequent messages (pings, elicitation responses, etc.).
+            // See https://github.com/modelcontextprotocol/kotlin-sdk/issues/572
+            scope.launch {
+                try {
+                    _onMessage.invoke(message)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Throwable) {
+                    logger.error(e) { "Error processing message" }
+                    _onError.invoke(e)
+                }
             }
         }
     }

--- a/kotlin-sdk-server/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/StdioServerTransportTest.kt
+++ b/kotlin-sdk-server/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/StdioServerTransportTest.kt
@@ -245,6 +245,10 @@ class StdioServerTransportTest {
         inputWriter.flush()
 
         secondMessageProcessed.await()
+        // With concurrent message processing, the error from the first
+        // message handler is delivered asynchronously on IODispatcher.
+        // Wait briefly for the error callback to fire.
+        kotlinx.coroutines.delay(100)
 
         capturedErrors shouldContain throwable
         receivedMessages shouldBe listOf(message2)


### PR DESCRIPTION
## Motivation and Context

Fixes #572

`StdioServerTransport.processReadBuffer()` invokes each message handler sequentially: `_onMessage.invoke(message)` blocks the loop until the handler returns. A long-running tool call (e.g., one that waits for elicitation) blocks all subsequent messages, including pings, progress notifications, and the elicitation response itself. This creates deadlocks for any bidirectional communication pattern.

As noted by @rnett in #572:
> This creates deadlocks for any bidirectional communication, which is now easy with `ClientConnection`. Even for `ping`.

## Fix

Launch each message handler in its own coroutine via `scope.launch` instead of awaiting it inline. The `ReadBuffer` parsing remains sequential (required for correct JSON-RPC framing), but handler execution is now concurrent.

This is the minimal transport-level fix. A prior attempt (#610) placed concurrency in `AbstractTransport` but was closed due to complications with transports that already handle concurrency (SSE server). This PR scopes the change to `StdioServerTransport` only.

## Test changes

The error-handling parameterized test (`should continue processing messages after handler throws`) needed a brief `delay(100)` after `secondMessageProcessed.await()` because the error callback from the first message's coroutine now fires asynchronously on `IODispatcher` rather than synchronously in the processing loop.

## How Has This Been Tested?

All 17 `StdioServerTransportTest` cases pass, including the 3 parameterized error-handling variants.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling