### PR TITLE
fix(core): apply the request timeout while awaiting the response

### DIFF
--- a/kotlin-sdk-client/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/client/streamable/http/StreamableHttpClientTransportTest.kt
+++ b/kotlin-sdk-client/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/client/streamable/http/StreamableHttpClientTransportTest.kt
@@ -471,7 +471,7 @@ class StreamableHttpClientTransportTest {
         )
 
         try {
-            // Real time-keeping is needed; otherwise Protocol will always throw TimeoutCancellationException in tests
+            // Real time-keeping is needed; otherwise Protocol will always fail the request with a timeout in tests
             val mcpException = assertFailsWith<McpException>(
                 message = "Expected client.connect to fail on invalid JSON response",
             ) {

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/shared/Protocol.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/shared/Protocol.kt
@@ -32,6 +32,8 @@ import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -483,9 +485,6 @@ public abstract class Protocol(@PublishedApi internal val options: ProtocolOptio
         }
 
         val cancel: suspend (Throwable) -> Unit = { reason: Throwable ->
-            _responseHandlers.update { current -> current.remove(jsonRpcRequestId) }
-            _progressHandlers.update { current -> current.remove(jsonRpcRequestId) }
-
             val notification = CancelledNotification(
                 params = CancelledNotificationParams(
                     requestId = jsonRpcRequestId,
@@ -502,22 +501,29 @@ public abstract class Protocol(@PublishedApi internal val options: ProtocolOptio
 
         val timeout = options?.timeout ?: DEFAULT_REQUEST_TIMEOUT
         try {
-            withTimeout(timeout) {
+            return withTimeout(timeout) {
                 logger.trace { "Sending request message with id: $jsonRpcRequestId" }
                 this@Protocol.transport?.send(jsonRpcRequest, options)
+                result.await()
             }
-            return result.await()
         } catch (cause: TimeoutCancellationException) {
+            // An enclosing withTimeout cancelling us also surfaces here as a TCE; rethrow instead of converting.
+            currentCoroutineContext().ensureActive()
+
             logger.error { "Request timed out after ${timeout.inWholeMilliseconds}ms: ${request.method}" }
-            cancel(
-                McpException(
-                    code = RPCError.ErrorCode.REQUEST_TIMEOUT,
-                    message = "Request timed out",
-                    data = JsonObject(mutableMapOf("timeout" to JsonPrimitive(timeout.inWholeMilliseconds))),
-                ),
+            val error = McpException(
+                code = RPCError.ErrorCode.REQUEST_TIMEOUT,
+                message = "Request timed out",
+                data = JsonObject(mutableMapOf("timeout" to JsonPrimitive(timeout.inWholeMilliseconds))),
+                cause = cause,
             )
+            cancel(error)
             result.cancel(cause)
-            throw cause
+            throw error
+        } finally {
+            // Centralized cleanup so no exit path leaves this request's handlers registered.
+            _responseHandlers.update { current -> current.remove(jsonRpcRequestId) }
+            _progressHandlers.update { current -> current.remove(jsonRpcRequestId) }
         }
     }
 

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/shared/ProtocolTimeoutTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/shared/ProtocolTimeoutTest.kt
@@ -1,0 +1,219 @@
+package io.modelcontextprotocol.kotlin.sdk.shared
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.maps.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.modelcontextprotocol.kotlin.sdk.types.CustomRequest
+import io.modelcontextprotocol.kotlin.sdk.types.EmptyResult
+import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCMessage
+import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCNotification
+import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCRequest
+import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCResponse
+import io.modelcontextprotocol.kotlin.sdk.types.McpException
+import io.modelcontextprotocol.kotlin.sdk.types.McpJson
+import io.modelcontextprotocol.kotlin.sdk.types.Method
+import io.modelcontextprotocol.kotlin.sdk.types.RPCError
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.jsonObject
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class ProtocolTimeoutTest {
+    private lateinit var protocol: TimeoutTestProtocol
+    private lateinit var transport: TimeoutTestTransport
+
+    @BeforeTest
+    fun setUp() {
+        protocol = TimeoutTestProtocol()
+        transport = TimeoutTestTransport()
+    }
+
+    private fun newRequest() = CustomRequest(method = Method.Custom("example"), params = null)
+
+    @Test
+    fun `should fail request with REQUEST_TIMEOUT when no response arrives within timeout`() = runTest {
+        protocol.connect(transport)
+
+        val exception = shouldThrow<McpException> {
+            protocol.request<EmptyResult>(newRequest(), RequestOptions(timeout = 100.milliseconds))
+        }
+
+        exception.code shouldBe RPCError.ErrorCode.REQUEST_TIMEOUT
+        exception.cause.shouldBeInstanceOf<TimeoutCancellationException>()
+    }
+
+    @Test
+    fun `should clean up handlers and notify cancellation when request times out`() = runTest {
+        protocol.connect(transport)
+
+        shouldThrow<McpException> {
+            protocol.request<EmptyResult>(
+                newRequest(),
+                RequestOptions(timeout = 100.milliseconds, onProgress = {}),
+            )
+        }
+
+        protocol.responseHandlers shouldHaveSize 0
+        protocol.progressHandlers shouldHaveSize 0
+
+        val sent = transport.awaitRequest()
+        val cancellations = transport.sentCancellations()
+        cancellations shouldHaveSize 1
+        cancellations[0].params?.jsonObject?.get("requestId") shouldBe McpJson.encodeToJsonElement(sent.id)
+    }
+
+    @Test
+    fun `should complete request normally when response arrives within timeout`() = runTest {
+        protocol.connect(transport)
+
+        val inFlight = async {
+            protocol.request<EmptyResult>(newRequest(), RequestOptions(timeout = 5.seconds))
+        }
+
+        val sent = transport.awaitRequest()
+        transport.deliver(JSONRPCResponse(sent.id, EmptyResult()))
+
+        inFlight.await() shouldBe EmptyResult()
+        transport.sentCancellations() shouldHaveSize 0
+        protocol.responseHandlers shouldHaveSize 0
+    }
+
+    @Test
+    fun `should propagate the caller's own timeout cancellation instead of reporting a request timeout`() = runTest {
+        protocol.connect(transport)
+
+        shouldThrow<TimeoutCancellationException> {
+            withTimeout(50.milliseconds) {
+                protocol.request<EmptyResult>(
+                    newRequest(),
+                    RequestOptions(timeout = 10.seconds, onProgress = {}),
+                )
+            }
+        }
+
+        transport.sentCancellations() shouldHaveSize 0
+        protocol.responseHandlers shouldHaveSize 0
+        protocol.progressHandlers shouldHaveSize 0
+    }
+
+    @Test
+    fun `should clean up handlers when the caller cancels while awaiting the response`() = runTest {
+        protocol.connect(transport)
+
+        val inFlight = async {
+            protocol.request<EmptyResult>(newRequest(), RequestOptions(timeout = 10.seconds, onProgress = {}))
+        }
+        transport.awaitRequest()
+        protocol.responseHandlers shouldHaveSize 1
+        protocol.progressHandlers shouldHaveSize 1
+
+        inFlight.cancelAndJoin()
+
+        protocol.responseHandlers shouldHaveSize 0
+        protocol.progressHandlers shouldHaveSize 0
+    }
+
+    @Test
+    fun `should clean up handlers when sending the request fails`() = runTest {
+        val throwingTransport = ThrowingSendTransport()
+        protocol.connect(throwingTransport)
+
+        shouldThrow<IllegalStateException> {
+            protocol.request<EmptyResult>(newRequest(), RequestOptions(onProgress = {}))
+        }
+
+        protocol.responseHandlers shouldHaveSize 0
+        protocol.progressHandlers shouldHaveSize 0
+    }
+
+    @Test
+    fun `should fail request with REQUEST_TIMEOUT when sending the request exceeds the timeout`() = runTest {
+        val slowTransport = SlowSendTransport(delayFor = 10.seconds)
+        protocol.connect(slowTransport)
+
+        val exception = shouldThrow<McpException> {
+            protocol.request<EmptyResult>(newRequest(), RequestOptions(timeout = 100.milliseconds))
+        }
+
+        exception.code shouldBe RPCError.ErrorCode.REQUEST_TIMEOUT
+    }
+}
+
+private class TimeoutTestProtocol : Protocol(null) {
+    override fun assertCapabilityForMethod(method: Method) {
+        // noop
+    }
+    override fun assertNotificationCapability(method: Method) {
+        // noop
+    }
+    override fun assertRequestHandlerCapability(method: Method) {
+        // noop
+    }
+}
+
+private open class TimeoutTestTransport : Transport {
+    val sent = mutableListOf<JSONRPCMessage>()
+    private val requests = Channel<JSONRPCRequest>(Channel.UNLIMITED)
+    private var onMessageCallback: (suspend (JSONRPCMessage) -> Unit)? = null
+
+    override suspend fun start() {
+        // noop
+    }
+
+    override suspend fun send(message: JSONRPCMessage, options: TransportSendOptions?) {
+        sent += message
+        if (message is JSONRPCRequest) {
+            requests.trySend(message)
+        }
+    }
+
+    override suspend fun close() {
+        // noop
+    }
+
+    override fun onClose(block: () -> Unit) {
+        // noop
+    }
+
+    override fun onError(block: (Throwable) -> Unit) {
+        // noop
+    }
+
+    override fun onMessage(block: suspend (JSONRPCMessage) -> Unit) {
+        onMessageCallback = block
+    }
+
+    suspend fun awaitRequest(): JSONRPCRequest = requests.receive()
+
+    suspend fun deliver(message: JSONRPCMessage) {
+        val callback = onMessageCallback ?: error("onMessage callback not registered")
+        callback(message)
+    }
+
+    fun sentCancellations(): List<JSONRPCNotification> =
+        sent.filterIsInstance<JSONRPCNotification>().filter { it.method == "notifications/cancelled" }
+}
+
+private class SlowSendTransport(private val delayFor: Duration) : TimeoutTestTransport() {
+    override suspend fun send(message: JSONRPCMessage, options: TransportSendOptions?) {
+        delay(delayFor)
+        super.send(message, options)
+    }
+}
+
+private class ThrowingSendTransport : TimeoutTestTransport() {
+    override suspend fun send(message: JSONRPCMessage, options: TransportSendOptions?): Unit =
+        throw IllegalStateException("send failed")
+}


### PR DESCRIPTION
Make `Protocol.request()` apply `RequestOptions.timeout` to the whole send-and-response-wait sequence, surface the documented `McpException` (code `RequestTimeout`) when it fires, and remove each request's response/progress handlers on every exit path.

closes #869

## Motivation and Context

`withTimeout` wrapped only `transport.send(...)`; `result.await()` was outside the block, so a request against a peer that never delivers a response stayed suspended past `RequestOptions.timeout`. Details in #869.

## How Has This Been Tested?

Added `ProtocolTimeoutTest` (7 cases) covering the timeout, caller-cancellation, normal-completion, and send-failure paths. They pass locally; reverting this change makes 6 of the 7 fail on `main` (only the normal-completion case still passes), confirming the tests pin the new behavior. Locally, the JVM test suites of all modules, the `integration-test` `ClientTest` suite, and `apiCheck` / `ktlintCheck` / `detekt` also pass.

## Breaking Changes

No public API changes (`apiCheck` passes). For the newly-covered response-wait path, this turns an indefinite suspension into the documented `McpException` (code `RequestTimeout`). The exception-type change from `TimeoutCancellationException` to that `McpException` (with the underlying `TimeoutCancellationException` attached as `cause`) only affects the pre-existing path where `send` itself blocked past the timeout.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

- Moving `result.await()` inside `withTimeout` means an enclosing scope's cancellation (e.g. a caller's own `withTimeout`) can also surface in the catch as a `TimeoutCancellationException`. `currentCoroutineContext().ensureActive()` at the top of the catch rethrows it, so a genuine cancellation is not converted into a request-timeout error (covered by the existing caller-side-timeout integration test, `should handle request timeout`).
- A `finally` now removes the request's response/progress handler entries on every exit path (completion, timeout, caller cancellation, send failure). This closes a pre-existing leak when the caller cancels mid-await or the send fails, and keeps the cancellation guard above from leaking on the enclosing-`withTimeout` path.
- On caller-initiated cancellation the request now propagates the cancellation and cleans up without attempting to send `notifications/cancelled` from the cancelled coroutine. A best-effort courtesy notification from `NonCancellable` could be considered separately.
- Also updates one stale test comment (`StreamableHttpClientTransportTest`) that described the previous exception type.