### PR TITLE
fix: handle UTF-8 BOM in JSON-RPC frames

### DIFF
--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/shared/ReadBuffer.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/shared/ReadBuffer.kt
@@ -128,7 +128,8 @@ public class TooLongFrameException(public val frameSize: Long, public val maxFra
             "before a newline terminator (observed $frameSize bytes).",
     )
 
-internal fun deserializeMessage(line: String): JSONRPCMessage = McpJson.decodeFromString<JSONRPCMessage>(line)
+internal fun deserializeMessage(line: String): JSONRPCMessage =
+    McpJson.decodeFromString<JSONRPCMessage>(line.trimStart('\uFEFF'))
 
 /** Serializes a [JSONRPCMessage] to its JSON string representation with a trailing newline. */
 public fun serializeMessage(message: JSONRPCMessage): String = McpJson.encodeToString(message) + "\n"

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/shared/ReadBufferTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/shared/ReadBufferTest.kt
@@ -108,4 +108,10 @@ class ReadBufferTest {
         readBuffer.append(serializeMessage(testMessage).encodeToByteArray())
         assertEquals(testMessage, readBuffer.readMessage())
     }
+
+    @Test
+    fun `should deserialize message with leading UTF-8 BOM`() {
+        val messageJson = "\uFEFF${json.encodeToString(testMessage)}"
+        assertEquals(testMessage, deserializeMessage(messageJson))
+    }
 }


### PR DESCRIPTION
## What
Fixes #956. BOM-prefixed JSON-RPC frames currently fall into `ReadBuffer`'s recovery path before parsing.

## Fix
Normalize leading UTF-8 BOM characters before JSON-RPC deserialization, so stdio frames parse directly instead of logging a recovery error.

## Test
Added a `ReadBuffer` regression for BOM-prefixed messages.