### PR TITLE
feat: add Kotlin SDK BOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ This Kotlin SDK implements the MCP specification, making it easy to:
 ### Artifacts
 
 - `io.modelcontextprotocol:kotlin-sdk` – umbrella SDK (client + server APIs)
+- `io.modelcontextprotocol:kotlin-sdk-bom` – version alignment for the core, client, and server artifacts
 - `io.modelcontextprotocol:kotlin-sdk-client` – client-only APIs
 - `io.modelcontextprotocol:kotlin-sdk-server` – server-only APIs
 
@@ -96,6 +97,17 @@ Use _kotlin-sdk-client_ or _kotlin-sdk-server_ if you only need one side of the 
 dependencies {
     implementation("io.modelcontextprotocol:kotlin-sdk-client:$mcpVersion")
     implementation("io.modelcontextprotocol:kotlin-sdk-server:$mcpVersion")
+}
+```
+
+To keep the core, client, and server artifacts on the same version, import the BOM and omit versions from the
+individual SDK dependencies:
+
+```kotlin
+dependencies {
+    implementation(platform("io.modelcontextprotocol:kotlin-sdk-bom:$mcpVersion"))
+    implementation("io.modelcontextprotocol:kotlin-sdk-client")
+    implementation("io.modelcontextprotocol:kotlin-sdk-server")
 }
 ```
 

--- a/kotlin-sdk-bom/build.gradle.kts
+++ b/kotlin-sdk-bom/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    `java-platform`
+    id("mcp.publishing")
+}
+
+dependencies {
+    constraints {
+        api(project(":kotlin-sdk-core"))
+        api(project(":kotlin-sdk-client"))
+        api(project(":kotlin-sdk-server"))
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,6 +22,7 @@ include(
     ":kotlin-sdk-core",
     ":kotlin-sdk-client",
     ":kotlin-sdk-server",
+    ":kotlin-sdk-bom",
     ":kotlin-sdk-testing",
     ":kotlin-sdk",
     ":integration-test",


### PR DESCRIPTION
## Summary

- add a publishable `kotlin-sdk-bom` Java platform
- constrain `kotlin-sdk-core`, `kotlin-sdk-client`, and `kotlin-sdk-server` to the project version
- document importing the BOM and using versionless SDK dependencies

The module reuses the existing `mcp.publishing` convention, so its POM carries the same Maven Central metadata and signing setup as the other SDK artifacts. It publishes platform metadata and a POM, not a runtime JAR.

Fixes #351

## Validation

- `./gradlew :kotlin-sdk-bom:clean :kotlin-sdk-bom:build :kotlin-sdk-bom:generatePomFileForMavenPublication ktlintCheck detekt apiCheck --stacktrace --continue`
- published the BOM to an isolated Maven repository and verified that an external Gradle consumer resolves all three versionless SDK modules to `0.15.0`
- `./gradlew jvmTest :conformance-test:build :docs:build :kotlin-sdk-bom:build --max-workers 3 --continue`

A broader `./gradlew build --max-workers 3 --continue --rerun-tasks` completed the JVM suites and platform compilation until Apple native link tasks required Xcode, which is not installed in this environment (`xcrun xcodebuild -version` exits 72). Those Apple link tasks are left to macOS CI.
