### PR TITLE
fix(server): gate resource not found errors by protocol version

### DIFF
--- a/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/kotlin/AbstractResourceIntegrationTest.kt
+++ b/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/kotlin/AbstractResourceIntegrationTest.kt
@@ -21,6 +21,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.util.concurrent.CopyOnWriteArrayList
@@ -208,6 +210,8 @@ abstract class AbstractResourceIntegrationTest : KotlinTestBase() {
             exception.code,
             "Exception code should be RESOURCE_NOT_FOUND: ${RPCError.ErrorCode.RESOURCE_NOT_FOUND}",
         )
+        assertEquals("Resource not found", exception.message)
+        assertEquals(buildJsonObject { put("uri", invalidUri) }, exception.data)
     }
 
     @Test

--- a/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ServerResourceTemplateTest.kt
+++ b/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ServerResourceTemplateTest.kt
@@ -18,6 +18,8 @@ import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
 import io.modelcontextprotocol.kotlin.sdk.types.TextResourceContents
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
@@ -119,12 +121,15 @@ class ServerResourceTemplateTest : AbstractServerFeaturesTest() {
     }
 
     @Test
-    fun `readResource should return RESOURCE_NOT_FOUND error when no match`() = runTest {
+    fun `readResource should return legacy error with URI for current protocol`() = runTest {
+        val uri = "test://nonexistent/uri"
         val exception = assertThrows<McpException> {
-            client.readResource(ReadResourceRequest(ReadResourceRequestParams("test://nonexistent/uri")))
+            client.readResource(ReadResourceRequest(ReadResourceRequestParams(uri)))
         }
 
         exception.code shouldBe RPCError.ErrorCode.RESOURCE_NOT_FOUND
+        exception.message shouldBe "Resource not found"
+        exception.data shouldBe buildJsonObject { put("uri", uri) }
     }
 
     @Test

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/jsonRpc.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/jsonRpc.kt
@@ -266,7 +266,11 @@ public data class RPCError(val code: Int, val message: String, val data: JsonEle
         /** Request timed out */
         public const val REQUEST_TIMEOUT: Int = -32001
 
-        /** Resource not found */
+        /**
+         * Legacy resource-not-found code used by MCP 2025-11-25 and earlier.
+         *
+         * MCP 2026-07-28 and later use [INVALID_PARAMS] for missing resources.
+         */
         public const val RESOURCE_NOT_FOUND: Int = -32002
 
         /** The request selected a protocol version that the receiver does not support. */

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/JsonRpcTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/JsonRpcTest.kt
@@ -476,4 +476,10 @@ class JsonRpcTest {
         val message = McpJson.decodeFromString<JSONRPCMessage>(json)
         message shouldBeSameInstanceAs JSONRPCEmptyMessage
     }
+
+    @Test
+    fun `should expose legacy and standard resource not found error codes`() {
+        assertEquals(-32002, RPCError.ErrorCode.RESOURCE_NOT_FOUND)
+        assertEquals(-32602, RPCError.ErrorCode.INVALID_PARAMS)
+    }
 }

--- a/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/Server.kt
+++ b/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/Server.kt
@@ -62,6 +62,15 @@ import kotlin.jvm.JvmOverloads
 import kotlin.time.ExperimentalTime
 
 private val logger = KotlinLogging.logger {}
+private const val STANDARD_RESOURCE_NOT_FOUND_PROTOCOL_VERSION = "2026-07-28"
+
+internal fun resourceNotFoundErrorCode(protocolVersion: String?): Int =
+    // MCP protocol versions use ISO YYYY-MM-DD, so lexical and chronological ordering match.
+    if (protocolVersion != null && protocolVersion >= STANDARD_RESOURCE_NOT_FOUND_PROTOCOL_VERSION) {
+        RPCError.ErrorCode.INVALID_PARAMS
+    } else {
+        RPCError.ErrorCode.RESOURCE_NOT_FOUND
+    }
 
 /**
  * Configuration options for the MCP server.
@@ -714,7 +723,7 @@ public open class Server(
             ?: run {
                 logger.error { "Resource not found: $uri" }
                 throw McpException(
-                    code = RPCError.ErrorCode.RESOURCE_NOT_FOUND,
+                    code = resourceNotFoundErrorCode(session.negotiatedProtocolVersion),
                     message = "Resource not found",
                     data = buildJsonObject { put("uri", uri) },
                 )

--- a/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ServerSession.kt
+++ b/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ServerSession.kt
@@ -70,12 +70,16 @@ public open class ServerSession(
 
     private val _clientCapabilities: AtomicRef<ClientCapabilities?> = atomic(null)
     private val _clientVersion: AtomicRef<Implementation?> = atomic(null)
+    private val _negotiatedProtocolVersion: AtomicRef<String?> = atomic(null)
 
     /** Capabilities reported by the client during initialization, or `null` before the handshake completes. */
     public val clientCapabilities: ClientCapabilities? get() = _clientCapabilities.value
 
     /** Client implementation information reported during initialization, or `null` before the handshake completes. */
     public val clientVersion: Implementation? get() = _clientVersion.value
+
+    /** Protocol version selected during initialization, or `null` before the handshake completes. */
+    internal val negotiatedProtocolVersion: String? get() = _negotiatedProtocolVersion.value
 
     /**
      * The capabilities supported by the server, related to the session.
@@ -361,6 +365,7 @@ public open class ServerSession(
             }
             LATEST_PROTOCOL_VERSION
         }
+        _negotiatedProtocolVersion.value = protocolVersion
 
         return InitializeResult(
             protocolVersion = protocolVersion,

--- a/kotlin-sdk-server/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ResourceNotFoundErrorCodeTest.kt
+++ b/kotlin-sdk-server/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ResourceNotFoundErrorCodeTest.kt
@@ -1,0 +1,20 @@
+package io.modelcontextprotocol.kotlin.sdk.server
+
+import io.modelcontextprotocol.kotlin.sdk.types.RPCError
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ResourceNotFoundErrorCodeTest {
+
+    @Test
+    fun `uses legacy code before 2026 protocol`() {
+        assertEquals(RPCError.ErrorCode.RESOURCE_NOT_FOUND, resourceNotFoundErrorCode(null))
+        assertEquals(RPCError.ErrorCode.RESOURCE_NOT_FOUND, resourceNotFoundErrorCode("2025-11-25"))
+    }
+
+    @Test
+    fun `uses invalid params from 2026 protocol onward`() {
+        assertEquals(RPCError.ErrorCode.INVALID_PARAMS, resourceNotFoundErrorCode("2026-07-28"))
+        assertEquals(RPCError.ErrorCode.INVALID_PARAMS, resourceNotFoundErrorCode("2027-01-01"))
+    }
+}

--- a/kotlin-sdk-server/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ServerSessionAssertCapabilityTest.kt
+++ b/kotlin-sdk-server/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ServerSessionAssertCapabilityTest.kt
@@ -15,6 +15,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
 import io.modelcontextprotocol.kotlin.sdk.types.toJSON
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 /**
@@ -79,7 +80,24 @@ class ServerSessionAssertCapabilityTest {
         ex.message.orEmpty() shouldContain "Server does not support tasks"
     }
 
+    @Test
+    fun `server retains the negotiated protocol version`() = runTest {
+        val protocolVersion = "2025-03-26"
+
+        val session = newTestServerSession(protocolVersion = protocolVersion)
+
+        assertEquals(protocolVersion, session.negotiatedProtocolVersion)
+    }
+
+    @Test
+    fun `server retains the fallback for an unsupported protocol version`() = runTest {
+        val session = newTestServerSession(protocolVersion = "2099-01-01")
+
+        assertEquals(LATEST_PROTOCOL_VERSION, session.negotiatedProtocolVersion)
+    }
+
     private suspend fun newTestServerSession(
+        protocolVersion: String = LATEST_PROTOCOL_VERSION,
         clientCapabilities: ClientCapabilities = ClientCapabilities(),
         serverCapabilities: ServerCapabilities = ServerCapabilities(),
     ): TestServerSession {
@@ -88,7 +106,7 @@ class ServerSessionAssertCapabilityTest {
             options = ServerOptions(capabilities = serverCapabilities),
             instructions = null,
         )
-        val transport = InitializeReplayTransport(clientCapabilities)
+        val transport = InitializeReplayTransport(protocolVersion, clientCapabilities)
         session.connect(transport)
         return session
     }
@@ -113,14 +131,17 @@ class ServerSessionAssertCapabilityTest {
      * [ServerSession.clientCapabilities] before [start] returns. Other JSON-RPC
      * traffic the session subsequently emits is silently consumed.
      */
-    private class InitializeReplayTransport(private val clientCapabilities: ClientCapabilities) : Transport {
+    private class InitializeReplayTransport(
+        private val protocolVersion: String,
+        private val clientCapabilities: ClientCapabilities,
+    ) : Transport {
         private var onMessageBlock: (suspend (JSONRPCMessage) -> Unit)? = null
         private var onCloseBlock: (() -> Unit)? = null
 
         override suspend fun start() {
             val initializeRequest = InitializeRequest(
                 params = InitializeRequestParams(
-                    protocolVersion = LATEST_PROTOCOL_VERSION,
+                    protocolVersion = protocolVersion,
                     capabilities = clientCapabilities,
                     clientInfo = Implementation("mock-client", "1.0.0"),
                 ),


### PR DESCRIPTION
Implements the server-side resource-not-found error selection from SEP-2164 while preserving the behavior of currently negotiated 2025 protocol versions.

- retain the negotiated protocol version on each server session
- return the legacy `RESOURCE_NOT_FOUND` (`-32002`) through MCP 2025-11-25
- return `INVALID_PARAMS` (`-32602`) for MCP 2026-07-28 and later
- preserve the existing error message and `data.uri` payload
- document both error-code roles and add decision, handshake, and transport coverage

## Motivation and Context

Refs #805. Related lifecycle work: #815.

SEP-2164 standardizes an unknown `resources/read` URI as JSON-RPC `INVALID_PARAMS` for the 2026-07-28 specification. Applying that code unconditionally would change the wire behavior of clients that negotiate one of the SDK's currently supported 2025 protocol versions.

This change therefore makes the decision at the server boundary using the version retained from initialization. The ISO `YYYY-MM-DD` comparison follows the compatibility approach already used by the official C# and Rust SDK implementations. Unsupported initialization versions still fall back to `LATEST_PROTOCOL_VERSION`, so they cannot accidentally opt into a future error contract.

## How Has This Been Tested?

- `gradlew.bat ktlintCheck detekt apiCheck` — passed (173 tasks; 80 executed and 93 up-to-date).
- Focused core/server tests for `JsonRpcTest`, `ResourceNotFoundErrorCodeTest`, and `ServerSessionAssertCapabilityTest` — 29 passed.
- Linux JVM resource integration tests for `ServerResourceTemplateTest` and the stdio, SSE, and Streamable HTTP `ResourceIntegrationTest` variants — 47 passed, 0 failed, 0 skipped.
- A wider Windows JVM run completed the core (598 tests) and server (232 tests) suites without failures. Its TypeScript interop tests could not launch because `ProcessBuilder("npx", ...)` does not resolve the installed Windows `npx.cmd`; the affected resource integrations were therefore rerun successfully under Linux, where `npx` is executable.

The 2026+ decision branch is unit-tested, but full 2026-07-28 wire-level coverage is not yet reachable because this SDK does not currently negotiate the modern lifecycle. That end-to-end path depends on #815; this PR does not claim complete 2026-07-28 conformance.

## Breaking Changes

There is no behavior change for the SDK's currently supported 2025 protocol versions: missing resources continue to return `-32002`.

Once a session can negotiate MCP 2026-07-28 or later, the same condition will intentionally return `-32602` as required by SEP-2164. The public `RESOURCE_NOT_FOUND` constant remains available with its legacy `-32002` value.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

This contribution was developed with Codex assistance. The implementation was checked against #805, SEP-2164, the current protocol-version negotiation behavior, and official C# and Rust SDK precedents, then verified with the focused checks above.
