### PR TITLE
fix(server): preserve id on duplicate initialize errors

### DIFF
--- a/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/StreamableHttpServerTransport.kt
+++ b/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/StreamableHttpServerTransport.kt
@@ -370,9 +370,10 @@ public class StreamableHttpServerTransport(private val configuration: Configurat
             }
 
             val messages = parseBody(call) ?: return
-            val isInitializationRequest = messages.any {
-                it is JSONRPCRequest && it.method == Method.Defined.Initialize.value
+            val initializationRequest = messages.filterIsInstance<JSONRPCRequest>().firstOrNull {
+                it.method == Method.Defined.Initialize.value
             }
+            val isInitializationRequest = initializationRequest != null
 
             if (isInitializationRequest) {
                 if (initialized.load() && sessionId != null) {
@@ -380,6 +381,7 @@ public class StreamableHttpServerTransport(private val configuration: Configurat
                         HttpStatusCode.BadRequest,
                         RPCError.ErrorCode.INVALID_REQUEST,
                         "Invalid Request: Server already initialized",
+                        initializationRequest.id,
                     )
                     return
                 }
@@ -414,8 +416,7 @@ public class StreamableHttpServerTransport(private val configuration: Configurat
             // For initialize requests, get from request params.
             // For other requests, get from header (already validated).
             val clientProtocolVersion = if (isInitializationRequest) {
-                val initRequest = messages.first() as JSONRPCRequest
-                (initRequest.params as? JsonObject)?.get("protocolVersion")
+                (initializationRequest.params as? JsonObject)?.get("protocolVersion")
                     ?.let { McpJson.decodeFromJsonElement<String>(it) }
                     ?: DEFAULT_NEGOTIATED_PROTOCOL_VERSION
             } else {
@@ -784,7 +785,12 @@ public class StreamableHttpServerTransport(private val configuration: Configurat
     }
 }
 
-internal suspend fun ApplicationCall.reject(status: HttpStatusCode, code: Int, message: String) {
+internal suspend fun ApplicationCall.reject(
+    status: HttpStatusCode,
+    code: Int,
+    message: String,
+    id: RequestId? = null,
+) {
     this.response.status(status)
-    this.respond(JSONRPCError(id = null, error = RPCError(code = code, message = message)))
+    this.respond(JSONRPCError(id = id, error = RPCError(code = code, message = message)))
 }

--- a/kotlin-sdk-server/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/StreamableHttpServerTransportTest.kt
+++ b/kotlin-sdk-server/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/StreamableHttpServerTransportTest.kt
@@ -33,6 +33,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import io.modelcontextprotocol.kotlin.sdk.types.InitializeRequest
 import io.modelcontextprotocol.kotlin.sdk.types.InitializeRequestParams
 import io.modelcontextprotocol.kotlin.sdk.types.InitializedNotification
+import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCError
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCMessage
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCRequest
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCResponse
@@ -146,7 +147,7 @@ class StreamableHttpServerTransportTest {
     }
 
     @Test
-    fun `second initialization request returns an HTTP error`() = testApplication {
+    fun `second initialization request returns JSON-RPC error with request id`() = testApplication {
         configTestServer()
 
         val client = createTestClient()
@@ -169,13 +170,17 @@ class StreamableHttpServerTransportTest {
 
         firstResponse.status shouldBe HttpStatusCode.OK
 
+        val secondRequest = buildInitializeRequestPayload().copy(id = RequestId("second-init"))
         val secondResponse = client.post(path) {
             addStreamableHeaders()
             header("mcp-session-id", firstResponse.headers[MCP_SESSION_ID_HEADER])
-            setBody(payload)
+            setBody(secondRequest)
         }
 
         secondResponse.status shouldBe HttpStatusCode.BadRequest
+        val error = secondResponse.body<JSONRPCError>()
+        error.id shouldBe secondRequest.id
+        error.error.message shouldBe "Invalid Request: Server already initialized"
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #866.

## Changes

- Preserve the parsed JSON-RPC request id when Streamable HTTP rejects a duplicate `initialize` request.
- Keep pre-parse and transport-level rejection paths unchanged when the request id is not available.
- Extend the duplicate-initialize regression test to assert the error response id as well as the HTTP status.

## Verification

```bash
./gradlew :kotlin-sdk-server:jvmTest --tests 'io.modelcontextprotocol.kotlin.sdk.server.StreamableHttpServerTransportTest.second initialization request returns JSON-RPC error with request id'
./gradlew :kotlin-sdk-server:jvmTest --tests 'io.modelcontextprotocol.kotlin.sdk.server.StreamableHttpServerTransportTest'
./gradlew :kotlin-sdk-server:jvmTest
./gradlew :kotlin-sdk-server:ktlintCheck :kotlin-sdk-server:detekt
```

