### PR TITLE
Close stateless Streamable HTTP session after request completion

### DIFF
--- a/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/KtorServer.kt
+++ b/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/KtorServer.kt
@@ -380,11 +380,17 @@ private suspend fun RoutingContext.mcpStatelessStreamableHttpEndpoint(
     logger.info { "New stateless StreamableHttp connection established without sessionId" }
 
     val server = block()
-    server.onClose { logger.info { "Server connection closed without sessionId" } }
-    server.createSession(transport)
+    val session = server.createSession(transport)
 
-    transport.handleRequest(null, this.call)
-    logger.debug { "Server connected to transport without sessionId" }
+    try {
+        transport.handleRequest(null, this.call)
+        logger.debug { "Server connected to transport without sessionId" }
+    } finally {
+        // A stateless session serves exactly one request: close it so the server's
+        // session registry and notification subscriptions do not grow unboundedly.
+        session.close()
+        logger.debug { "Stateless session closed after request completion" }
+    }
 }
 
 private suspend fun RoutingContext.mcpPostEndpoint(transportManager: TransportManager<SseServerTransport>) {

--- a/kotlin-sdk-server/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/StatelessStreamableHttpSessionLifecycleTest.kt
+++ b/kotlin-sdk-server/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/StatelessStreamableHttpSessionLifecycleTest.kt
@@ -1,0 +1,100 @@
+package io.modelcontextprotocol.kotlin.sdk.server
+
+import io.kotest.assertions.nondeterministic.eventually
+import io.kotest.matchers.maps.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.testing.testApplication
+import io.modelcontextprotocol.kotlin.sdk.types.ClientCapabilities
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+import io.modelcontextprotocol.kotlin.sdk.types.InitializeRequest
+import io.modelcontextprotocol.kotlin.sdk.types.InitializeRequestParams
+import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCMessage
+import io.modelcontextprotocol.kotlin.sdk.types.LATEST_PROTOCOL_VERSION
+import io.modelcontextprotocol.kotlin.sdk.types.McpJson
+import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
+import io.modelcontextprotocol.kotlin.sdk.types.toJSON
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Verifies that the stateless Streamable HTTP endpoint does not leak server sessions:
+ * every session created to serve a single request must be closed and removed from the
+ * session registry once that request completes (https://github.com/modelcontextprotocol/kotlin-sdk/issues/786).
+ */
+class StatelessStreamableHttpSessionLifecycleTest {
+
+    private fun testServer(): Server = Server(
+        Implementation("test-server", "1.0"),
+        ServerOptions(capabilities = ServerCapabilities()),
+    )
+
+    @Test
+    fun `stateless endpoint removes session after each request`() = testApplication {
+        val server = testServer()
+        application {
+            mcpStatelessStreamableHttp { server }
+        }
+
+        repeat(5) {
+            val response = client.post("/mcp") {
+                addStreamableHeaders()
+                setBody(initializeRequestBody())
+            }
+            response.status shouldBe HttpStatusCode.OK
+        }
+
+        eventually(5.seconds) {
+            server.sessions.shouldBeEmpty()
+        }
+    }
+
+    @Test
+    fun `stateless endpoint removes session when the request is rejected`() = testApplication {
+        val server = testServer()
+        application {
+            mcpStatelessStreamableHttp { server }
+        }
+
+        // Missing "text/event-stream" in Accept makes the transport reject the request.
+        val response = client.post("/mcp") {
+            header(HttpHeaders.Host, "localhost")
+            header(HttpHeaders.Accept, ContentType.Application.Json.toString())
+            contentType(ContentType.Application.Json)
+            setBody(initializeRequestBody())
+        }
+        response.status shouldBe HttpStatusCode.NotAcceptable
+
+        eventually(5.seconds) {
+            server.sessions.shouldBeEmpty()
+        }
+    }
+
+    private fun HttpRequestBuilder.addStreamableHeaders() {
+        header(HttpHeaders.Host, "localhost")
+        header(
+            HttpHeaders.Accept,
+            listOf(ContentType.Application.Json, ContentType.Text.EventStream).joinToString(", "),
+        )
+        contentType(ContentType.Application.Json)
+    }
+
+    private fun initializeRequestBody(): String {
+        val request = InitializeRequest(
+            InitializeRequestParams(
+                protocolVersion = LATEST_PROTOCOL_VERSION,
+                capabilities = ClientCapabilities(),
+                clientInfo = Implementation(name = "test-client", version = "1.0.0"),
+            ),
+        ).toJSON()
+
+        return McpJson.encodeToString(JSONRPCMessage.serializer(), request)
+    }
+}


### PR DESCRIPTION
## Goal

Fixes #786 — the stateless Streamable HTTP endpoint (`Application.mcpStatelessStreamableHttp`) registers a new `ServerSession` for every incoming POST request but never removes it, so the session registry and its notification-service subscriptions grow without bound across requests.

## Summary

- `mcpStatelessStreamableHttpEndpoint` now closes the per-request session in a `finally` block once `transport.handleRequest` returns. Closing the session closes the transport, which fires the cleanup registered in `Server.createSession` (`notificationService.unsubscribeSession` + `sessionRegistry.removeSession`), so `Removing session` now balances `Adding session`.
- Removed the per-request `server.onClose { log }` registration. `Server.onClose` chains callbacks, so when the factory block returns a shared `Server` instance this accumulated one callback per request — a second unbounded growth on the same path.

## Design decisions

- Only the session is closed, not the `Server`: the factory block may legitimately return a shared `Server` instance across requests, and `Server.close()` would tear down its notification service and all other sessions.
- Cleanup runs in `finally` so sessions are also released when the request is rejected (e.g. invalid `Accept` header) or `handleRequest` throws. `StreamableHttpServerTransport.close()` already runs under `NonCancellable`, so cleanup survives call cancellation.

## Testing

New `StatelessStreamableHttpSessionLifecycleTest` (jvmTest), written first to reproduce the leak:
- `stateless endpoint removes session after each request` — 5 POSTs against a shared `Server`; asserts every request succeeds and `server.sessions` drains to empty (previously stayed at 5).
- `stateless endpoint removes session when the request is rejected` — a POST rejected by header validation must not leak its session either (previously leaked, since the session was created before validation).

Verified locally: `:kotlin-sdk-server:jvmTest`, `ktlintCheck`, `detekt`, and `apiCheck` all pass. No public API changes.