### PR TITLE
feat!: implement SEP-2575 stateless MCP

### DIFF
--- a/integration-test/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/client/ClientTest.kt
+++ b/integration-test/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/client/ClientTest.kt
@@ -1,6 +1,7 @@
 package io.modelcontextprotocol.kotlin.sdk.client
 
 import io.kotest.matchers.shouldBe
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
 import io.modelcontextprotocol.kotlin.sdk.server.Server
 import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
 import io.modelcontextprotocol.kotlin.sdk.server.ServerSession
@@ -19,6 +20,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.ElicitResult
 import io.modelcontextprotocol.kotlin.sdk.types.ElicitationCompleteNotification
 import io.modelcontextprotocol.kotlin.sdk.types.ElicitationCompleteNotificationParams
 import io.modelcontextprotocol.kotlin.sdk.types.EmptyJsonObject
+import io.modelcontextprotocol.kotlin.sdk.types.HANDSHAKE_PROTOCOL_VERSIONS
 import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import io.modelcontextprotocol.kotlin.sdk.types.InitializeRequest
 import io.modelcontextprotocol.kotlin.sdk.types.InitializeResult
@@ -27,7 +29,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCMessage
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCNotification
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCRequest
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCResponse
-import io.modelcontextprotocol.kotlin.sdk.types.LATEST_PROTOCOL_VERSION
+import io.modelcontextprotocol.kotlin.sdk.types.LATEST_HANDSHAKE_VERSION
 import io.modelcontextprotocol.kotlin.sdk.types.ListResourcesRequest
 import io.modelcontextprotocol.kotlin.sdk.types.ListResourcesResult
 import io.modelcontextprotocol.kotlin.sdk.types.ListRootsRequest
@@ -37,11 +39,14 @@ import io.modelcontextprotocol.kotlin.sdk.types.LoggingLevel
 import io.modelcontextprotocol.kotlin.sdk.types.LoggingMessageNotification
 import io.modelcontextprotocol.kotlin.sdk.types.LoggingMessageNotificationParams
 import io.modelcontextprotocol.kotlin.sdk.types.McpException
+import io.modelcontextprotocol.kotlin.sdk.types.McpJson
 import io.modelcontextprotocol.kotlin.sdk.types.Method
+import io.modelcontextprotocol.kotlin.sdk.types.MissingRequiredClientCapabilityData
+import io.modelcontextprotocol.kotlin.sdk.types.RPCError
+import io.modelcontextprotocol.kotlin.sdk.types.RequestResult
 import io.modelcontextprotocol.kotlin.sdk.types.Role
 import io.modelcontextprotocol.kotlin.sdk.types.Root
 import io.modelcontextprotocol.kotlin.sdk.types.RootsListChangedNotification
-import io.modelcontextprotocol.kotlin.sdk.types.SUPPORTED_PROTOCOL_VERSIONS
 import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
 import io.modelcontextprotocol.kotlin.sdk.types.StringSchema
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
@@ -63,6 +68,8 @@ import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import kotlin.coroutines.cancellation.CancellationException
@@ -86,7 +93,7 @@ class ClientTest {
                 if (message !is JSONRPCRequest) return
                 initialised = true
                 val result = InitializeResult(
-                    protocolVersion = LATEST_PROTOCOL_VERSION,
+                    protocolVersion = LATEST_HANDSHAKE_VERSION,
                     capabilities = ServerCapabilities(),
                     serverInfo = Implementation(
                         name = "test",
@@ -124,7 +131,7 @@ class ClientTest {
 
     @Test
     fun `should initialize with supported older protocol version`() = runTest {
-        val oldVersion = SUPPORTED_PROTOCOL_VERSIONS[1]
+        val oldVersion = HANDSHAKE_PROTOCOL_VERSIONS.first()
         val clientTransport = object : AbstractTransport() {
             override suspend fun start() {}
 
@@ -364,7 +371,7 @@ class ClientTest {
         val serverSession = serverSessionResult.await()
         serverSession.setRequestHandler<InitializeRequest>(Method.Defined.Initialize) { _, _ ->
             InitializeResult(
-                protocolVersion = LATEST_PROTOCOL_VERSION,
+                protocolVersion = LATEST_HANDSHAKE_VERSION,
                 capabilities = ServerCapabilities(
                     resources = ServerCapabilities.Resources(null, null),
                     tools = ServerCapabilities.Tools(null),
@@ -703,7 +710,7 @@ class ClientTest {
 
         serverSession.setRequestHandler<InitializeRequest>(Method.Defined.Initialize) { _, _ ->
             InitializeResult(
-                protocolVersion = LATEST_PROTOCOL_VERSION,
+                protocolVersion = LATEST_HANDSHAKE_VERSION,
                 capabilities = ServerCapabilities(
                     resources = ServerCapabilities.Resources(null, null),
                     tools = ServerCapabilities.Tools(null),
@@ -742,7 +749,7 @@ class ClientTest {
         val receivedAsResponse = receivedMessage as JSONRPCResponse
         assertEquals(request.id, receivedAsResponse.id)
         assertEquals(request.jsonrpc, receivedAsResponse.jsonrpc)
-        assertEquals(serverListToolsResult, receivedAsResponse.result)
+        assertEquals(serverListToolsResult, receivedAsResponse.result.readBack())
     }
 
     @Test
@@ -962,8 +969,7 @@ class ClientTest {
 
         val serverSession = serverSessionResult.await()
 
-        // Verify that creating an elicitation throws an exception
-        val exception = assertFailsWith<IllegalStateException> {
+        val exception = assertFailsWith<McpException> {
             serverSession.createElicitation(
                 message = "Please provide your GitHub username",
                 requestedSchema = ElicitRequestParams.RequestedSchema(
@@ -972,11 +978,17 @@ class ClientTest {
                 ),
             )
         }
+        assertEquals(RPCError.ErrorCode.MISSING_REQUIRED_CLIENT_CAPABILITY, exception.code)
         assertEquals(
-            "Client does not support elicitation (required for elicitation/create)",
-            exception.message,
+            ClientCapabilities(elicitation = ClientCapabilities.Elicitation(form = EmptyJsonObject)),
+            exception.missingCapabilities(),
         )
     }
+
+    /** The capabilities a [RPCError.ErrorCode.MISSING_REQUIRED_CLIENT_CAPABILITY] error reports as missing. */
+    @OptIn(ExperimentalMcpApi::class)
+    private fun McpException.missingCapabilities(): ClientCapabilities =
+        McpJson.decodeFromJsonElement<MissingRequiredClientCapabilityData>(checkNotNull(data)).requiredCapabilities
 
     @Test
     fun `should handle logging setLevel request`() = runTest {
@@ -1408,14 +1420,18 @@ class ClientTest {
             ElicitResult(action = ElicitResult.Action.Accept)
         }
 
-        val exception = assertFailsWith<IllegalArgumentException> {
+        val exception = assertFailsWith<McpException> {
             serverSession.createElicitation(
                 message = "Authorize",
                 elicitationId = "id-1",
                 url = "https://example.com/auth",
             )
         }
-        assertTrue(exception.message!!.contains("elicitation.url"))
+        assertEquals(RPCError.ErrorCode.MISSING_REQUIRED_CLIENT_CAPABILITY, exception.code)
+        assertEquals(
+            ClientCapabilities(elicitation = ClientCapabilities.Elicitation(url = EmptyJsonObject)),
+            exception.missingCapabilities(),
+        )
 
         client.close()
     }
@@ -1575,3 +1591,7 @@ class ClientTest {
         client to serverSessionResult.await()
     }
 }
+
+/** The result as a peer on a serializing transport would decode it. */
+private fun RequestResult.readBack(): RequestResult =
+    McpJson.decodeFromJsonElement(McpJson.encodeToJsonElement<RequestResult>(this))

--- a/integration-test/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/client/ClientTest.kt
+++ b/integration-test/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/client/ClientTest.kt
@@ -1479,12 +1479,16 @@ class ClientTest {
             ElicitResult(action = ElicitResult.Action.Accept)
         }
 
-        val exception = assertFailsWith<IllegalArgumentException> {
+        val exception = assertFailsWith<McpException> {
             serverSession.sendElicitationComplete(
                 ElicitationCompleteNotification(ElicitationCompleteNotificationParams(elicitationId = "id-1")),
             )
         }
-        assertTrue(exception.message!!.contains("elicitation.url"))
+        assertEquals(RPCError.ErrorCode.MISSING_REQUIRED_CLIENT_CAPABILITY, exception.code)
+        assertEquals(
+            ClientCapabilities(elicitation = ClientCapabilities.Elicitation(url = EmptyJsonObject)),
+            exception.missingCapabilities(),
+        )
 
         client.close()
     }

--- a/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/EraInterleavingTest.kt
+++ b/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/EraInterleavingTest.kt
@@ -1,0 +1,176 @@
+package io.modelcontextprotocol.kotlin.sdk.integration
+
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
+import io.modelcontextprotocol.kotlin.sdk.testing.ChannelTransport
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.EmptyJsonObject
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCMessage
+import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCRequest
+import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCResponse
+import io.modelcontextprotocol.kotlin.sdk.types.LATEST_MODERN_VERSION
+import io.modelcontextprotocol.kotlin.sdk.types.LoggingLevel
+import io.modelcontextprotocol.kotlin.sdk.types.LoggingMessageNotification
+import io.modelcontextprotocol.kotlin.sdk.types.LoggingMessageNotificationParams
+import io.modelcontextprotocol.kotlin.sdk.types.McpJson
+import io.modelcontextprotocol.kotlin.sdk.types.RequestId
+import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import io.modelcontextprotocol.kotlin.sdk.types.serverInfo
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * One connection, both lifecycles, no memory between requests — the property the revision states for
+ * stdio, where an open process is explicitly not a session and a client may interleave unrelated
+ * requests freely.
+ *
+ * Driven over raw JSON-RPC messages rather than through
+ * [io.modelcontextprotocol.kotlin.sdk.client.Client] because the typed client settles exactly one
+ * lifecycle per connection: interleaving is something a conforming client does not do, so no
+ * client-shaped API can produce it. The property under test is classification, not framing, so an
+ * in-memory pair stands in for the pipe.
+ */
+@OptIn(ExperimentalMcpApi::class)
+class EraInterleavingTest {
+
+    @Test
+    fun `one connection answers a handshake request and a request-scoped request in turn`() = runBlocking {
+        val peer = connect()
+
+        val handshake = peer.call(id = 1, method = "tools/call", envelope = null)
+        val scoped = peer.call(id = 2, method = "tools/call", envelope = LATEST_MODERN_VERSION)
+
+        // Same connection, same tool, two lifecycles: the identity stamp is the observable
+        // difference, and each request got the one its own body asked for.
+        handshake.meta()?.serverInfo shouldBe null
+        scoped.meta()?.serverInfo shouldBe Implementation("interleaving-server", "1.0")
+        peer.close()
+    }
+
+    @Test
+    fun `a request-scoped request does not inherit a log level an earlier request set`() = runBlocking {
+        val peer = connect()
+
+        // The handshake lifecycle's own way of asking for logs, which the revision replaced.
+        peer.call(
+            id = 1,
+            method = "logging/setLevel",
+            envelope = null,
+            params = buildJsonObject {
+                put("level", "debug")
+            },
+        )
+        peer.call(id = 2, method = "tools/call", envelope = LATEST_MODERN_VERSION)
+
+        // A level set for one request must not widen what any other request may emit; a
+        // request-scoped request that did not opt in gets nothing.
+        peer.notifications shouldContainExactly emptyList()
+        peer.close()
+    }
+
+    /** A raw peer holding one connection to a server that logs while serving `echo`. */
+    private class Peer(private val transport: ChannelTransport) {
+        val notifications: MutableList<String> = mutableListOf()
+        private val pending = mutableMapOf<RequestId, CompletableDeferred<JSONRPCResponse>>()
+
+        suspend fun start() {
+            transport.onMessage { message ->
+                when (message) {
+                    is JSONRPCResponse -> pending.remove(message.id)?.complete(message)
+                    else -> notifications += McpJson.encodeToString(message)
+                }
+            }
+            transport.start()
+        }
+
+        suspend fun call(
+            id: Int,
+            method: String,
+            envelope: String?,
+            params: JsonObject = buildJsonObject { },
+        ): JSONRPCResponse {
+            val requestId = RequestId.NumberId(id.toLong())
+            val answer = CompletableDeferred<JSONRPCResponse>()
+            pending[requestId] = answer
+            transport.send(request(requestId, method, envelope, params))
+            return withTimeout(5.seconds) { answer.await() }
+        }
+
+        suspend fun close() = transport.close()
+
+        private fun request(
+            id: RequestId,
+            method: String,
+            envelope: String?,
+            params: JsonObject,
+        ): JSONRPCMessage {
+            val body = when (method) {
+                "tools/call" -> buildJsonObject {
+                    put("name", "echo")
+                    put("arguments", EmptyJsonObject)
+                }
+
+                else -> params
+            }
+            val withMeta = if (envelope == null) {
+                body
+            } else {
+                JsonObject(
+                    body + (
+                        "_meta" to buildJsonObject {
+                            put("io.modelcontextprotocol/protocolVersion", envelope)
+                            put("io.modelcontextprotocol/clientCapabilities", EmptyJsonObject)
+                        }
+                        ),
+                )
+            }
+            return JSONRPCRequest(id = id, method = method, params = withMeta)
+        }
+    }
+
+    private suspend fun connect(): Peer {
+        val server = Server(
+            serverInfo = Implementation("interleaving-server", "1.0"),
+            options = ServerOptions(
+                capabilities = ServerCapabilities(
+                    tools = ServerCapabilities.Tools(null),
+                    logging = EmptyJsonObject,
+                ),
+            ),
+        )
+        server.addTool(
+            name = "echo",
+            description = "echoes, noisily",
+            inputSchema = ToolSchema(properties = EmptyJsonObject, required = null),
+        ) {
+            sendLoggingMessage(
+                LoggingMessageNotification(
+                    LoggingMessageNotificationParams(
+                        level = LoggingLevel.Debug,
+                        data = JsonPrimitive("serving echo"),
+                    ),
+                ),
+            )
+            CallToolResult(content = listOf(TextContent("echoed")))
+        }
+
+        val (clientTransport, serverTransport) = ChannelTransport.createLinkedPair()
+        server.createSession(serverTransport)
+        return Peer(clientTransport).also { it.start() }
+    }
+
+    private fun JSONRPCResponse.meta() = result.meta
+}

--- a/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/MalformedEnvelopeFieldTest.kt
+++ b/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/MalformedEnvelopeFieldTest.kt
@@ -1,0 +1,271 @@
+package io.modelcontextprotocol.kotlin.sdk.integration
+
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
+import io.modelcontextprotocol.kotlin.sdk.shared.RequestHandlerExtra
+import io.modelcontextprotocol.kotlin.sdk.shared.currentRequestHandlerExtra
+import io.modelcontextprotocol.kotlin.sdk.testing.ChannelTransport
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.ClientCapabilities
+import io.modelcontextprotocol.kotlin.sdk.types.EmptyJsonObject
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCError
+import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCMessage
+import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCRequest
+import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCResponse
+import io.modelcontextprotocol.kotlin.sdk.types.LATEST_HANDSHAKE_VERSION
+import io.modelcontextprotocol.kotlin.sdk.types.LATEST_MODERN_VERSION
+import io.modelcontextprotocol.kotlin.sdk.types.LoggingLevel
+import io.modelcontextprotocol.kotlin.sdk.types.LoggingMessageNotification
+import io.modelcontextprotocol.kotlin.sdk.types.LoggingMessageNotificationParams
+import io.modelcontextprotocol.kotlin.sdk.types.McpJson
+import io.modelcontextprotocol.kotlin.sdk.types.RPCError
+import io.modelcontextprotocol.kotlin.sdk.types.RequestId
+import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * What a server does with a request-scoped `_meta` envelope whose **optional** fields are malformed
+ * while its required ones are intact.
+ *
+ * The revision does not treat the two optional fields alike, so neither does this:
+ * `io.modelcontextprotocol/clientInfo` is self-reported, unverified and for display only, and a
+ * receiver **SHOULD NOT** change behaviour on account of it; `io.modelcontextprotocol/logLevel`
+ * decides what the server may emit, and a receiver **SHOULD** answer `-32602` for a level it does
+ * not recognize rather than guess.
+ *
+ * Driven over raw JSON-RPC rather than through [io.modelcontextprotocol.kotlin.sdk.client.Client]
+ * because the typed client builds its envelope from typed values and cannot express a malformed one:
+ * this is a property of what the server accepts from a foreign peer, which is exactly where the
+ * revision's optional fields get sent imperfectly.
+ */
+@OptIn(ExperimentalMcpApi::class)
+class MalformedEnvelopeFieldTest {
+
+    private val declared = ClientCapabilities(sampling = ClientCapabilities.Sampling())
+
+    @Test
+    fun `a malformed client identity leaves the rest of the envelope in force`() = runBlocking {
+        val seen = CompletableDeferred<RequestHandlerExtra>()
+        val peer = connect(seen)
+
+        // Well-formed required fields; an identity missing the `version` the schema requires.
+        val answer = peer.call(
+            id = 1,
+            meta = buildJsonObject {
+                put("io.modelcontextprotocol/protocolVersion", LATEST_MODERN_VERSION)
+                put("io.modelcontextprotocol/clientCapabilities", McpJson.encodeToJsonElement(declared))
+                put(
+                    "io.modelcontextprotocol/clientInfo",
+                    buildJsonObject { put("name", "no-version-client") },
+                )
+            },
+        )
+
+        answer.shouldBeSuccess()
+        val extra = withTimeout(5.seconds) { seen.await() }
+
+        // Identity degrades to not-supplied, which is what an absent value already means...
+        extra.clientInfo shouldBe null
+        // ...and nothing else does. Losing these is what silently demoted the request to the
+        // connection-scoped lifecycle: capabilities the peer declared read as undeclared, and the
+        // version fell back far enough that the log gate below inverted.
+        extra.envelope.shouldNotBeNull()
+        extra.protocolVersion shouldBe LATEST_MODERN_VERSION
+        extra.clientCapabilities shouldBe declared
+
+        peer.close()
+    }
+
+    @Test
+    fun `a malformed client identity does not reopen log delivery`() = runBlocking {
+        val seen = CompletableDeferred<RequestHandlerExtra>()
+        val peer = connect(seen)
+
+        peer.call(
+            id = 1,
+            meta = buildJsonObject {
+                put("io.modelcontextprotocol/protocolVersion", LATEST_MODERN_VERSION)
+                put("io.modelcontextprotocol/clientCapabilities", McpJson.encodeToJsonElement(declared))
+                put("io.modelcontextprotocol/clientInfo", JsonPrimitive("not-an-implementation"))
+            },
+        )
+
+        // The request opted into no level, so it gets nothing. Read after the awaited call over one
+        // ordered in-memory stream, so this list is the whole delivery.
+        peer.notifications.shouldContainExactly(emptyList())
+        peer.close()
+    }
+
+    @Test
+    fun `a request-scoped request never borrows an earlier handshake declaration`() = runBlocking {
+        val seen = CompletableDeferred<RequestHandlerExtra>()
+        val peer = connect(seen)
+
+        // One connection carrying both lifecycles, which the revision states for stdio: an open
+        // process is not a session. The handshake declares capabilities the envelope below does not.
+        peer.initialize(
+            id = 1,
+            capabilities = ClientCapabilities(
+                roots = ClientCapabilities.Roots(),
+                elicitation = ClientCapabilities.Elicitation(),
+            ),
+        )
+
+        peer.call(
+            id = 2,
+            meta = buildJsonObject {
+                put("io.modelcontextprotocol/protocolVersion", LATEST_MODERN_VERSION)
+                put("io.modelcontextprotocol/clientCapabilities", McpJson.encodeToJsonElement(declared))
+                put(
+                    "io.modelcontextprotocol/clientInfo",
+                    buildJsonObject { put("name", "no-version-client") },
+                )
+            },
+        )
+
+        // Only what this request declared. The handshake's roots and elicitation are another
+        // request's business, and on this transport they are sitting right there to be borrowed.
+        val extra = withTimeout(5.seconds) { seen.await() }
+        extra.clientCapabilities shouldBe declared
+        extra.protocolVersion shouldBe LATEST_MODERN_VERSION
+        extra.clientInfo shouldBe null
+
+        peer.close()
+    }
+
+    @Test
+    fun `a log level naming no known severity is rejected`() = runBlocking {
+        val peer = connect(CompletableDeferred())
+
+        listOf(JsonPrimitive("verbose"), JsonPrimitive(7), EmptyJsonObject).forEach { level ->
+            val answer = peer.call(
+                id = 1,
+                meta = buildJsonObject {
+                    put("io.modelcontextprotocol/protocolVersion", LATEST_MODERN_VERSION)
+                    put("io.modelcontextprotocol/clientCapabilities", McpJson.encodeToJsonElement(declared))
+                    put("io.modelcontextprotocol/logLevel", level)
+                },
+            )
+
+            val error = (answer as JSONRPCError).error
+            error.code shouldBe RPCError.ErrorCode.INVALID_PARAMS
+            // Naming the key is what lets the peer fix the field rather than guess at the envelope.
+            (error.message.contains("io.modelcontextprotocol/logLevel")) shouldBe true
+        }
+
+        peer.close()
+    }
+
+    private fun JSONRPCMessage.shouldBeSuccess() {
+        if (this is JSONRPCError) {
+            throw AssertionError("Expected the request to be served, but it answered ${error.code}: ${error.message}")
+        }
+    }
+
+    /** A raw peer holding one connection to a server that logs while serving `echo`. */
+    private class Peer(private val transport: ChannelTransport) {
+        val notifications: MutableList<String> = mutableListOf()
+        private val pending = mutableMapOf<RequestId, CompletableDeferred<JSONRPCMessage>>()
+
+        suspend fun start() {
+            transport.onMessage { message ->
+                when (message) {
+                    is JSONRPCResponse -> pending.remove(message.id)?.complete(message)
+                    is JSONRPCError -> message.id?.let { pending.remove(it)?.complete(message) }
+                    else -> notifications += McpJson.encodeToString(message)
+                }
+            }
+            transport.start()
+        }
+
+        /** Settles the connection-scoped lifecycle, so its declaration is there to be borrowed. */
+        suspend fun initialize(id: Int, capabilities: ClientCapabilities): JSONRPCMessage {
+            val requestId = RequestId.NumberId(id.toLong())
+            val answer = CompletableDeferred<JSONRPCMessage>()
+            pending[requestId] = answer
+            transport.send(
+                JSONRPCRequest(
+                    id = requestId,
+                    method = "initialize",
+                    params = buildJsonObject {
+                        put("protocolVersion", LATEST_HANDSHAKE_VERSION)
+                        put("capabilities", McpJson.encodeToJsonElement(capabilities))
+                        put(
+                            "clientInfo",
+                            McpJson.encodeToJsonElement(Implementation("handshake-client", "1.0")),
+                        )
+                    },
+                ),
+            )
+            return withTimeout(5.seconds) { answer.await() }
+        }
+
+        suspend fun call(id: Int, meta: JsonObject): JSONRPCMessage {
+            val requestId = RequestId.NumberId(id.toLong())
+            val answer = CompletableDeferred<JSONRPCMessage>()
+            pending[requestId] = answer
+            transport.send(
+                JSONRPCRequest(
+                    id = requestId,
+                    method = "tools/call",
+                    params = buildJsonObject {
+                        put("name", "echo")
+                        put("arguments", EmptyJsonObject)
+                        put("_meta", meta)
+                    },
+                ),
+            )
+            return withTimeout(5.seconds) { answer.await() }
+        }
+
+        suspend fun close() = transport.close()
+    }
+
+    private suspend fun connect(seen: CompletableDeferred<RequestHandlerExtra>): Peer {
+        val server = Server(
+            serverInfo = Implementation("envelope-server", "1.0"),
+            options = ServerOptions(
+                capabilities = ServerCapabilities(
+                    tools = ServerCapabilities.Tools(null),
+                    logging = EmptyJsonObject,
+                ),
+            ),
+        )
+        server.addTool(
+            name = "echo",
+            description = "echoes, noisily",
+            inputSchema = ToolSchema(properties = EmptyJsonObject, required = null),
+        ) {
+            currentRequestHandlerExtra()?.let(seen::complete)
+            sendLoggingMessage(
+                LoggingMessageNotification(
+                    LoggingMessageNotificationParams(
+                        level = LoggingLevel.Debug,
+                        data = JsonPrimitive("serving echo"),
+                    ),
+                ),
+            )
+            CallToolResult(content = listOf(TextContent("echoed")))
+        }
+
+        val (clientTransport, serverTransport) = ChannelTransport.createLinkedPair()
+        server.createSession(serverTransport)
+        return Peer(clientTransport).also { it.start() }
+    }
+}

--- a/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/ModernStreamableHttpDisconnectTest.kt
+++ b/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/ModernStreamableHttpDisconnectTest.kt
@@ -1,0 +1,145 @@
+package io.modelcontextprotocol.kotlin.sdk.integration
+
+import io.kotest.assertions.nondeterministic.eventually
+import io.kotest.matchers.maps.shouldBeEmpty
+import io.kotest.matchers.string.shouldContain
+import io.ktor.server.cio.CIO
+import io.ktor.server.engine.embeddedServer
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
+import io.modelcontextprotocol.kotlin.sdk.server.mcpStatelessStreamableHttp
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.EmptyJsonObject
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+import io.modelcontextprotocol.kotlin.sdk.types.LATEST_MODERN_VERSION
+import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import java.net.Socket
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Closing the response stream is the request-scoped wire's only cancellation channel, so the
+ * server must notice a client disconnect while the handler is still running — including inside the
+ * SSE deferral window, where nothing is written to the socket that could fail.
+ *
+ * Runs against a real CIO server: the in-process test engine has no socket to close, so it cannot
+ * express a disconnect at all.
+ */
+@OptIn(ExperimentalMcpApi::class)
+class ModernStreamableHttpDisconnectTest {
+
+    @Test
+    fun `a client disconnect during the deferral window cancels the handler and closes the session`(): Unit =
+        runBlocking(Dispatchers.IO) {
+            val started = CompletableDeferred<Unit>()
+            val cancelled = CompletableDeferred<Unit>()
+            val mcpServer = hangingServer(started, cancelled)
+            val server = embeddedServer(CIO, port = 0) {
+                mcpStatelessStreamableHttp { mcpServer }
+            }.start(wait = false)
+
+            try {
+                val port = server.engine.resolvedConnectors().first().port
+                Socket("localhost", port).use { socket ->
+                    socket.getOutputStream().run {
+                        write(post(callTool("hang"), name = "hang").encodeToByteArray())
+                        flush()
+                    }
+                    withTimeout(5.seconds) { started.await() }
+                }
+                // The socket is closed with the handler parked mid-request and the response
+                // uncommitted: only the engine's disconnect signal can end the exchange now — a
+                // write failure never will, because nothing is being written.
+                withTimeout(5.seconds) { cancelled.await() }
+                eventually(5.seconds) { mcpServer.sessions.shouldBeEmpty() }
+            } finally {
+                server.stop(1000, 2000)
+            }
+        }
+
+    @Test
+    fun `a request that closes its own connection still gets its full response`(): Unit = runBlocking(Dispatchers.IO) {
+        // CIO fires the same close signal early for a request that asks for connection close,
+        // while the handler is still running. That signal must not be read as a disconnect: the
+        // shape is what a default nginx proxy_pass sends upstream.
+        val server = embeddedServer(CIO, port = 0) {
+            mcpStatelessStreamableHttp { slowServer() }
+        }.start(wait = false)
+
+        try {
+            val port = server.engine.resolvedConnectors().first().port
+            val body = Socket("localhost", port).use { socket ->
+                socket.getOutputStream().run {
+                    write(post(callTool("slow"), name = "slow", connection = "close").encodeToByteArray())
+                    flush()
+                }
+                withTimeout(10.seconds) {
+                    withContext(Dispatchers.IO) { socket.getInputStream().readBytes().decodeToString() }
+                }
+            }
+            body shouldContain "200 OK"
+            body shouldContain "slowed"
+        } finally {
+            server.stop(1000, 2000)
+        }
+    }
+
+    private fun hangingServer(started: CompletableDeferred<Unit>, cancelled: CompletableDeferred<Unit>): Server =
+        toolServer("hang") {
+            started.complete(Unit)
+            try {
+                awaitCancellation()
+            } finally {
+                cancelled.complete(Unit)
+            }
+        }
+
+    private fun slowServer(): Server = toolServer("slow") {
+        // Long enough that the engine's early close signal — fired as soon as the request parses —
+        // lands while the handler is still suspended; the assertion is on the response, not time.
+        delay(1.seconds)
+        CallToolResult(content = listOf(TextContent("slowed")))
+    }
+
+    private fun toolServer(name: String, block: suspend () -> CallToolResult): Server = Server(
+        Implementation("disconnect-server", "1.0"),
+        ServerOptions(capabilities = ServerCapabilities(tools = ServerCapabilities.Tools(null))),
+    ).apply {
+        addTool(
+            name = name,
+            description = "test tool",
+            inputSchema = ToolSchema(properties = EmptyJsonObject, required = null),
+        ) { block() }
+    }
+
+    private fun callTool(name: String): String = """
+        {"jsonrpc":"2.0","id":1,"method":"tools/call",
+         "params":{"name":"$name","arguments":{},
+                   "_meta":{"io.modelcontextprotocol/protocolVersion":"$LATEST_MODERN_VERSION",
+                            "io.modelcontextprotocol/clientCapabilities":{}}}}
+    """.trimIndent()
+
+    private fun post(body: String, name: String, connection: String? = null): String = buildString {
+        append("POST /mcp HTTP/1.1\r\n")
+        append("Host: localhost\r\n")
+        append("Content-Type: application/json\r\n")
+        append("Accept: application/json, text/event-stream\r\n")
+        append("MCP-Protocol-Version: $LATEST_MODERN_VERSION\r\n")
+        append("Mcp-Method: tools/call\r\n")
+        append("Mcp-Name: $name\r\n")
+        connection?.let { append("Connection: $it\r\n") }
+        append("Content-Length: ${body.encodeToByteArray().size}\r\n")
+        append("\r\n")
+        append(body)
+    }
+}

--- a/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/ModernStreamableHttpStreamTest.kt
+++ b/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/ModernStreamableHttpStreamTest.kt
@@ -1,0 +1,118 @@
+package io.modelcontextprotocol.kotlin.sdk.integration
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.ktor.client.HttpClient
+import io.ktor.client.request.header
+import io.ktor.client.request.preparePost
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.cio.CIO
+import io.ktor.server.engine.embeddedServer
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
+import io.modelcontextprotocol.kotlin.sdk.server.mcpStatelessStreamableHttp
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.EmptyJsonObject
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+import io.modelcontextprotocol.kotlin.sdk.types.LATEST_MODERN_VERSION
+import io.modelcontextprotocol.kotlin.sdk.types.LoggingLevel
+import io.modelcontextprotocol.kotlin.sdk.types.LoggingMessageNotification
+import io.modelcontextprotocol.kotlin.sdk.types.LoggingMessageNotificationParams
+import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+import io.ktor.client.engine.cio.CIO as ClientCIO
+
+/**
+ * What a request-scoped response stream carries once it commits to `text/event-stream`: the
+ * handler's notifications, then the response that ends it.
+ *
+ * Runs against a real CIO server and client rather than the in-process test engine, which does not
+ * drive a streaming body concurrently with the handler still filling it — the very concurrency this
+ * asserts. The commit itself (status, media type, `X-Accel-Buffering`) is covered in-process by
+ * `ModernStreamableHttpTest`.
+ */
+@OptIn(ExperimentalMcpApi::class)
+class ModernStreamableHttpStreamTest {
+
+    @Test
+    fun `a committed stream carries the handler's notifications and then its response`(): Unit =
+        runBlocking(Dispatchers.IO) {
+            val server = embeddedServer(CIO, port = 0) {
+                mcpStatelessStreamableHttp {
+                    Server(
+                        Implementation("stream-server", "1.0"),
+                        ServerOptions(
+                            capabilities = ServerCapabilities(
+                                tools = ServerCapabilities.Tools(null),
+                                logging = EmptyJsonObject,
+                            ),
+                        ),
+                    ).apply {
+                        addTool(
+                            name = "echo",
+                            description = "echoes, noisily",
+                            inputSchema = ToolSchema(properties = EmptyJsonObject, required = null),
+                        ) {
+                            sendLoggingMessage(
+                                LoggingMessageNotification(
+                                    LoggingMessageNotificationParams(
+                                        level = LoggingLevel.Warning,
+                                        data = JsonPrimitive("mid-flight"),
+                                    ),
+                                ),
+                            )
+                            CallToolResult(content = listOf(TextContent("echoed")))
+                        }
+                    }
+                }
+            }.start(wait = false)
+
+            val client = HttpClient(ClientCIO)
+            try {
+                val port = server.engine.resolvedConnectors().first().port
+                client.preparePost("http://localhost:$port/mcp") {
+                    header(HttpHeaders.Host, "localhost")
+                    header(HttpHeaders.Accept, "${ContentType.Application.Json}, ${ContentType.Text.EventStream}")
+                    header("MCP-Protocol-Version", LATEST_MODERN_VERSION)
+                    header("Mcp-Method", "tools/call")
+                    header("Mcp-Name", "echo")
+                    contentType(ContentType.Application.Json)
+                    setBody(callEcho())
+                }.execute { response ->
+                    response.status shouldBe HttpStatusCode.OK
+                    response.contentType()?.withoutParameters() shouldBe ContentType.Text.EventStream
+
+                    // Read to completion: the stream ends when the response is written, so the body
+                    // is the whole exchange rather than whatever had arrived at some instant.
+                    val body = response.bodyAsText()
+                    body shouldContain "notifications/message"
+                    body shouldContain "echoed"
+                    // Ordering is the point of a response stream: the notifications belong to the
+                    // request being answered, and the answer is what closes it.
+                    (body.indexOf("notifications/message") < body.indexOf("echoed")) shouldBe true
+                }
+            } finally {
+                client.close()
+                server.stop(1000, 2000)
+            }
+        }
+
+    private fun callEcho(): String = """
+        {"jsonrpc":"2.0","id":1,"method":"tools/call",
+         "params":{"name":"echo","arguments":{},
+                   "_meta":{"io.modelcontextprotocol/protocolVersion":"$LATEST_MODERN_VERSION",
+                            "io.modelcontextprotocol/clientCapabilities":{},
+                            "io.modelcontextprotocol/logLevel":"warning"}}}
+    """.trimIndent()
+}

--- a/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/ModernStreamableHttpStreamTest.kt
+++ b/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/ModernStreamableHttpStreamTest.kt
@@ -27,7 +27,9 @@ import io.modelcontextprotocol.kotlin.sdk.types.LoggingMessageNotificationParams
 import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.JsonPrimitive
 import kotlin.test.Test
@@ -108,9 +110,137 @@ class ModernStreamableHttpStreamTest {
             }
         }
 
-    private fun callEcho(): String = """
+    @Test
+    fun `a burst of notifications outrunning the reader is delivered in full, never dropped`(): Unit =
+        runBlocking(Dispatchers.IO) {
+            val burst = 200 // well past the channel's buffer, where trySend would have dropped
+            val server = embeddedServer(CIO, port = 0) {
+                mcpStatelessStreamableHttp {
+                    Server(
+                        Implementation("stream-server", "1.0"),
+                        ServerOptions(
+                            capabilities = ServerCapabilities(
+                                tools = ServerCapabilities.Tools(null),
+                                logging = EmptyJsonObject,
+                            ),
+                        ),
+                    ).apply {
+                        addTool(
+                            name = "flood",
+                            description = "emits many notifications",
+                            inputSchema = ToolSchema(properties = EmptyJsonObject, required = null),
+                        ) {
+                            repeat(burst) { i ->
+                                sendLoggingMessage(
+                                    LoggingMessageNotification(
+                                        LoggingMessageNotificationParams(
+                                            level = LoggingLevel.Warning,
+                                            data = JsonPrimitive("n-$i"),
+                                        ),
+                                    ),
+                                )
+                            }
+                            CallToolResult(content = listOf(TextContent("flooded")))
+                        }
+                    }
+                }
+            }.start(wait = false)
+
+            val client = HttpClient(ClientCIO)
+            try {
+                val port = server.engine.resolvedConnectors().first().port
+                client.preparePost("http://localhost:$port/mcp") {
+                    header(HttpHeaders.Host, "localhost")
+                    header(HttpHeaders.Accept, "${ContentType.Application.Json}, ${ContentType.Text.EventStream}")
+                    header("MCP-Protocol-Version", LATEST_MODERN_VERSION)
+                    header("Mcp-Method", "tools/call")
+                    header("Mcp-Name", "flood")
+                    contentType(ContentType.Application.Json)
+                    setBody(callTool("flood"))
+                }.execute { response ->
+                    val body = response.bodyAsText()
+                    val delivered = (0 until burst).count { body.contains("\"n-$it\"") }
+                    delivered shouldBe burst
+                    body shouldContain "flooded"
+                }
+            } finally {
+                client.close()
+                server.stop(1000, 2000)
+            }
+        }
+
+    @Test
+    fun `a request-scoped stream carries none of the server's broadcast notifications`(): Unit =
+        runBlocking(Dispatchers.IO) {
+            val started = CompletableDeferred<Unit>()
+            val proceed = CompletableDeferred<Unit>()
+            val mcpServer = Server(
+                Implementation("stream-server", "1.0"),
+                ServerOptions(
+                    capabilities = ServerCapabilities(
+                        tools = ServerCapabilities.Tools(listChanged = true),
+                        logging = EmptyJsonObject,
+                    ),
+                ),
+            ).apply {
+                addTool(
+                    name = "wait",
+                    description = "waits, then answers",
+                    inputSchema = ToolSchema(properties = EmptyJsonObject, required = null),
+                ) {
+                    started.complete(Unit)
+                    proceed.await()
+                    sendLoggingMessage(
+                        LoggingMessageNotification(
+                            LoggingMessageNotificationParams(level = LoggingLevel.Warning, data = JsonPrimitive("own")),
+                        ),
+                    )
+                    CallToolResult(content = listOf(TextContent("answered")))
+                }
+            }
+            val server = embeddedServer(CIO, port = 0) { mcpStatelessStreamableHttp { mcpServer } }.start(wait = false)
+
+            val client = HttpClient(ClientCIO)
+            try {
+                val port = server.engine.resolvedConnectors().first().port
+                // Broadcast a catalogue change while the request is parked, before it has emitted
+                // anything: a subscribed session would stream it (and commit SSE early); a
+                // request-scoped one must not. Runs off the request coroutine so the parked handler
+                // is what gates it, not the response.
+                launch {
+                    started.await()
+                    mcpServer.addTool(
+                        name = "added-mid-flight",
+                        description = "announces a change to every subscribed session",
+                        inputSchema = ToolSchema(properties = EmptyJsonObject, required = null),
+                    ) { error("registered only to broadcast") }
+                    proceed.complete(Unit)
+                }
+                client.preparePost("http://localhost:$port/mcp") {
+                    header(HttpHeaders.Host, "localhost")
+                    header(HttpHeaders.Accept, "${ContentType.Application.Json}, ${ContentType.Text.EventStream}")
+                    header("MCP-Protocol-Version", LATEST_MODERN_VERSION)
+                    header("Mcp-Method", "tools/call")
+                    header("Mcp-Name", "wait")
+                    contentType(ContentType.Application.Json)
+                    setBody(callTool("wait"))
+                }.execute { response ->
+                    val body = response.bodyAsText()
+                    body shouldContain "answered"
+                    body shouldContain "\"own\""
+                    (body.contains("list_changed")) shouldBe false
+                }
+            } finally {
+                client.close()
+                server.stop(1000, 2000)
+            }
+        }
+
+    private fun callEcho(): String = callTool("echo")
+
+    private fun callTool(name: String): String = """
         {"jsonrpc":"2.0","id":1,"method":"tools/call",
-         "params":{"name":"echo","arguments":{},
+         "params":{"name":"$name","arguments":{},
                    "_meta":{"io.modelcontextprotocol/protocolVersion":"$LATEST_MODERN_VERSION",
                             "io.modelcontextprotocol/clientCapabilities":{},
                             "io.modelcontextprotocol/logLevel":"warning"}}}

--- a/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/ProtocolConcurrencyIntegrationTest.kt
+++ b/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/ProtocolConcurrencyIntegrationTest.kt
@@ -24,13 +24,15 @@ import io.modelcontextprotocol.kotlin.sdk.types.InitializedNotification
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCError
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCMessage
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCResponse
-import io.modelcontextprotocol.kotlin.sdk.types.LATEST_PROTOCOL_VERSION
+import io.modelcontextprotocol.kotlin.sdk.types.LATEST_HANDSHAKE_VERSION
 import io.modelcontextprotocol.kotlin.sdk.types.ListRootsRequest
 import io.modelcontextprotocol.kotlin.sdk.types.ListRootsResult
 import io.modelcontextprotocol.kotlin.sdk.types.ListToolsRequest
 import io.modelcontextprotocol.kotlin.sdk.types.ListToolsResult
+import io.modelcontextprotocol.kotlin.sdk.types.McpJson
 import io.modelcontextprotocol.kotlin.sdk.types.Method
 import io.modelcontextprotocol.kotlin.sdk.types.RequestId
+import io.modelcontextprotocol.kotlin.sdk.types.RequestResult
 import io.modelcontextprotocol.kotlin.sdk.types.Role
 import io.modelcontextprotocol.kotlin.sdk.types.SamplingMessage
 import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
@@ -40,6 +42,8 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.encodeToJsonElement
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicReference
@@ -258,7 +262,7 @@ class ProtocolConcurrencyIntegrationTest {
 
             val initRequest = InitializeRequest(
                 InitializeRequestParams(
-                    protocolVersion = LATEST_PROTOCOL_VERSION,
+                    protocolVersion = LATEST_HANDSHAKE_VERSION,
                     capabilities = ClientCapabilities(),
                     clientInfo = Implementation(name = "raw-client", version = "1.0"),
                 ),
@@ -290,7 +294,10 @@ class ProtocolConcurrencyIntegrationTest {
             clientTransport.send(toolCallRequest)
 
             val toolCallResponse = withTimeout(10.seconds) { toolCallAnswered.await() } as JSONRPCResponse
-            val text = (toolCallResponse.result as CallToolResult).content.filterIsInstance<TextContent>().single().text
+            val toolCallResult = McpJson.decodeFromJsonElement<RequestResult>(
+                McpJson.encodeToJsonElement(toolCallResponse.result),
+            )
+            val text = (toolCallResult as CallToolResult).content.filterIsInstance<TextContent>().single().text
             // The handler echoed its request id, proving currentRequestHandlerExtra() was available.
             text shouldBe toolCallRequest.id.asText()
         }

--- a/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/RequestScopedLifecycleTest.kt
+++ b/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/RequestScopedLifecycleTest.kt
@@ -1,0 +1,252 @@
+package io.modelcontextprotocol.kotlin.sdk.integration
+
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
+import io.modelcontextprotocol.kotlin.sdk.client.Client
+import io.modelcontextprotocol.kotlin.sdk.client.ClientOptions
+import io.modelcontextprotocol.kotlin.sdk.client.VersionNegotiationMode
+import io.modelcontextprotocol.kotlin.sdk.server.ClientConnection
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
+import io.modelcontextprotocol.kotlin.sdk.shared.RequestHandlerExtra
+import io.modelcontextprotocol.kotlin.sdk.shared.currentRequestHandlerExtra
+import io.modelcontextprotocol.kotlin.sdk.testing.ChannelTransport
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolRequest
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.ClientCapabilities
+import io.modelcontextprotocol.kotlin.sdk.types.EmptyJsonObject
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+import io.modelcontextprotocol.kotlin.sdk.types.LATEST_HANDSHAKE_VERSION
+import io.modelcontextprotocol.kotlin.sdk.types.LATEST_MODERN_VERSION
+import io.modelcontextprotocol.kotlin.sdk.types.LoggingLevel
+import io.modelcontextprotocol.kotlin.sdk.types.LoggingMessageNotification
+import io.modelcontextprotocol.kotlin.sdk.types.LoggingMessageNotificationParams
+import io.modelcontextprotocol.kotlin.sdk.types.MODERN_PROTOCOL_VERSIONS
+import io.modelcontextprotocol.kotlin.sdk.types.McpException
+import io.modelcontextprotocol.kotlin.sdk.types.Method
+import io.modelcontextprotocol.kotlin.sdk.types.RPCError
+import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
+import io.modelcontextprotocol.kotlin.sdk.types.SubscribeRequest
+import io.modelcontextprotocol.kotlin.sdk.types.SubscribeRequestParams
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import io.modelcontextprotocol.kotlin.sdk.types.serverInfo
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+/**
+ * End-to-end behaviour of the per-request `_meta` envelope of protocol revision 2026-07-28
+ * (SEP-2575), driven through [Client] and [Server] over an in-memory transport pair.
+ *
+ * Every assertion is spec-mandated unless its own comment says otherwise. The two lifecycles are
+ * exercised side by side on purpose: most of this contract is about which of the two a request is
+ * served under, so a claim about one is only meaningful against the other.
+ */
+@OptIn(ExperimentalMcpApi::class)
+class RequestScopedLifecycleTest {
+
+    private val clientInfo = Implementation(name = "probe-client", version = "3.1")
+
+    private val serverInfo = Implementation(name = "probe-server", version = "9.9")
+
+    private val clientCapabilities = ClientCapabilities(roots = ClientCapabilities.Roots())
+
+    @Test
+    fun `a request-scoped request carries the client identity and capabilities to the handler`() = runBlocking {
+        val seen = CompletableDeferred<RequestHandlerExtra>()
+        val client = connect(VersionNegotiationMode.Auto) { request ->
+            request.params.name shouldBe "echo"
+            seen.complete(checkNotNull(currentRequestHandlerExtra()))
+            ok()
+        }
+
+        client.callTool("echo", emptyMap())
+
+        val extra = seen.await()
+        extra.envelope?.protocolVersion shouldBe LATEST_MODERN_VERSION
+        extra.protocolVersion shouldBe LATEST_MODERN_VERSION
+        extra.clientCapabilities shouldBe clientCapabilities
+        extra.clientInfo shouldBe clientInfo
+        client.close()
+    }
+
+    @Test
+    fun `a handshake request reports the negotiated version and the declared capabilities`() = runBlocking {
+        val seen = CompletableDeferred<RequestHandlerExtra>()
+        val client = connect(VersionNegotiationMode.Legacy) {
+            seen.complete(checkNotNull(currentRequestHandlerExtra()))
+            ok()
+        }
+
+        client.callTool("echo", emptyMap())
+
+        val extra = seen.await()
+        // An absent envelope is what distinguishes the lifecycles; the derived accessors are
+        // populated either way, which is what lets a tool author write one implementation.
+        extra.envelope.shouldBeNull()
+        extra.protocolVersion shouldBe LATEST_HANDSHAKE_VERSION
+        extra.clientCapabilities shouldBe clientCapabilities
+        extra.clientInfo shouldBe clientInfo
+        client.close()
+    }
+
+    @Test
+    fun `a request-scoped result identifies the server in its metadata`() = runBlocking {
+        val client = connect(VersionNegotiationMode.Auto) { ok() }
+
+        val result = client.callTool("echo", emptyMap())
+
+        result?.meta?.serverInfo shouldBe serverInfo
+        client.close()
+    }
+
+    @Test
+    fun `a handshake result carries no server identity`() = runBlocking {
+        val client = connect(VersionNegotiationMode.Legacy) { ok() }
+
+        val result = client.callTool("echo", emptyMap())
+
+        // The handshake reports the identity once, in its own result; stamping it onto every result
+        // would change a wire this SDK has always emitted.
+        result?.meta?.serverInfo.shouldBeNull()
+        client.close()
+    }
+
+    @Test
+    fun `discovery advertises the request-scoped revisions and the server capabilities`() = runBlocking {
+        val client = connect(VersionNegotiationMode.Auto) { ok() }
+
+        val discovered = client.discover()
+
+        discovered.supportedVersions shouldContainExactly MODERN_PROTOCOL_VERSIONS
+        discovered.capabilities.tools shouldBe ServerCapabilities.Tools(null)
+        discovered.meta?.serverInfo shouldBe serverInfo
+        client.protocolVersion shouldBe LATEST_MODERN_VERSION
+        client.close()
+    }
+
+    @Test
+    fun `a method the revision removed is refused on a request-scoped connection`() = runBlocking {
+        val client = connect(VersionNegotiationMode.Auto) { ok() }
+
+        // `resources/subscribe` is one of the six the revision removed. Refused before the
+        // transport, because the connection's revision has no such method to answer it.
+        val error = assertFailsWith<McpException> {
+            client.subscribeResource(SubscribeRequest(SubscribeRequestParams(uri = "test://thing")))
+        }
+
+        error.code shouldBe RPCError.ErrorCode.METHOD_NOT_FOUND
+        client.close()
+    }
+
+    @Test
+    fun `a server asking a request-scoped client for roots is refused`() = runBlocking {
+        val refusal = CompletableDeferred<McpException>()
+        val client = connect(VersionNegotiationMode.Auto) {
+            refusal.complete(assertFailsWith { listRoots() })
+            ok()
+        }
+
+        client.callTool("echo", emptyMap())
+
+        // Server-initiated requests are replaced by multi-round-trip requests, which this SDK does
+        // not implement — so this refusal is what a server author meets, and it must be legible.
+        refusal.await().code shouldBe RPCError.ErrorCode.METHOD_NOT_FOUND
+        client.close()
+    }
+
+    @Test
+    fun `a request-scoped request that did not opt in receives no log notifications`() = runBlocking {
+        val logs = mutableListOf<LoggingLevel>()
+        val client = connect(VersionNegotiationMode.Auto, onLog = { logs += it }) {
+            sendLoggingMessage(log(LoggingLevel.Warning))
+            ok()
+        }
+
+        client.callTool("echo", emptyMap())
+
+        // Emitted while serving the awaited call, over one ordered in-memory stream, so the list
+        // read afterwards is the whole delivery.
+        logs.shouldContainExactly()
+        client.close()
+    }
+
+    @Test
+    fun `a request-scoped request that opted in receives logs at and above its level`() = runBlocking {
+        val logs = mutableListOf<LoggingLevel>()
+        val client = connect(
+            negotiation = VersionNegotiationMode.Auto,
+            logLevel = LoggingLevel.Warning,
+            onLog = { logs += it },
+        ) {
+            sendLoggingMessage(log(LoggingLevel.Debug))
+            sendLoggingMessage(log(LoggingLevel.Warning))
+            ok()
+        }
+
+        client.callTool("echo", emptyMap())
+
+        logs.shouldContainExactly(LoggingLevel.Warning)
+        client.close()
+    }
+
+    private fun ok() = CallToolResult(content = listOf(TextContent("ok")))
+
+    private fun log(level: LoggingLevel) = LoggingMessageNotification(
+        LoggingMessageNotificationParams(level = level, data = JsonPrimitive("entry")),
+    )
+
+    /**
+     * Serves one `echo` tool backed by [handler] and returns a client connected to it, having
+     * settled its lifecycle through [negotiation].
+     */
+    private suspend fun connect(
+        negotiation: VersionNegotiationMode,
+        logLevel: LoggingLevel? = null,
+        onLog: (LoggingLevel) -> Unit = {},
+        handler: suspend ClientConnection.(CallToolRequest) -> CallToolResult,
+    ): Client {
+        val server = Server(
+            serverInfo = serverInfo,
+            options = ServerOptions(
+                capabilities = ServerCapabilities(
+                    tools = ServerCapabilities.Tools(null),
+                    resources = ServerCapabilities.Resources(subscribe = true, listChanged = null),
+                    logging = EmptyJsonObject,
+                ),
+            ),
+        )
+        server.addTool(
+            name = "echo",
+            description = "echoes",
+            inputSchema = ToolSchema(properties = EmptyJsonObject, required = null),
+            handler = handler,
+        )
+
+        val client = Client(
+            clientInfo = clientInfo,
+            options = ClientOptions(
+                capabilities = clientCapabilities,
+                versionNegotiation = negotiation,
+                logLevel = logLevel,
+            ),
+        )
+        client.setNotificationHandler<LoggingMessageNotification>(Method.Defined.NotificationsMessage) {
+            onLog(it.params.level)
+            CompletableDeferred(Unit)
+        }
+
+        val (clientTransport, serverTransport) = ChannelTransport.createLinkedPair()
+        runBlocking {
+            launch { server.createSession(serverTransport) }
+            launch { client.connect(clientTransport) }
+        }
+        return client
+    }
+}

--- a/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/ResponseCacheTest.kt
+++ b/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/ResponseCacheTest.kt
@@ -1,0 +1,162 @@
+package io.modelcontextprotocol.kotlin.sdk.integration
+
+import io.kotest.matchers.shouldBe
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
+import io.modelcontextprotocol.kotlin.sdk.client.CacheMode
+import io.modelcontextprotocol.kotlin.sdk.client.Client
+import io.modelcontextprotocol.kotlin.sdk.client.ClientOptions
+import io.modelcontextprotocol.kotlin.sdk.client.InMemoryResponseCacheStore
+import io.modelcontextprotocol.kotlin.sdk.client.VersionNegotiationMode
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
+import io.modelcontextprotocol.kotlin.sdk.testing.ChannelTransport
+import io.modelcontextprotocol.kotlin.sdk.types.CacheScope
+import io.modelcontextprotocol.kotlin.sdk.types.EmptyJsonObject
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+import io.modelcontextprotocol.kotlin.sdk.types.ListToolsRequest
+import io.modelcontextprotocol.kotlin.sdk.types.ListToolsResult
+import io.modelcontextprotocol.kotlin.sdk.types.Method
+import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
+import io.modelcontextprotocol.kotlin.sdk.types.Tool
+import io.modelcontextprotocol.kotlin.sdk.types.ToolListChangedNotification
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * The client-side response cache (SEP-2549, revision 2026-07-28): what it reuses, what it refuses to
+ * reuse, and what stales it.
+ *
+ * Driven through [Client] over an in-memory pair. Reuse is observed by counting how many times the
+ * server's `tools/list` handler ran: the round trip either happened or it did not, and that count is
+ * the only honest witness to which.
+ */
+@OptIn(ExperimentalMcpApi::class)
+class ResponseCacheTest {
+
+    @Test
+    fun `a fresh cached listing is served without a round trip`() = runBlocking {
+        val fixture = connect(ttlMs = 60_000)
+
+        fixture.client.listTools()
+        fixture.client.listTools()
+
+        fixture.listCalls.get() shouldBe 1
+        fixture.client.close()
+    }
+
+    @Test
+    fun `a listing the server marked immediately stale is fetched again`() = runBlocking {
+        // `ttlMs = 0` is the conservative default a handler that says nothing produces.
+        val fixture = connect(ttlMs = 0)
+
+        fixture.client.listTools()
+        fixture.client.listTools()
+
+        fixture.listCalls.get() shouldBe 2
+        fixture.client.close()
+    }
+
+    @Test
+    fun `a refresh asks the server even while a fresh entry is held`() = runBlocking {
+        val fixture = connect(ttlMs = 60_000)
+
+        fixture.client.listTools()
+        fixture.client.listTools(cacheMode = CacheMode.Refresh)
+        fixture.client.listTools()
+
+        // The refresh both bypassed the entry and replaced it, so the third call is served from it.
+        fixture.listCalls.get() shouldBe 2
+        fixture.client.close()
+    }
+
+    @Test
+    fun `a tools list-changed notification stales the cached listing`() = runBlocking {
+        val fixture = connect(ttlMs = 60_000)
+        val announced = CompletableDeferred<Unit>()
+        fixture.client.setNotificationHandler<ToolListChangedNotification>(
+            Method.Defined.NotificationsToolsListChanged,
+        ) {
+            announced.complete(Unit)
+            CompletableDeferred(Unit)
+        }
+
+        fixture.client.listTools()
+        fixture.server.addTool(
+            name = "added-later",
+            description = "arrives after the listing was cached",
+            inputSchema = ToolSchema(properties = EmptyJsonObject, required = null),
+        ) { error("registered only to announce a catalogue change") }
+        // Invalidation runs at the router, ahead of handler lookup, so this handler completing
+        // proves the cache was already staled.
+        withTimeout(5.seconds) { announced.await() }
+        fixture.client.listTools()
+
+        fixture.listCalls.get() shouldBe 2
+        fixture.client.close()
+    }
+
+    @Test
+    fun `a handshake connection caches nothing`() = runBlocking {
+        val fixture = connect(ttlMs = 60_000, negotiation = VersionNegotiationMode.Legacy)
+
+        fixture.client.listTools()
+        fixture.client.listTools()
+
+        // The directives saying for how long and for whom exist only on the other lifecycle, so a
+        // handshake result carries no terms this client is entitled to honour.
+        fixture.listCalls.get() shouldBe 2
+        fixture.client.close()
+    }
+
+    private class Fixture(val server: Server, val client: Client, val listCalls: AtomicInteger)
+
+    /** A connected pair whose `tools/list` reports [ttlMs] as how long its listing stays fresh. */
+    private suspend fun connect(
+        ttlMs: Long,
+        negotiation: VersionNegotiationMode = VersionNegotiationMode.Auto,
+    ): Fixture {
+        val listCalls = AtomicInteger()
+        val server = Server(
+            serverInfo = Implementation("cache-server", "1.0"),
+            options = ServerOptions(
+                capabilities = ServerCapabilities(tools = ServerCapabilities.Tools(listChanged = true)),
+            ),
+        )
+        val client = Client(
+            clientInfo = Implementation("cache-client", "1.0"),
+            options = ClientOptions(
+                versionNegotiation = negotiation,
+                responseCache = InMemoryResponseCacheStore(),
+            ),
+        )
+
+        val (clientTransport, serverTransport) = ChannelTransport.createLinkedPair()
+        runBlocking {
+            launch {
+                val session = server.createSession(serverTransport)
+                session.setRequestHandler<ListToolsRequest>(Method.Defined.ToolsList) { _, _ ->
+                    listCalls.incrementAndGet()
+                    ListToolsResult(
+                        tools = listOf(
+                            Tool(
+                                name = "echo",
+                                description = "echoes",
+                                inputSchema = ToolSchema(properties = EmptyJsonObject, required = null),
+                            ),
+                        ),
+                        ttlMs = ttlMs,
+                        cacheScope = CacheScope.Private,
+                    )
+                }
+            }
+            launch { client.connect(clientTransport) }
+        }
+        return Fixture(server, client, listCalls)
+    }
+}

--- a/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/ResponseCacheTest.kt
+++ b/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/ResponseCacheTest.kt
@@ -16,6 +16,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import io.modelcontextprotocol.kotlin.sdk.types.ListToolsRequest
 import io.modelcontextprotocol.kotlin.sdk.types.ListToolsResult
 import io.modelcontextprotocol.kotlin.sdk.types.Method
+import io.modelcontextprotocol.kotlin.sdk.types.PaginatedRequestParams
 import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
 import io.modelcontextprotocol.kotlin.sdk.types.Tool
 import io.modelcontextprotocol.kotlin.sdk.types.ToolListChangedNotification
@@ -99,6 +100,60 @@ class ResponseCacheTest {
 
         fixture.listCalls.get() shouldBe 2
         fixture.client.close()
+    }
+
+    @Test
+    fun `a continuation page is never served from or filed under the cursorless entry`() = runBlocking {
+        val listCalls = AtomicInteger()
+        val server = Server(
+            serverInfo = Implementation("cache-server", "1.0"),
+            options = ServerOptions(
+                capabilities = ServerCapabilities(tools = ServerCapabilities.Tools(listChanged = true)),
+            ),
+        )
+        val client = Client(
+            clientInfo = Implementation("cache-client", "1.0"),
+            options = ClientOptions(
+                versionNegotiation = VersionNegotiationMode.Auto,
+                responseCache = InMemoryResponseCacheStore(),
+            ),
+        )
+        val (clientTransport, serverTransport) = ChannelTransport.createLinkedPair()
+        runBlocking {
+            launch {
+                val session = server.createSession(serverTransport)
+                session.setRequestHandler<ListToolsRequest>(Method.Defined.ToolsList) { request, _ ->
+                    listCalls.incrementAndGet()
+                    // The first page names a cursor; a page-2 result is deliberately distinguishable.
+                    val page = if (request.params?.cursor == null) "page-1" else "page-2"
+                    ListToolsResult(
+                        tools = listOf(
+                            Tool(
+                                name = page,
+                                description = "the $page tool",
+                                inputSchema = ToolSchema(properties = EmptyJsonObject, required = null),
+                            ),
+                        ),
+                        nextCursor = "p2".takeIf { request.params?.cursor == null },
+                        ttlMs = 60_000,
+                        cacheScope = CacheScope.Private,
+                    )
+                }
+            }
+            launch { client.connect(clientTransport) }
+        }
+
+        client.listTools() // page 1, cached under the cursorless key
+        val secondPage = client.listTools(ListToolsRequest(PaginatedRequestParams(cursor = "p2")))
+        val secondPageAgain = client.listTools(ListToolsRequest(PaginatedRequestParams(cursor = "p2")))
+        val firstPageAgain = client.listTools() // must still be the cached page 1, not page 2
+
+        // Every cursor-bearing call round-trips; only the first cursorless call did.
+        listCalls.get() shouldBe 3
+        secondPage.tools.single().name shouldBe "page-2"
+        secondPageAgain.tools.single().name shouldBe "page-2"
+        firstPageAgain.tools.single().name shouldBe "page-1"
+        client.close()
     }
 
     @Test

--- a/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/kotlin/AbstractResourceIntegrationTest.kt
+++ b/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/kotlin/AbstractResourceIntegrationTest.kt
@@ -204,9 +204,10 @@ abstract class AbstractResourceIntegrationTest : KotlinTestBase() {
         }
 
         assertEquals(
-            RPCError.ErrorCode.RESOURCE_NOT_FOUND,
+            RPCError.ErrorCode.INVALID_PARAMS,
             exception.code,
-            "Exception code should be RESOURCE_NOT_FOUND: ${RPCError.ErrorCode.RESOURCE_NOT_FOUND}",
+            "A resource that does not exist is an invalid-params rejection; the retired " +
+                "RESOURCE_NOT_FOUND (-32002) is no longer emitted on either era",
         )
     }
 

--- a/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/streamablehttp/StreamableHttpHeartbeatIntegrationTest.kt
+++ b/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/streamablehttp/StreamableHttpHeartbeatIntegrationTest.kt
@@ -20,7 +20,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import io.modelcontextprotocol.kotlin.sdk.types.InitializeRequest
 import io.modelcontextprotocol.kotlin.sdk.types.InitializeRequestParams
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCRequest
-import io.modelcontextprotocol.kotlin.sdk.types.LATEST_PROTOCOL_VERSION
+import io.modelcontextprotocol.kotlin.sdk.types.LATEST_HANDSHAKE_VERSION
 import io.modelcontextprotocol.kotlin.sdk.types.toJSON
 import io.modelcontextprotocol.kotlin.test.utils.actualPort
 import kotlinx.coroutines.Dispatchers
@@ -140,7 +140,7 @@ class StreamableHttpHeartbeatIntegrationTest : AbstractStreamableHttpIntegration
 
     private fun buildInitPayload(): JSONRPCRequest = InitializeRequest(
         InitializeRequestParams(
-            protocolVersion = LATEST_PROTOCOL_VERSION,
+            protocolVersion = LATEST_HANDSHAKE_VERSION,
             capabilities = ClientCapabilities(),
             clientInfo = Implementation(name = "heartbeat-test-client", version = "1.0.0"),
         ),
@@ -149,7 +149,7 @@ class StreamableHttpHeartbeatIntegrationTest : AbstractStreamableHttpIntegration
     private fun io.ktor.client.request.HttpRequestBuilder.addSseHeaders(sessionId: String) {
         header(HttpHeaders.Accept, ContentType.Text.EventStream.toString())
         header(SESSION_ID_HEADER, sessionId)
-        header(PROTOCOL_VERSION_HEADER, LATEST_PROTOCOL_VERSION)
+        header(PROTOCOL_VERSION_HEADER, LATEST_HANDSHAKE_VERSION)
     }
 
     private suspend fun ByteReadChannel.readLineMatching(expectedLine: String, timeoutMillis: Long = 2_000): String? =

--- a/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/streamablehttp/StreamableHttpIntegrationTest.kt
+++ b/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/streamablehttp/StreamableHttpIntegrationTest.kt
@@ -7,7 +7,7 @@ import io.modelcontextprotocol.kotlin.sdk.client.StreamableHttpClientTransport
 import io.modelcontextprotocol.kotlin.sdk.types.GetPromptRequest
 import io.modelcontextprotocol.kotlin.sdk.types.GetPromptRequestParams
 import io.modelcontextprotocol.kotlin.sdk.types.Implementation
-import io.modelcontextprotocol.kotlin.sdk.types.LATEST_PROTOCOL_VERSION
+import io.modelcontextprotocol.kotlin.sdk.types.LATEST_HANDSHAKE_VERSION
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import io.modelcontextprotocol.kotlin.test.utils.actualPort
 import kotlinx.coroutines.Dispatchers
@@ -34,7 +34,7 @@ class StreamableHttpIntegrationTest : AbstractStreamableHttpIntegrationTest() {
                     client = httpClient,
                     url = "http://$URL:$port/mcp",
                 ).apply {
-                    protocolVersion = LATEST_PROTOCOL_VERSION
+                    protocolVersion = LATEST_HANDSHAKE_VERSION
                 }
 
                 client = Client(Implementation("streamable-http-client", VERSION))

--- a/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/streamablehttp/StreamableHttpSseReconnectTest.kt
+++ b/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/integration/streamablehttp/StreamableHttpSseReconnectTest.kt
@@ -19,7 +19,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import io.modelcontextprotocol.kotlin.sdk.types.InitializeRequest
 import io.modelcontextprotocol.kotlin.sdk.types.InitializeRequestParams
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCRequest
-import io.modelcontextprotocol.kotlin.sdk.types.LATEST_PROTOCOL_VERSION
+import io.modelcontextprotocol.kotlin.sdk.types.LATEST_HANDSHAKE_VERSION
 import io.modelcontextprotocol.kotlin.sdk.types.toJSON
 import io.modelcontextprotocol.kotlin.test.utils.actualPort
 import kotlinx.coroutines.Dispatchers
@@ -74,7 +74,7 @@ class StreamableHttpSseReconnectTest : AbstractStreamableHttpIntegrationTest() {
             httpClient.prepareGet(mcpUrl) {
                 header(HttpHeaders.Accept, ContentType.Text.EventStream.toString())
                 header(SESSION_ID_HEADER, sessionId)
-                header(PROTOCOL_VERSION_HEADER, LATEST_PROTOCOL_VERSION)
+                header(PROTOCOL_VERSION_HEADER, LATEST_HANDSHAKE_VERSION)
             }.execute { response ->
                 response.status shouldBe HttpStatusCode.OK
                 response.bodyAsChannel().readUTF8Line()
@@ -86,7 +86,7 @@ class StreamableHttpSseReconnectTest : AbstractStreamableHttpIntegrationTest() {
             httpClient.prepareGet(mcpUrl) {
                 header(HttpHeaders.Accept, ContentType.Text.EventStream.toString())
                 header(SESSION_ID_HEADER, sessionId)
-                header(PROTOCOL_VERSION_HEADER, LATEST_PROTOCOL_VERSION)
+                header(PROTOCOL_VERSION_HEADER, LATEST_HANDSHAKE_VERSION)
             }.execute { response ->
                 response.status shouldBe HttpStatusCode.OK
                 response.headers[SESSION_ID_HEADER] shouldBe sessionId
@@ -134,7 +134,7 @@ class StreamableHttpSseReconnectTest : AbstractStreamableHttpIntegrationTest() {
             httpClient.prepareGet(mcpUrl) {
                 header(HttpHeaders.Accept, ContentType.Text.EventStream.toString())
                 header(SESSION_ID_HEADER, sessionId)
-                header(PROTOCOL_VERSION_HEADER, LATEST_PROTOCOL_VERSION)
+                header(PROTOCOL_VERSION_HEADER, LATEST_HANDSHAKE_VERSION)
             }.execute { firstResponse ->
                 firstResponse.status shouldBe HttpStatusCode.OK
                 firstResponse.bodyAsChannel().readUTF8Line()
@@ -143,7 +143,7 @@ class StreamableHttpSseReconnectTest : AbstractStreamableHttpIntegrationTest() {
                 httpClient.prepareGet(mcpUrl) {
                     header(HttpHeaders.Accept, ContentType.Text.EventStream.toString())
                     header(SESSION_ID_HEADER, sessionId)
-                    header(PROTOCOL_VERSION_HEADER, LATEST_PROTOCOL_VERSION)
+                    header(PROTOCOL_VERSION_HEADER, LATEST_HANDSHAKE_VERSION)
                 }.execute { secondResponse ->
                     secondResponse.status shouldBe HttpStatusCode.OK
                     secondResponse.headers[SESSION_ID_HEADER] shouldBe sessionId
@@ -163,7 +163,7 @@ class StreamableHttpSseReconnectTest : AbstractStreamableHttpIntegrationTest() {
 
     private fun buildInitPayload(): JSONRPCRequest = InitializeRequest(
         InitializeRequestParams(
-            protocolVersion = LATEST_PROTOCOL_VERSION,
+            protocolVersion = LATEST_HANDSHAKE_VERSION,
             capabilities = ClientCapabilities(),
             clientInfo = Implementation(name = "reconnect-test-client", version = "1.0.0"),
         ),

--- a/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/SamplingTest.kt
+++ b/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/SamplingTest.kt
@@ -1,5 +1,6 @@
 package io.modelcontextprotocol.kotlin.sdk.server
 
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
 import io.modelcontextprotocol.kotlin.sdk.client.Client
 import io.modelcontextprotocol.kotlin.sdk.client.ClientOptions
 import io.modelcontextprotocol.kotlin.sdk.shared.InMemoryTransport
@@ -10,7 +11,11 @@ import io.modelcontextprotocol.kotlin.sdk.types.CreateMessageResult
 import io.modelcontextprotocol.kotlin.sdk.types.EmptyJsonObject
 import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import io.modelcontextprotocol.kotlin.sdk.types.IncludeContext
+import io.modelcontextprotocol.kotlin.sdk.types.McpException
+import io.modelcontextprotocol.kotlin.sdk.types.McpJson
 import io.modelcontextprotocol.kotlin.sdk.types.Method
+import io.modelcontextprotocol.kotlin.sdk.types.MissingRequiredClientCapabilityData
+import io.modelcontextprotocol.kotlin.sdk.types.RPCError
 import io.modelcontextprotocol.kotlin.sdk.types.Role
 import io.modelcontextprotocol.kotlin.sdk.types.SamplingMessage
 import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
@@ -26,11 +31,13 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
 import org.junit.jupiter.api.assertDoesNotThrow
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
+@OptIn(ExperimentalMcpApi::class)
 class SamplingTest {
 
     private val dummyTool = Tool(
@@ -103,7 +110,7 @@ class SamplingTest {
     @Test
     fun `tools field rejected when client has no sampling tools capability`() {
         val (server, sessionId) = buildPair()
-        assertFailsWith<IllegalArgumentException> {
+        val error = assertFailsWith<McpException> {
             runBlocking {
                 server.createMessage(
                     sessionId = sessionId,
@@ -117,12 +124,18 @@ class SamplingTest {
                 )
             }
         }
+
+        assertEquals(RPCError.ErrorCode.MISSING_REQUIRED_CLIENT_CAPABILITY, error.code)
+        assertEquals(
+            ClientCapabilities(sampling = ClientCapabilities.Sampling(tools = EmptyJsonObject)),
+            error.missingCapabilities(),
+        )
     }
 
     @Test
     fun `toolChoice field rejected when client has no sampling tools capability`() {
         val (server, sessionId) = buildPair()
-        assertFailsWith<IllegalArgumentException> {
+        val error = assertFailsWith<McpException> {
             runBlocking {
                 server.createMessage(
                     sessionId = sessionId,
@@ -136,7 +149,17 @@ class SamplingTest {
                 )
             }
         }
+
+        assertEquals(RPCError.ErrorCode.MISSING_REQUIRED_CLIENT_CAPABILITY, error.code)
+        assertEquals(
+            ClientCapabilities(sampling = ClientCapabilities.Sampling(tools = EmptyJsonObject)),
+            error.missingCapabilities(),
+        )
     }
+
+    /** The capabilities a [RPCError.ErrorCode.MISSING_REQUIRED_CLIENT_CAPABILITY] error reports as missing. */
+    private fun McpException.missingCapabilities(): ClientCapabilities =
+        McpJson.decodeFromJsonElement<MissingRequiredClientCapabilityData>(checkNotNull(data)).requiredCapabilities
 
     @Test
     fun `includeContext with no sampling context capability succeeds with a warning`() {

--- a/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ServerResourceTemplateTest.kt
+++ b/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ServerResourceTemplateTest.kt
@@ -119,12 +119,12 @@ class ServerResourceTemplateTest : AbstractServerFeaturesTest() {
     }
 
     @Test
-    fun `readResource should return RESOURCE_NOT_FOUND error when no match`() = runTest {
+    fun `readResource should return INVALID_PARAMS error when no match`() = runTest {
         val exception = assertThrows<McpException> {
             client.readResource(ReadResourceRequest(ReadResourceRequestParams("test://nonexistent/uri")))
         }
 
-        exception.code shouldBe RPCError.ErrorCode.RESOURCE_NOT_FOUND
+        exception.code shouldBe RPCError.ErrorCode.INVALID_PARAMS
     }
 
     @Test

--- a/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ServerSessionInitializeTest.kt
+++ b/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ServerSessionInitializeTest.kt
@@ -9,7 +9,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCError
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCMessage
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCRequest
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCResponse
-import io.modelcontextprotocol.kotlin.sdk.types.LATEST_PROTOCOL_VERSION
+import io.modelcontextprotocol.kotlin.sdk.types.LATEST_HANDSHAKE_VERSION
 import io.modelcontextprotocol.kotlin.sdk.types.RPCError
 import io.modelcontextprotocol.kotlin.sdk.types.RequestId
 import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
@@ -41,7 +41,7 @@ class ServerSessionInitializeTest {
 
     private fun createInitializeRequest(clientName: String = "test-client"): InitializeRequest = InitializeRequest(
         InitializeRequestParams(
-            protocolVersion = LATEST_PROTOCOL_VERSION,
+            protocolVersion = LATEST_HANDSHAKE_VERSION,
             capabilities = ClientCapabilities(),
             clientInfo = Implementation(name = clientName, version = "1.0"),
         ),

--- a/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/testing/ChannelTransportTest.kt
+++ b/integration-test/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/testing/ChannelTransportTest.kt
@@ -9,7 +9,7 @@ import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
 import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import io.modelcontextprotocol.kotlin.sdk.types.InitializeRequest
 import io.modelcontextprotocol.kotlin.sdk.types.InitializeResult
-import io.modelcontextprotocol.kotlin.sdk.types.LATEST_PROTOCOL_VERSION
+import io.modelcontextprotocol.kotlin.sdk.types.LATEST_HANDSHAKE_VERSION
 import io.modelcontextprotocol.kotlin.sdk.types.ListResourcesRequest
 import io.modelcontextprotocol.kotlin.sdk.types.ListResourcesResult
 import io.modelcontextprotocol.kotlin.sdk.types.Method
@@ -44,7 +44,7 @@ class ChannelTransportTest {
 
         serverSession.setRequestHandler<InitializeRequest>(Method.Defined.Initialize) { _, _ ->
             InitializeResult(
-                protocolVersion = LATEST_PROTOCOL_VERSION,
+                protocolVersion = LATEST_HANDSHAKE_VERSION,
                 capabilities = ServerCapabilities(
                     resources = ServerCapabilities.Resources(null, null),
                     tools = ServerCapabilities.Tools(null),

--- a/kotlin-sdk-client/api/kotlin-sdk-client.api
+++ b/kotlin-sdk-client/api/kotlin-sdk-client.api
@@ -1,3 +1,43 @@
+public final class io/modelcontextprotocol/kotlin/sdk/client/CacheEntry {
+	public fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/RequestResult;Lkotlin/time/Instant;Lio/modelcontextprotocol/kotlin/sdk/types/CacheScope;)V
+	public final fun component1 ()Lio/modelcontextprotocol/kotlin/sdk/types/RequestResult;
+	public final fun component2 ()Lkotlin/time/Instant;
+	public final fun component3 ()Lio/modelcontextprotocol/kotlin/sdk/types/CacheScope;
+	public final fun copy (Lio/modelcontextprotocol/kotlin/sdk/types/RequestResult;Lkotlin/time/Instant;Lio/modelcontextprotocol/kotlin/sdk/types/CacheScope;)Lio/modelcontextprotocol/kotlin/sdk/client/CacheEntry;
+	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/client/CacheEntry;Lio/modelcontextprotocol/kotlin/sdk/types/RequestResult;Lkotlin/time/Instant;Lio/modelcontextprotocol/kotlin/sdk/types/CacheScope;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/client/CacheEntry;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCacheScope ()Lio/modelcontextprotocol/kotlin/sdk/types/CacheScope;
+	public final fun getExpiresAt ()Lkotlin/time/Instant;
+	public final fun getResult ()Lio/modelcontextprotocol/kotlin/sdk/types/RequestResult;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/modelcontextprotocol/kotlin/sdk/client/CacheKey {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/modelcontextprotocol/kotlin/sdk/client/CacheKey;
+	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/client/CacheKey;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/client/CacheKey;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMethod ()Ljava/lang/String;
+	public final fun getParamsKey ()Ljava/lang/String;
+	public final fun getPartition ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/modelcontextprotocol/kotlin/sdk/client/CacheMode : java/lang/Enum {
+	public static final field Bypass Lio/modelcontextprotocol/kotlin/sdk/client/CacheMode;
+	public static final field Refresh Lio/modelcontextprotocol/kotlin/sdk/client/CacheMode;
+	public static final field Use Lio/modelcontextprotocol/kotlin/sdk/client/CacheMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/modelcontextprotocol/kotlin/sdk/client/CacheMode;
+	public static fun values ()[Lio/modelcontextprotocol/kotlin/sdk/client/CacheMode;
+}
+
 public class io/modelcontextprotocol/kotlin/sdk/client/Client : io/modelcontextprotocol/kotlin/sdk/shared/Protocol {
 	public fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/Implementation;Lio/modelcontextprotocol/kotlin/sdk/client/ClientOptions;)V
 	public synthetic fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/Implementation;Lio/modelcontextprotocol/kotlin/sdk/client/ClientOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -14,23 +54,28 @@ public class io/modelcontextprotocol/kotlin/sdk/client/Client : io/modelcontextp
 	public final fun complete (Lio/modelcontextprotocol/kotlin/sdk/types/CompleteRequest;Lio/modelcontextprotocol/kotlin/sdk/shared/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun complete$default (Lio/modelcontextprotocol/kotlin/sdk/client/Client;Lio/modelcontextprotocol/kotlin/sdk/types/CompleteRequest;Lio/modelcontextprotocol/kotlin/sdk/shared/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public fun connect (Lio/modelcontextprotocol/kotlin/sdk/shared/Transport;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	protected final fun decorateOutboundRequest (Lio/modelcontextprotocol/kotlin/sdk/types/JSONRPCRequest;)Lio/modelcontextprotocol/kotlin/sdk/types/JSONRPCRequest;
+	public final fun discover (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	protected final fun getNegotiatedProtocolVersion ()Ljava/lang/String;
 	public final fun getPrompt (Lio/modelcontextprotocol/kotlin/sdk/types/GetPromptRequest;Lio/modelcontextprotocol/kotlin/sdk/shared/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getPrompt$default (Lio/modelcontextprotocol/kotlin/sdk/client/Client;Lio/modelcontextprotocol/kotlin/sdk/types/GetPromptRequest;Lio/modelcontextprotocol/kotlin/sdk/shared/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun getProtocolVersion ()Ljava/lang/String;
 	public final fun getServerCapabilities ()Lio/modelcontextprotocol/kotlin/sdk/types/ServerCapabilities;
 	public final fun getServerInstructions ()Ljava/lang/String;
 	public final fun getServerVersion ()Lio/modelcontextprotocol/kotlin/sdk/types/Implementation;
-	public final fun listPrompts (Lio/modelcontextprotocol/kotlin/sdk/types/ListPromptsRequest;Lio/modelcontextprotocol/kotlin/sdk/shared/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun listPrompts$default (Lio/modelcontextprotocol/kotlin/sdk/client/Client;Lio/modelcontextprotocol/kotlin/sdk/types/ListPromptsRequest;Lio/modelcontextprotocol/kotlin/sdk/shared/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun listResourceTemplates (Lio/modelcontextprotocol/kotlin/sdk/types/ListResourceTemplatesRequest;Lio/modelcontextprotocol/kotlin/sdk/shared/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun listResourceTemplates$default (Lio/modelcontextprotocol/kotlin/sdk/client/Client;Lio/modelcontextprotocol/kotlin/sdk/types/ListResourceTemplatesRequest;Lio/modelcontextprotocol/kotlin/sdk/shared/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun listResources (Lio/modelcontextprotocol/kotlin/sdk/types/ListResourcesRequest;Lio/modelcontextprotocol/kotlin/sdk/shared/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun listResources$default (Lio/modelcontextprotocol/kotlin/sdk/client/Client;Lio/modelcontextprotocol/kotlin/sdk/types/ListResourcesRequest;Lio/modelcontextprotocol/kotlin/sdk/shared/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun listTools (Lio/modelcontextprotocol/kotlin/sdk/types/ListToolsRequest;Lio/modelcontextprotocol/kotlin/sdk/shared/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun listTools$default (Lio/modelcontextprotocol/kotlin/sdk/client/Client;Lio/modelcontextprotocol/kotlin/sdk/types/ListToolsRequest;Lio/modelcontextprotocol/kotlin/sdk/shared/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun listPrompts (Lio/modelcontextprotocol/kotlin/sdk/types/ListPromptsRequest;Lio/modelcontextprotocol/kotlin/sdk/shared/RequestOptions;Lio/modelcontextprotocol/kotlin/sdk/client/CacheMode;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun listPrompts$default (Lio/modelcontextprotocol/kotlin/sdk/client/Client;Lio/modelcontextprotocol/kotlin/sdk/types/ListPromptsRequest;Lio/modelcontextprotocol/kotlin/sdk/shared/RequestOptions;Lio/modelcontextprotocol/kotlin/sdk/client/CacheMode;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun listResourceTemplates (Lio/modelcontextprotocol/kotlin/sdk/types/ListResourceTemplatesRequest;Lio/modelcontextprotocol/kotlin/sdk/shared/RequestOptions;Lio/modelcontextprotocol/kotlin/sdk/client/CacheMode;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun listResourceTemplates$default (Lio/modelcontextprotocol/kotlin/sdk/client/Client;Lio/modelcontextprotocol/kotlin/sdk/types/ListResourceTemplatesRequest;Lio/modelcontextprotocol/kotlin/sdk/shared/RequestOptions;Lio/modelcontextprotocol/kotlin/sdk/client/CacheMode;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun listResources (Lio/modelcontextprotocol/kotlin/sdk/types/ListResourcesRequest;Lio/modelcontextprotocol/kotlin/sdk/shared/RequestOptions;Lio/modelcontextprotocol/kotlin/sdk/client/CacheMode;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun listResources$default (Lio/modelcontextprotocol/kotlin/sdk/client/Client;Lio/modelcontextprotocol/kotlin/sdk/types/ListResourcesRequest;Lio/modelcontextprotocol/kotlin/sdk/shared/RequestOptions;Lio/modelcontextprotocol/kotlin/sdk/client/CacheMode;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun listTools (Lio/modelcontextprotocol/kotlin/sdk/types/ListToolsRequest;Lio/modelcontextprotocol/kotlin/sdk/shared/RequestOptions;Lio/modelcontextprotocol/kotlin/sdk/client/CacheMode;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun listTools$default (Lio/modelcontextprotocol/kotlin/sdk/client/Client;Lio/modelcontextprotocol/kotlin/sdk/types/ListToolsRequest;Lio/modelcontextprotocol/kotlin/sdk/shared/RequestOptions;Lio/modelcontextprotocol/kotlin/sdk/client/CacheMode;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	protected final fun onNotificationRouted (Lio/modelcontextprotocol/kotlin/sdk/types/JSONRPCNotification;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun ping (Lio/modelcontextprotocol/kotlin/sdk/shared/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun ping$default (Lio/modelcontextprotocol/kotlin/sdk/client/Client;Lio/modelcontextprotocol/kotlin/sdk/shared/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun readResource (Lio/modelcontextprotocol/kotlin/sdk/types/ReadResourceRequest;Lio/modelcontextprotocol/kotlin/sdk/shared/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun readResource$default (Lio/modelcontextprotocol/kotlin/sdk/client/Client;Lio/modelcontextprotocol/kotlin/sdk/types/ReadResourceRequest;Lio/modelcontextprotocol/kotlin/sdk/shared/RequestOptions;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun readResource (Lio/modelcontextprotocol/kotlin/sdk/types/ReadResourceRequest;Lio/modelcontextprotocol/kotlin/sdk/shared/RequestOptions;Lio/modelcontextprotocol/kotlin/sdk/client/CacheMode;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun readResource$default (Lio/modelcontextprotocol/kotlin/sdk/client/Client;Lio/modelcontextprotocol/kotlin/sdk/types/ReadResourceRequest;Lio/modelcontextprotocol/kotlin/sdk/shared/RequestOptions;Lio/modelcontextprotocol/kotlin/sdk/client/CacheMode;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun removeRoot (Ljava/lang/String;)Z
 	public final fun removeRoots (Ljava/util/List;)I
 	public final fun sendRootsListChanged (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -52,9 +97,21 @@ public final class io/modelcontextprotocol/kotlin/sdk/client/ClientKt {
 
 public final class io/modelcontextprotocol/kotlin/sdk/client/ClientOptions : io/modelcontextprotocol/kotlin/sdk/shared/ProtocolOptions {
 	public fun <init> ()V
-	public fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/ClientCapabilities;ZLkotlin/coroutines/CoroutineContext;)V
-	public synthetic fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/ClientCapabilities;ZLkotlin/coroutines/CoroutineContext;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/ClientCapabilities;ZLkotlin/coroutines/CoroutineContext;Lio/modelcontextprotocol/kotlin/sdk/client/VersionNegotiationMode;Lio/modelcontextprotocol/kotlin/sdk/types/LoggingLevel;Lio/modelcontextprotocol/kotlin/sdk/client/ResponseCacheStore;Ljava/lang/String;)V
+	public synthetic fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/ClientCapabilities;ZLkotlin/coroutines/CoroutineContext;Lio/modelcontextprotocol/kotlin/sdk/client/VersionNegotiationMode;Lio/modelcontextprotocol/kotlin/sdk/types/LoggingLevel;Lio/modelcontextprotocol/kotlin/sdk/client/ResponseCacheStore;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getCachePartition ()Ljava/lang/String;
 	public final fun getCapabilities ()Lio/modelcontextprotocol/kotlin/sdk/types/ClientCapabilities;
+	public final fun getLogLevel ()Lio/modelcontextprotocol/kotlin/sdk/types/LoggingLevel;
+	public final fun getResponseCache ()Lio/modelcontextprotocol/kotlin/sdk/client/ResponseCacheStore;
+	public final fun getVersionNegotiation ()Lio/modelcontextprotocol/kotlin/sdk/client/VersionNegotiationMode;
+}
+
+public final class io/modelcontextprotocol/kotlin/sdk/client/InMemoryResponseCacheStore : io/modelcontextprotocol/kotlin/sdk/client/ResponseCacheStore {
+	public fun <init> ()V
+	public fun clear (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun get (Lio/modelcontextprotocol/kotlin/sdk/client/CacheKey;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun invalidate (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun put (Lio/modelcontextprotocol/kotlin/sdk/client/CacheKey;Lio/modelcontextprotocol/kotlin/sdk/client/CacheEntry;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/client/KtorClientKt {
@@ -74,6 +131,17 @@ public final class io/modelcontextprotocol/kotlin/sdk/client/ReconnectionOptions
 	public final fun getReconnectionDelayMultiplier ()D
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/modelcontextprotocol/kotlin/sdk/client/ResponseCacheKt {
+	public static final field MAX_CACHE_TTL_MS J
+}
+
+public abstract interface class io/modelcontextprotocol/kotlin/sdk/client/ResponseCacheStore {
+	public abstract fun clear (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun get (Lio/modelcontextprotocol/kotlin/sdk/client/CacheKey;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun invalidate (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun put (Lio/modelcontextprotocol/kotlin/sdk/client/CacheKey;Lio/modelcontextprotocol/kotlin/sdk/client/CacheEntry;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/client/SseClientTransport : io/modelcontextprotocol/kotlin/sdk/shared/AbstractClientTransport {
@@ -130,6 +198,34 @@ public final class io/modelcontextprotocol/kotlin/sdk/client/StreamableHttpMcpKt
 	public static synthetic fun mcpStreamableHttpTransport$default (Lio/ktor/client/HttpClient;Ljava/lang/String;Lio/modelcontextprotocol/kotlin/sdk/client/ReconnectionOptions;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/client/StreamableHttpClientTransport;
 	public static final fun mcpStreamableHttpTransport-5_5nbZA (Lio/ktor/client/HttpClient;Ljava/lang/String;Lkotlin/time/Duration;Lkotlin/jvm/functions/Function1;)Lio/modelcontextprotocol/kotlin/sdk/client/StreamableHttpClientTransport;
 	public static synthetic fun mcpStreamableHttpTransport-5_5nbZA$default (Lio/ktor/client/HttpClient;Ljava/lang/String;Lkotlin/time/Duration;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/client/StreamableHttpClientTransport;
+}
+
+public abstract interface class io/modelcontextprotocol/kotlin/sdk/client/VersionNegotiationMode {
+}
+
+public final class io/modelcontextprotocol/kotlin/sdk/client/VersionNegotiationMode$Auto : io/modelcontextprotocol/kotlin/sdk/client/VersionNegotiationMode {
+	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/client/VersionNegotiationMode$Auto;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/modelcontextprotocol/kotlin/sdk/client/VersionNegotiationMode$Legacy : io/modelcontextprotocol/kotlin/sdk/client/VersionNegotiationMode {
+	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/client/VersionNegotiationMode$Legacy;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/modelcontextprotocol/kotlin/sdk/client/VersionNegotiationMode$Pin : io/modelcontextprotocol/kotlin/sdk/client/VersionNegotiationMode {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/modelcontextprotocol/kotlin/sdk/client/VersionNegotiationMode$Pin;
+	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/client/VersionNegotiationMode$Pin;Ljava/lang/String;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/client/VersionNegotiationMode$Pin;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getVersion ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/client/WebSocketClientTransport : io/modelcontextprotocol/kotlin/sdk/shared/WebSocketMcpTransport {

--- a/kotlin-sdk-client/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/client/Client.kt
+++ b/kotlin-sdk-client/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/client/Client.kt
@@ -8,6 +8,8 @@ import io.modelcontextprotocol.kotlin.sdk.shared.RequestHandlerExtra
 import io.modelcontextprotocol.kotlin.sdk.shared.RequestOptions
 import io.modelcontextprotocol.kotlin.sdk.shared.Transport
 import io.modelcontextprotocol.kotlin.sdk.types.BooleanSchema
+import io.modelcontextprotocol.kotlin.sdk.types.CacheScope
+import io.modelcontextprotocol.kotlin.sdk.types.CacheableResult
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolRequest
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolRequestParams
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
@@ -15,6 +17,9 @@ import io.modelcontextprotocol.kotlin.sdk.types.ClientCapabilities
 import io.modelcontextprotocol.kotlin.sdk.types.CompleteRequest
 import io.modelcontextprotocol.kotlin.sdk.types.CompleteResult
 import io.modelcontextprotocol.kotlin.sdk.types.CreateMessageRequest
+import io.modelcontextprotocol.kotlin.sdk.types.DiscoverRequest
+import io.modelcontextprotocol.kotlin.sdk.types.DiscoverRequestParams
+import io.modelcontextprotocol.kotlin.sdk.types.DiscoverResult
 import io.modelcontextprotocol.kotlin.sdk.types.DoubleSchema
 import io.modelcontextprotocol.kotlin.sdk.types.ElicitRequest
 import io.modelcontextprotocol.kotlin.sdk.types.ElicitRequestFormParams
@@ -23,13 +28,17 @@ import io.modelcontextprotocol.kotlin.sdk.types.ElicitationCompleteNotification
 import io.modelcontextprotocol.kotlin.sdk.types.EmptyResult
 import io.modelcontextprotocol.kotlin.sdk.types.GetPromptRequest
 import io.modelcontextprotocol.kotlin.sdk.types.GetPromptResult
+import io.modelcontextprotocol.kotlin.sdk.types.HANDSHAKE_PROTOCOL_VERSIONS
 import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import io.modelcontextprotocol.kotlin.sdk.types.InitializeRequest
 import io.modelcontextprotocol.kotlin.sdk.types.InitializeRequestParams
 import io.modelcontextprotocol.kotlin.sdk.types.InitializeResult
 import io.modelcontextprotocol.kotlin.sdk.types.InitializedNotification
 import io.modelcontextprotocol.kotlin.sdk.types.IntegerSchema
-import io.modelcontextprotocol.kotlin.sdk.types.LATEST_PROTOCOL_VERSION
+import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCNotification
+import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCRequest
+import io.modelcontextprotocol.kotlin.sdk.types.LATEST_HANDSHAKE_VERSION
+import io.modelcontextprotocol.kotlin.sdk.types.LATEST_MODERN_VERSION
 import io.modelcontextprotocol.kotlin.sdk.types.LegacyTitledEnumSchema
 import io.modelcontextprotocol.kotlin.sdk.types.ListPromptsRequest
 import io.modelcontextprotocol.kotlin.sdk.types.ListPromptsResult
@@ -42,18 +51,21 @@ import io.modelcontextprotocol.kotlin.sdk.types.ListRootsResult
 import io.modelcontextprotocol.kotlin.sdk.types.ListToolsRequest
 import io.modelcontextprotocol.kotlin.sdk.types.ListToolsResult
 import io.modelcontextprotocol.kotlin.sdk.types.LoggingLevel
+import io.modelcontextprotocol.kotlin.sdk.types.MODERN_PROTOCOL_VERSIONS
 import io.modelcontextprotocol.kotlin.sdk.types.McpException
+import io.modelcontextprotocol.kotlin.sdk.types.McpJson
 import io.modelcontextprotocol.kotlin.sdk.types.Method
 import io.modelcontextprotocol.kotlin.sdk.types.PingRequest
 import io.modelcontextprotocol.kotlin.sdk.types.PrimitiveSchemaDefinition
+import io.modelcontextprotocol.kotlin.sdk.types.RPCError
 import io.modelcontextprotocol.kotlin.sdk.types.ReadResourceRequest
 import io.modelcontextprotocol.kotlin.sdk.types.ReadResourceResult
 import io.modelcontextprotocol.kotlin.sdk.types.Request
+import io.modelcontextprotocol.kotlin.sdk.types.RequestEnvelope
 import io.modelcontextprotocol.kotlin.sdk.types.RequestMeta
 import io.modelcontextprotocol.kotlin.sdk.types.RequestResult
 import io.modelcontextprotocol.kotlin.sdk.types.Root
 import io.modelcontextprotocol.kotlin.sdk.types.RootsListChangedNotification
-import io.modelcontextprotocol.kotlin.sdk.types.SUPPORTED_PROTOCOL_VERSIONS
 import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
 import io.modelcontextprotocol.kotlin.sdk.types.SetLevelRequest
 import io.modelcontextprotocol.kotlin.sdk.types.SetLevelRequestParams
@@ -64,8 +76,12 @@ import io.modelcontextprotocol.kotlin.sdk.types.TitledSingleSelectEnumSchema
 import io.modelcontextprotocol.kotlin.sdk.types.UnsubscribeRequest
 import io.modelcontextprotocol.kotlin.sdk.types.UntitledMultiSelectEnumSchema
 import io.modelcontextprotocol.kotlin.sdk.types.UntitledSingleSelectEnumSchema
+import io.modelcontextprotocol.kotlin.sdk.types.isModernProtocolVersion
+import io.modelcontextprotocol.kotlin.sdk.types.serverInfo
 import io.modelcontextprotocol.kotlin.sdk.types.supportsUrl
 import io.modelcontextprotocol.kotlin.sdk.types.toJson
+import io.modelcontextprotocol.kotlin.sdk.types.toMeta
+import kotlinx.atomicfu.AtomicRef
 import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.getAndUpdate
 import kotlinx.atomicfu.update
@@ -79,8 +95,12 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.jsonObject
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
 
 private val logger = KotlinLogging.logger {}
 
@@ -90,11 +110,33 @@ private val logger = KotlinLogging.logger {}
  * @property capabilities The capabilities this client supports.
  * @param enforceStrictCapabilities Whether to strictly enforce capabilities when interacting with the server.
  * @param handlerCoroutineContext Coroutine context for inbound handlers. See [ProtocolOptions.handlerCoroutineContext].
+ * @property versionNegotiation How [Client.connect] settles which protocol lifecycle to speak.
+ *   Defaults to the `initialize` handshake, the only lifecycle offering sampling, elicitation,
+ *   roots, `ping`, `logging/setLevel` and resource subscriptions. Set [VersionNegotiationMode.Auto]
+ *   to probe `server/discover` and adopt the request-scoped lifecycle where the server offers it.
+ * @property logLevel Minimum severity of `notifications/message` a server may emit while serving
+ *   this client's requests, on the request-scoped lifecycle only, where a server emits nothing for
+ *   a request that did not ask. Ignored on the handshake lifecycle, where [Client.setLoggingLevel]
+ *   applies instead.
+ * @property responseCache Where to keep results a server marked reusable. Off by default;
+ *   [InMemoryResponseCacheStore] caches for the lifetime of this client. Consulted only on the
+ *   request-scoped lifecycle, the only one whose results carry caching directives.
+ * @property cachePartition The authorization context this client fetches under, which
+ *   [CacheScope.Private] entries are confined to. Only meaningful for a store shared across
+ *   principals; the default scopes such entries to this client instance.
  */
 public class ClientOptions(
     public val capabilities: ClientCapabilities = ClientCapabilities(),
     enforceStrictCapabilities: Boolean = true,
     handlerCoroutineContext: CoroutineContext = Dispatchers.Default,
+    @property:ExperimentalMcpApi
+    public val versionNegotiation: VersionNegotiationMode = VersionNegotiationMode.Legacy,
+    @property:ExperimentalMcpApi
+    public val logLevel: LoggingLevel? = null,
+    @property:ExperimentalMcpApi
+    public val responseCache: ResponseCacheStore? = null,
+    @property:ExperimentalMcpApi
+    public val cachePartition: String = "",
 ) : ProtocolOptions(
     enforceStrictCapabilities = enforceStrictCapabilities,
     handlerCoroutineContext = handlerCoroutineContext,
@@ -164,7 +206,50 @@ public open class Client(private val clientInfo: Implementation, options: Client
 
     private val capabilities: ClientCapabilities = options.capabilities
 
+    @OptIn(ExperimentalMcpApi::class)
+    private val versionNegotiation: VersionNegotiationMode = options.versionNegotiation
+
+    @OptIn(ExperimentalMcpApi::class)
+    private val logLevel: LoggingLevel? = options.logLevel
+
+    @OptIn(ExperimentalMcpApi::class)
+    private val responseCache: ResponseCacheStore? = options.responseCache
+
+    @OptIn(ExperimentalMcpApi::class)
+    private val cachePartition: String = options.cachePartition
+
     private val roots = atomic(persistentMapOf<String, Root>())
+
+    private val _protocolVersion: AtomicRef<String?> = atomic(null)
+
+    private val _discovered: AtomicRef<DiscoverResult?> = atomic(null)
+
+    /**
+     * The protocol version this connection settled on, or `null` before [connect] completes.
+     *
+     * Settled by the `initialize` handshake or by `server/discover`, depending on what the server
+     * turned out to speak; [serverCapabilities], [serverVersion] and [serverInstructions] mean the
+     * same thing either way.
+     */
+    public val protocolVersion: String? get() = _protocolVersion.value
+
+    final override val negotiatedProtocolVersion: String? get() = _protocolVersion.value
+
+    /**
+     * Attaches this client's protocol envelope to every request sent on a request-scoped connection.
+     *
+     * Entries the caller put in `_meta` win over the envelope's own, and unrelated entries such as
+     * `progressToken` survive untouched. On a connection settled by the handshake this returns
+     * [request] unchanged.
+     */
+    @OptIn(ExperimentalMcpApi::class)
+    final override fun decorateOutboundRequest(request: JSONRPCRequest): JSONRPCRequest {
+        val version = _protocolVersion.value?.takeIf(::isModernProtocolVersion) ?: return request
+        val params = (request.params as? JsonObject).orEmpty()
+        val supplied = (params["_meta"] as? JsonObject).orEmpty()
+        val meta = JsonObject(McpJson.encodeToJsonElement(envelope(version)).jsonObject + supplied)
+        return request.copy(params = JsonObject(params + ("_meta" to meta)))
+    }
 
     init {
         logger.debug { "Initializing MCP client with capabilities: $capabilities" }
@@ -199,30 +284,14 @@ public open class Client(private val clientInfo: Implementation, options: Client
      * @param transport The transport to use for communication with the server.
      * @throws IllegalStateException If the server's protocol version is not supported.
      */
+    @OptIn(ExperimentalMcpApi::class)
     override suspend fun connect(transport: Transport) {
         super.connect(transport)
 
         try {
-            val message = InitializeRequest(
-                InitializeRequestParams(
-                    protocolVersion = LATEST_PROTOCOL_VERSION,
-                    capabilities = capabilities,
-                    clientInfo = clientInfo,
-                ),
-            )
-            val result = request<InitializeResult>(message)
-
-            if (!SUPPORTED_PROTOCOL_VERSIONS.contains(result.protocolVersion)) {
-                error(
-                    "Server's protocol version is not supported: ${result.protocolVersion}",
-                )
+            if (!negotiateRequestScoped(transport)) {
+                handshake(transport)
             }
-
-            serverCapabilities = result.capabilities
-            serverVersion = result.serverInfo
-            serverInstructions = result.instructions
-
-            notification(InitializedNotification())
             enableConcurrentDispatch()
         } catch (error: Throwable) {
             logger.error(error) { "Failed to initialize client: ${error.message}" }
@@ -239,6 +308,213 @@ public open class Client(private val clientInfo: Implementation, options: Client
             }
         }
     }
+
+    /** The plain `initialize` handshake, unchanged from a client built without version negotiation. */
+    private suspend fun handshake(transport: Transport) {
+        val message = InitializeRequest(
+            InitializeRequestParams(
+                protocolVersion = LATEST_HANDSHAKE_VERSION,
+                capabilities = capabilities,
+                clientInfo = clientInfo,
+            ),
+        )
+        val result = request<InitializeResult>(message)
+
+        if (!HANDSHAKE_PROTOCOL_VERSIONS.contains(result.protocolVersion)) {
+            error(
+                "Server's protocol version is not supported: ${result.protocolVersion}",
+            )
+        }
+
+        serverCapabilities = result.capabilities
+        serverVersion = result.serverInfo
+        serverInstructions = result.instructions
+        settle(result.protocolVersion, transport)
+
+        notification(InitializedNotification())
+    }
+
+    /**
+     * Probes `server/discover` and adopts the request-scoped lifecycle when the answer says to.
+     *
+     * @return `true` when the connection settled on that lifecycle, `false` when the caller should
+     * run the handshake instead
+     */
+    @OptIn(ExperimentalMcpApi::class)
+    private suspend fun negotiateRequestScoped(transport: Transport): Boolean {
+        val mode = versionNegotiation
+        if (mode == VersionNegotiationMode.Legacy) return false
+
+        val offered = if (mode is VersionNegotiationMode.Pin) listOf(mode.version) else MODERN_PROTOCOL_VERSIONS
+        val fallbackAvailable = mode !is VersionNegotiationMode.Pin
+        var version = offered.first()
+        var corrected = false
+
+        while (true) {
+            val outcome = probeDiscovery(version, transport)
+            val verdict = classifyProbeOutcome(
+                outcome = outcome,
+                clientModernVersions = offered,
+                fallbackAvailable = fallbackAvailable,
+                overStdio = transport is StdioClientTransport,
+            )
+            when (verdict) {
+                is ProbeVerdict.Modern -> {
+                    adopt(verdict.version, verdict.discover, transport)
+                    return true
+                }
+
+                is ProbeVerdict.Corrective -> {
+                    // The revision mandates one corrective continuation. A server that rejects the
+                    // version it just named is not negotiating, so the second rejection is reported.
+                    if (corrected) throw (outcome as ProbeOutcome.Refused).error
+                    corrected = true
+                    version = verdict.version
+                }
+
+                ProbeVerdict.Legacy -> return false
+
+                is ProbeVerdict.Failed -> throw verdict.cause
+            }
+        }
+    }
+
+    /**
+     * Sends one `server/discover` probe at [version].
+     *
+     * The probe rides the ordinary request path, so it consumes a request id and honours the
+     * configured timeout. [version] is settled for the duration of the probe — it is what admits a
+     * request-scoped method, attaches the envelope and sets the `MCP-Protocol-Version` header — and
+     * withdrawn afterwards, so a fallback handshake carries none of the three.
+     */
+    @OptIn(ExperimentalMcpApi::class)
+    private suspend fun probeDiscovery(version: String, transport: Transport): ProbeOutcome {
+        settle(version, transport)
+        return try {
+            ProbeOutcome.Answered(
+                request<DiscoverResult>(DiscoverRequest(DiscoverRequestParams(meta = envelope(version).toMeta()))),
+            )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: McpException) {
+            // Silence and a peer that went away instead of answering are the same signal; on stdio
+            // both mean a server that predates discovery, and the classifier decides what to do.
+            if (e.code == RPCError.ErrorCode.REQUEST_TIMEOUT || e.code == RPCError.ErrorCode.CONNECTION_CLOSED) {
+                ProbeOutcome.Silent
+            } else {
+                ProbeOutcome.Refused(e)
+            }
+        } catch (_: SerializationException) {
+            ProbeOutcome.Answered(null)
+        } catch (_: ClassCastException) {
+            // The peer answered something that parsed as a different result type.
+            ProbeOutcome.Answered(null)
+        } finally {
+            withdraw(transport)
+        }
+    }
+
+    /** Undoes [settle], leaving the connection unsettled again. */
+    private fun withdraw(transport: Transport) {
+        _protocolVersion.value = null
+        if (transport is StreamableHttpClientTransport) {
+            transport.protocolVersion = null
+        }
+    }
+
+    /** Adopts a discovery result as this connection's settled state. */
+    @OptIn(ExperimentalMcpApi::class)
+    private fun adopt(version: String, discover: DiscoverResult, transport: Transport) {
+        serverCapabilities = discover.capabilities
+        serverVersion = runCatching<Implementation?> { discover.meta?.serverInfo }.getOrNull()
+        serverInstructions = discover.instructions
+        _discovered.value = discover
+        settle(version, transport)
+    }
+
+    /**
+     * Records [version] as settled and pushes it onto [transport], which needs it for the
+     * `MCP-Protocol-Version` header both lifecycles require.
+     */
+    private fun settle(version: String, transport: Transport) {
+        _protocolVersion.value = version
+        if (transport is StreamableHttpClientTransport) {
+            transport.protocolVersion = version
+        }
+    }
+
+    /**
+     * The protocol versions, capabilities and instructions this server advertises.
+     *
+     * Answered from the result [connect] adopted when it settled the connection by discovery, so
+     * asking again costs no round trip.
+     *
+     * @throws McpException with [RPCError.ErrorCode.METHOD_NOT_FOUND] on a connection settled by the
+     * `initialize` handshake, which has no `server/discover`
+     */
+    @ExperimentalMcpApi
+    public suspend fun discover(): DiscoverResult {
+        _discovered.value?.let { return it }
+        val version = _protocolVersion.value ?: LATEST_MODERN_VERSION
+        return request<DiscoverResult>(DiscoverRequest(DiscoverRequestParams(meta = envelope(version).toMeta())))
+            .also { _discovered.value = it }
+    }
+
+    /**
+     * Serves [method] from the response cache when it holds a fresh entry, and files what [fetch]
+     * answers when it does not.
+     *
+     * Only the request-scoped lifecycle caches, being the only one whose results carry caching
+     * directives. A result that is not [CacheableResult] is passed through untouched.
+     */
+    @OptIn(ExperimentalMcpApi::class, ExperimentalTime::class)
+    private suspend fun <T : RequestResult> cached(
+        method: String,
+        paramsKey: String,
+        mode: CacheMode,
+        fetch: suspend () -> T,
+    ): T {
+        val store = responseCache
+        if (store == null ||
+            mode == CacheMode.Bypass ||
+            _protocolVersion.value?.let(::isModernProtocolVersion) != true
+        ) {
+            return fetch()
+        }
+        val key = CacheKey(method = method, paramsKey = paramsKey, partition = cachePartition)
+        if (mode == CacheMode.Use) {
+            store.get(key)?.takeIf { Clock.System.now() < it.expiresAt }?.let {
+                @Suppress("UNCHECKED_CAST")
+                return it.result as T
+            }
+        }
+        val fresh = fetch()
+        if (fresh is CacheableResult) {
+            store.put(key, CacheEntry(result = fresh, expiresAt = fresh.expiryFrom(), cacheScope = fresh.cacheScope))
+        }
+        return fresh
+    }
+
+    /**
+     * Drops every cached result this notification stales.
+     *
+     * Runs at the router rather than in a handler, so a stale listing is dropped whether or not the
+     * application registered a handler for the notification.
+     */
+    @OptIn(ExperimentalMcpApi::class)
+    final override suspend fun onNotificationRouted(notification: JSONRPCNotification) {
+        val store = responseCache ?: return
+        CACHE_INVALIDATING_NOTIFICATIONS[notification.method]?.forEach { store.invalidate(it) }
+    }
+
+    /** This client's protocol envelope for a request made under [version]. */
+    @OptIn(ExperimentalMcpApi::class)
+    private fun envelope(version: String): RequestEnvelope = RequestEnvelope(
+        protocolVersion = version,
+        clientCapabilities = capabilities,
+        clientInfo = clientInfo,
+        logLevel = logLevel,
+    )
 
     override fun assertCapabilityForMethod(method: Method) {
         when (method) {
@@ -444,7 +720,8 @@ public open class Client(private val clientInfo: Implementation, options: Client
     public suspend fun listPrompts(
         request: ListPromptsRequest = ListPromptsRequest(),
         options: RequestOptions? = null,
-    ): ListPromptsResult = request(request, options)
+        cacheMode: CacheMode = CacheMode.Use,
+    ): ListPromptsResult = cached(request.method.value, "", cacheMode) { request(request, options) }
 
     /**
      * Lists all available resources from the server.
@@ -457,7 +734,8 @@ public open class Client(private val clientInfo: Implementation, options: Client
     public suspend fun listResources(
         request: ListResourcesRequest = ListResourcesRequest(),
         options: RequestOptions? = null,
-    ): ListResourcesResult = request(request, options)
+        cacheMode: CacheMode = CacheMode.Use,
+    ): ListResourcesResult = cached(request.method.value, "", cacheMode) { request(request, options) }
 
     /**
      * Lists resource templates available on the server.
@@ -470,7 +748,8 @@ public open class Client(private val clientInfo: Implementation, options: Client
     public suspend fun listResourceTemplates(
         request: ListResourceTemplatesRequest,
         options: RequestOptions? = null,
-    ): ListResourceTemplatesResult = request(request, options)
+        cacheMode: CacheMode = CacheMode.Use,
+    ): ListResourceTemplatesResult = cached(request.method.value, "", cacheMode) { request(request, options) }
 
     /**
      * Reads a resource from the server by its URI.
@@ -483,7 +762,8 @@ public open class Client(private val clientInfo: Implementation, options: Client
     public suspend fun readResource(
         request: ReadResourceRequest,
         options: RequestOptions? = null,
-    ): ReadResourceResult = request(request, options)
+        cacheMode: CacheMode = CacheMode.Use,
+    ): ReadResourceResult = cached(request.method.value, request.params.uri, cacheMode) { request(request, options) }
 
     /**
      * Subscribes to resource changes on the server.
@@ -561,7 +841,8 @@ public open class Client(private val clientInfo: Implementation, options: Client
     public suspend fun listTools(
         request: ListToolsRequest = ListToolsRequest(),
         options: RequestOptions? = null,
-    ): ListToolsResult = request(request, options)
+        cacheMode: CacheMode = CacheMode.Use,
+    ): ListToolsResult = cached(request.method.value, "", cacheMode) { request(request, options) }
 
     /**
      * Registers a single root.
@@ -576,7 +857,7 @@ public open class Client(private val clientInfo: Implementation, options: Client
             "Client does not support roots capability."
         }
         logger.info { "Adding root: $name ($uri)" }
-        roots.update { current -> current.put(uri, Root(uri, name)) }
+        roots.update { current -> current.putting(uri, Root(uri, name)) }
     }
 
     /**
@@ -591,7 +872,7 @@ public open class Client(private val clientInfo: Implementation, options: Client
             "Client does not support roots capability."
         }
         logger.info { "Adding ${rootsToAdd.size} roots" }
-        roots.update { current -> current.putAll(rootsToAdd.associateBy { it.uri }) }
+        roots.update { current -> current.puttingAll(rootsToAdd.associateBy { it.uri }) }
     }
 
     /**
@@ -606,7 +887,7 @@ public open class Client(private val clientInfo: Implementation, options: Client
             "Client does not support roots capability."
         }
         logger.info { "Removing root: $uri" }
-        val oldMap = roots.getAndUpdate { current -> current.remove(uri) }
+        val oldMap = roots.getAndUpdate { current -> current.removing(uri) }
         val removed = uri in oldMap
         logger.debug {
             if (removed) {

--- a/kotlin-sdk-client/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/client/Client.kt
+++ b/kotlin-sdk-client/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/client/Client.kt
@@ -466,16 +466,22 @@ public open class Client(private val clientInfo: Implementation, options: Client
      *
      * Only the request-scoped lifecycle caches, being the only one whose results carry caching
      * directives. A result that is not [CacheableResult] is passed through untouched.
+     *
+     * @param cacheable `false` for a continuation page: a cursor makes the result a slice, not the
+     *   listing the cursor-less key names, so serving it from — or filing it under — that key would
+     *   return one page as the whole list. Such calls neither read nor write the cache.
      */
     @OptIn(ExperimentalMcpApi::class, ExperimentalTime::class)
     private suspend fun <T : RequestResult> cached(
         method: String,
         paramsKey: String,
         mode: CacheMode,
+        cacheable: Boolean = true,
         fetch: suspend () -> T,
     ): T {
         val store = responseCache
         if (store == null ||
+            !cacheable ||
             mode == CacheMode.Bypass ||
             _protocolVersion.value?.let(::isModernProtocolVersion) != true
         ) {
@@ -714,6 +720,8 @@ public open class Client(private val clientInfo: Implementation, options: Client
      *
      * @param request A request object for listing prompts (usually empty).
      * @param options Optional request options.
+     * @param cacheMode How the response cache participates; effective only on the request-scoped
+     *   lifecycle with [ClientOptions.responseCache] set, and never for a request carrying a cursor.
      * @return The list of available prompts, or `null` if none.
      * @throws IllegalStateException If the server does not support prompts.
      */
@@ -721,13 +729,17 @@ public open class Client(private val clientInfo: Implementation, options: Client
         request: ListPromptsRequest = ListPromptsRequest(),
         options: RequestOptions? = null,
         cacheMode: CacheMode = CacheMode.Use,
-    ): ListPromptsResult = cached(request.method.value, "", cacheMode) { request(request, options) }
+    ): ListPromptsResult = cached(request.method.value, "", cacheMode, cacheable = request.params?.cursor == null) {
+        request(request, options)
+    }
 
     /**
      * Lists all available resources from the server.
      *
      * @param request A request object for listing resources (usually empty).
      * @param options Optional request options.
+     * @param cacheMode How the response cache participates; effective only on the request-scoped
+     *   lifecycle with [ClientOptions.responseCache] set, and never for a request carrying a cursor.
      * @return The list of resources, or `null` if none.
      * @throws IllegalStateException If the server does not support resources.
      */
@@ -735,13 +747,17 @@ public open class Client(private val clientInfo: Implementation, options: Client
         request: ListResourcesRequest = ListResourcesRequest(),
         options: RequestOptions? = null,
         cacheMode: CacheMode = CacheMode.Use,
-    ): ListResourcesResult = cached(request.method.value, "", cacheMode) { request(request, options) }
+    ): ListResourcesResult = cached(request.method.value, "", cacheMode, cacheable = request.params?.cursor == null) {
+        request(request, options)
+    }
 
     /**
      * Lists resource templates available on the server.
      *
      * @param request The request object for listing resource templates.
      * @param options Optional request options.
+     * @param cacheMode How the response cache participates; effective only on the request-scoped
+     *   lifecycle with [ClientOptions.responseCache] set, and never for a request carrying a cursor.
      * @return The list of resource templates, or `null` if none.
      * @throws IllegalStateException If the server does not support resources.
      */
@@ -749,13 +765,18 @@ public open class Client(private val clientInfo: Implementation, options: Client
         request: ListResourceTemplatesRequest,
         options: RequestOptions? = null,
         cacheMode: CacheMode = CacheMode.Use,
-    ): ListResourceTemplatesResult = cached(request.method.value, "", cacheMode) { request(request, options) }
+    ): ListResourceTemplatesResult =
+        cached(request.method.value, "", cacheMode, cacheable = request.params?.cursor == null) {
+            request(request, options)
+        }
 
     /**
      * Reads a resource from the server by its URI.
      *
      * @param request The request object containing the resource URI.
      * @param options Optional request options.
+     * @param cacheMode How the response cache participates; effective only on the request-scoped
+     *   lifecycle with [ClientOptions.responseCache] set.
      * @return The resource content, or `null` if the resource is not found.
      * @throws IllegalStateException If the server does not support resources.
      */
@@ -835,6 +856,8 @@ public open class Client(private val clientInfo: Implementation, options: Client
      *
      * @param request A request object for listing tools (usually empty).
      * @param options Optional request options.
+     * @param cacheMode How the response cache participates; effective only on the request-scoped
+     *   lifecycle with [ClientOptions.responseCache] set, and never for a request carrying a cursor.
      * @return The list of available tools, or `null` if none.
      * @throws IllegalStateException If the server does not support tools.
      */
@@ -842,7 +865,9 @@ public open class Client(private val clientInfo: Implementation, options: Client
         request: ListToolsRequest = ListToolsRequest(),
         options: RequestOptions? = null,
         cacheMode: CacheMode = CacheMode.Use,
-    ): ListToolsResult = cached(request.method.value, "", cacheMode) { request(request, options) }
+    ): ListToolsResult = cached(request.method.value, "", cacheMode, cacheable = request.params?.cursor == null) {
+        request(request, options)
+    }
 
     /**
      * Registers a single root.

--- a/kotlin-sdk-client/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/client/ResponseCache.kt
+++ b/kotlin-sdk-client/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/client/ResponseCache.kt
@@ -1,0 +1,130 @@
+package io.modelcontextprotocol.kotlin.sdk.client
+
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
+import io.modelcontextprotocol.kotlin.sdk.types.CacheScope
+import io.modelcontextprotocol.kotlin.sdk.types.CacheableResult
+import io.modelcontextprotocol.kotlin.sdk.types.Method
+import io.modelcontextprotocol.kotlin.sdk.types.RequestResult
+import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.update
+import kotlinx.collections.immutable.PersistentMap
+import kotlinx.collections.immutable.persistentMapOf
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+/** How a call should treat whatever the response cache already holds. */
+@ExperimentalMcpApi
+public enum class CacheMode {
+    /** Serve a fresh entry when there is one, and store what the server answers otherwise. */
+    Use,
+
+    /** Ignore any stored entry, ask the server, and store the answer. */
+    Refresh,
+
+    /** Ignore the cache entirely, in both directions. */
+    Bypass,
+}
+
+/**
+ * What a cached result is filed under.
+ *
+ * @property method the JSON-RPC method that produced the result
+ * @property paramsKey the part of the request that changes the result — a URI for `resources/read`,
+ * empty for the list methods, whose results depend on nothing else
+ * @property partition the authorization context the result was fetched under, supplied by the
+ * caller. A [CacheScope.Private] entry is never served across partitions; empty scopes it to this
+ * client instance.
+ */
+@ExperimentalMcpApi
+public data class CacheKey(val method: String, val paramsKey: String = "", val partition: String = "")
+
+/**
+ * A stored result and the terms it was stored under.
+ *
+ * @property result the result exactly as the server sent it
+ * @property expiresAt the instant after which the result is stale
+ * @property cacheScope whether shared caches may serve it to other principals
+ */
+@ExperimentalMcpApi
+@OptIn(ExperimentalTime::class)
+public data class CacheEntry(val result: RequestResult, val expiresAt: Instant, val cacheScope: CacheScope)
+
+/**
+ * Where a client keeps results a server said were worth reusing.
+ *
+ * Implement it to share a cache across client instances or processes; [InMemoryResponseCacheStore]
+ * is the single-instance default. Implementations are called from arbitrary coroutines and must be
+ * safe to use concurrently.
+ */
+@ExperimentalMcpApi
+public interface ResponseCacheStore {
+    /** The entry filed under [key], whether or not it is still fresh, or `null` when there is none. */
+    public suspend fun get(key: CacheKey): CacheEntry?
+
+    /** Files [entry] under [key], replacing any entry already there. */
+    public suspend fun put(key: CacheKey, entry: CacheEntry)
+
+    /** Drops every entry produced by [method], whatever its params or partition. */
+    public suspend fun invalidate(method: String)
+
+    /** Drops everything. */
+    public suspend fun clear()
+}
+
+/** The longest a result may be treated as fresh, however large a `ttlMs` a server asks for. */
+@ExperimentalMcpApi
+public const val MAX_CACHE_TTL_MS: Long = 24L * 60 * 60 * 1000
+
+/**
+ * A [ResponseCacheStore] holding entries in memory for the lifetime of this instance.
+ *
+ * Unbounded, holding one entry per method-and-params combination the client has issued.
+ */
+@ExperimentalMcpApi
+public class InMemoryResponseCacheStore : ResponseCacheStore {
+    private val entries = atomic(persistentMapOf<CacheKey, CacheEntry>())
+
+    override suspend fun get(key: CacheKey): CacheEntry? = entries.value[key]
+
+    override suspend fun put(key: CacheKey, entry: CacheEntry) {
+        entries.update { it.putting(key, entry) }
+    }
+
+    override suspend fun invalidate(method: String) {
+        entries.update { current -> current.removeAll { key -> key.method == method } }
+    }
+
+    override suspend fun clear() {
+        entries.update { it.cleared() }
+    }
+}
+
+/** The map without every key [predicate] accepts. */
+@OptIn(ExperimentalMcpApi::class)
+private fun PersistentMap<CacheKey, CacheEntry>.removeAll(
+    predicate: (CacheKey) -> Boolean,
+): PersistentMap<CacheKey, CacheEntry> = keys.filter(predicate).fold(this) { map, key -> map.removing(key) }
+
+/** The methods whose cached results each notification stales. */
+@ExperimentalMcpApi
+internal val CACHE_INVALIDATING_NOTIFICATIONS: Map<String, List<String>> = mapOf(
+    Method.Defined.NotificationsToolsListChanged.value to listOf(Method.Defined.ToolsList.value),
+    Method.Defined.NotificationsPromptsListChanged.value to listOf(Method.Defined.PromptsList.value),
+    Method.Defined.NotificationsResourcesListChanged.value to listOf(
+        Method.Defined.ResourcesList.value,
+        Method.Defined.ResourcesTemplatesList.value,
+    ),
+    Method.Defined.NotificationsResourcesUpdated.value to listOf(Method.Defined.ResourcesRead.value),
+)
+
+/**
+ * The instant [result] goes stale, measured from [now].
+ *
+ * A `ttlMs` longer than [MAX_CACHE_TTL_MS] is clamped rather than refused.
+ */
+@OptIn(ExperimentalTime::class)
+@ExperimentalMcpApi
+internal fun CacheableResult.expiryFrom(now: Instant = Clock.System.now()): Instant =
+    now + ttlMs.coerceAtMost(MAX_CACHE_TTL_MS).milliseconds

--- a/kotlin-sdk-client/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/client/StreamableHttpClientTransport.kt
+++ b/kotlin-sdk-client/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/client/StreamableHttpClientTransport.kt
@@ -23,6 +23,7 @@ import io.ktor.http.contentType
 import io.ktor.http.isSuccess
 import io.ktor.utils.io.charsets.TooLongLineException
 import io.ktor.utils.io.readUTF8Line
+import io.modelcontextprotocol.kotlin.sdk.InternalMcpApi
 import io.modelcontextprotocol.kotlin.sdk.shared.AbstractClientTransport
 import io.modelcontextprotocol.kotlin.sdk.shared.TooLongFrameException
 import io.modelcontextprotocol.kotlin.sdk.shared.TransportSendOptions
@@ -30,8 +31,13 @@ import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCMessage
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCNotification
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCRequest
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCResponse
+import io.modelcontextprotocol.kotlin.sdk.types.MCP_METHOD_HEADER
+import io.modelcontextprotocol.kotlin.sdk.types.MCP_NAME_HEADER
+import io.modelcontextprotocol.kotlin.sdk.types.MCP_PROTOCOL_VERSION_HEADER
 import io.modelcontextprotocol.kotlin.sdk.types.McpJson
+import io.modelcontextprotocol.kotlin.sdk.types.NAME_BEARING_METHODS
 import io.modelcontextprotocol.kotlin.sdk.types.RequestId
+import io.modelcontextprotocol.kotlin.sdk.types.encodeMcpHeaderValue
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
@@ -45,20 +51,13 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
-import kotlin.io.encoding.Base64
-import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.math.pow
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 private const val MCP_SESSION_ID_HEADER = "mcp-session-id"
-private const val MCP_PROTOCOL_VERSION_HEADER = "mcp-protocol-version"
 private const val MCP_RESUMPTION_TOKEN_HEADER = "Last-Event-ID"
-private const val MCP_METHOD_HEADER = "Mcp-Method"
-private const val MCP_NAME_HEADER = "Mcp-Name"
-private const val MCP_BASE64_PREFIX = "=?base64?"
-private const val MCP_BASE64_SUFFIX = "?="
 
 /**
  * Default maximum size, in characters, of a single inline SSE event assembled from a POST response.
@@ -98,6 +97,7 @@ private sealed interface ConnectResult {
  *      with [io.modelcontextprotocol.kotlin.sdk.shared.TooLongFrameException]. Defaults to 16 MiB.
  * @param requestBuilder builder applied to every outgoing HTTP request, e.g. for adding auth headers
  */
+@OptIn(InternalMcpApi::class)
 public class StreamableHttpClientTransport(
     private val client: HttpClient,
     private val url: String,
@@ -399,35 +399,29 @@ public class StreamableHttpClientTransport(
         }
     }
 
+    /**
+     * Restates a request's method and named subject as headers, so an intermediary can route on them
+     * without parsing the body.
+     *
+     * Requests only: the revision leaves header requirements for posted notifications undefined, and
+     * a receiver cross-checking them against a notification would be checking a rule nobody wrote.
+     * The subject is selected by method rather than by whichever of `name` or `uri` happens to be
+     * present, so both ends compare the same field by construction.
+     */
     private fun applyStandardPostHeaders(builder: HttpRequestBuilder, message: JSONRPCMessage) {
-        val (method, params) = when (message) {
-            is JSONRPCRequest -> message.method to message.params
-            is JSONRPCNotification -> message.method to message.params
-            else -> return
-        }
+        if (message !is JSONRPCRequest) return
 
         builder.headers {
-            append(MCP_METHOD_HEADER, method)
+            append(MCP_METHOD_HEADER, message.method)
 
-            val paramsObject = params as? JsonObject ?: return@headers
-            val mcpName = paramsObject.stringValue("name") ?: paramsObject.stringValue("uri")
-            mcpName?.let { append(MCP_NAME_HEADER, it.encodeMcpHeaderValue()) }
+            val nameKey = NAME_BEARING_METHODS[message.method] ?: return@headers
+            val paramsObject = message.params as? JsonObject ?: return@headers
+            paramsObject.stringValue(nameKey)?.let { append(MCP_NAME_HEADER, it.encodeMcpHeaderValue()) }
         }
     }
 
     private fun JsonObject.stringValue(key: String): String? =
         (get(key) as? JsonPrimitive)?.takeIf { it.isString }?.content
-
-    @OptIn(ExperimentalEncodingApi::class)
-    private fun String.encodeMcpHeaderValue(): String {
-        val containsUnsafeCharacters = any { it != '\t' && it.code !in 0x20..0x7e }
-        val hasEdgeWhitespace = firstOrNull()?.isWhitespace() == true || lastOrNull()?.isWhitespace() == true
-        val matchesBase64Sentinel = startsWith(MCP_BASE64_PREFIX) && endsWith(MCP_BASE64_SUFFIX)
-
-        if (!containsUnsafeCharacters && !hasEdgeWhitespace && !matchesBase64Sentinel) return this
-
-        return "$MCP_BASE64_PREFIX${Base64.Default.encode(encodeToByteArray())}$MCP_BASE64_SUFFIX"
-    }
 
     private suspend fun collectSse(
         session: ClientSSESession,

--- a/kotlin-sdk-client/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/client/VersionNegotiation.kt
+++ b/kotlin-sdk-client/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/client/VersionNegotiation.kt
@@ -1,0 +1,186 @@
+package io.modelcontextprotocol.kotlin.sdk.client
+
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
+import io.modelcontextprotocol.kotlin.sdk.types.DiscoverResult
+import io.modelcontextprotocol.kotlin.sdk.types.HANDSHAKE_PROTOCOL_VERSIONS
+import io.modelcontextprotocol.kotlin.sdk.types.McpException
+import io.modelcontextprotocol.kotlin.sdk.types.McpJson
+import io.modelcontextprotocol.kotlin.sdk.types.RPCError
+import io.modelcontextprotocol.kotlin.sdk.types.UnsupportedProtocolVersionData
+import io.modelcontextprotocol.kotlin.sdk.types.isModernProtocolVersion
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.decodeFromJsonElement
+
+/**
+ * How a client settles which protocol lifecycle it speaks with a server.
+ *
+ * The two lifecycles cannot interoperate, so a client settles this once per connection — unlike a
+ * server, which decides it per request.
+ */
+@ExperimentalMcpApi
+public sealed interface VersionNegotiationMode {
+    /**
+     * The plain `initialize` handshake, byte-identical to a client built without this option.
+     *
+     * The default, and the only lifecycle offering sampling, elicitation, roots, `ping`,
+     * `logging/setLevel` and resource subscriptions; the request-scoped lifecycle has none of them.
+     */
+    public data object Legacy : VersionNegotiationMode
+
+    /**
+     * Probe `server/discover`, and fall back to the handshake unless the answer is positive
+     * evidence of the request-scoped lifecycle.
+     *
+     * Anything not recognized as such evidence falls back, so a server that has never heard of
+     * discovery still connects, at the cost of one extra round trip.
+     */
+    public data object Auto : VersionNegotiationMode
+
+    /**
+     * The request-scoped lifecycle at exactly [version], with no fallback.
+     *
+     * @throws IllegalArgumentException if [version] predates the request-scoped lifecycle, which
+     * has no envelope to pin — such a version is reached through [Legacy] instead
+     */
+    public data class Pin(public val version: String) : VersionNegotiationMode {
+        init {
+            require(isModernProtocolVersion(version)) {
+                "$version is not a request-scoped protocol revision, so it cannot be pinned; " +
+                    "use VersionNegotiationMode.Legacy to reach it through the initialize handshake."
+            }
+        }
+    }
+}
+
+/** What a `server/discover` probe came back as, normalized for [classifyProbeOutcome]. */
+internal sealed interface ProbeOutcome {
+    /** The server answered. [result] is `null` when the answer did not parse as a discovery result. */
+    data class Answered(val result: DiscoverResult?) : ProbeOutcome
+
+    /** The server answered with a JSON-RPC error. */
+    data class Refused(val error: McpException) : ProbeOutcome
+
+    /** Nothing arrived within the probe timeout, or the peer went away instead of answering. */
+    data object Silent : ProbeOutcome
+}
+
+/** What a client does next, given a probe outcome. */
+internal sealed interface ProbeVerdict {
+    /** Positive evidence: adopt [discover] and speak [version] without a handshake. */
+    data class Modern(val version: String, val discover: DiscoverResult) : ProbeVerdict
+
+    /**
+     * The server named a revision both ends speak: re-probe at [version]. This continuation is
+     * part of negotiation, not a retry.
+     */
+    data class Corrective(val version: String) : ProbeVerdict
+
+    /** No positive evidence: run the plain `initialize` handshake. */
+    data object Legacy : ProbeVerdict
+
+    /** A genuine incompatibility: report [cause] rather than pretending either lifecycle works. */
+    data class Failed(val cause: McpException) : ProbeVerdict
+}
+
+/**
+ * What [outcome] means for the lifecycle of this connection.
+ *
+ * Pure and total: retry state, loop guards and I/O all live in the caller. The verdict is
+ * [ProbeVerdict.Modern] only on evidence that positively identifies the request-scoped lifecycle;
+ * everything else falls back. A failure that is not the server answering — a network outage, a
+ * cancellation — is not a verdict about which protocol a server speaks and never reaches here.
+ *
+ * @param clientModernVersions request-scoped revisions this client can speak, in preference order
+ * @param fallbackAvailable whether the handshake is still open to this client; `false` under
+ *   [VersionNegotiationMode.Pin], where an outcome that would have fallen back is a failure instead
+ * @param overStdio whether the probe ran over stdio, where a server that stays silent or exits is a
+ *   handshake-era signal rather than an outage — there is no status code to tell the two apart
+ */
+internal fun classifyProbeOutcome(
+    outcome: ProbeOutcome,
+    clientModernVersions: List<String>,
+    fallbackAvailable: Boolean,
+    overStdio: Boolean,
+): ProbeVerdict = when (outcome) {
+    is ProbeOutcome.Answered -> classifyAnswer(outcome.result, clientModernVersions, fallbackAvailable)
+
+    is ProbeOutcome.Refused -> classifyRefusal(outcome.error, clientModernVersions, fallbackAvailable)
+
+    ProbeOutcome.Silent -> if (overStdio) {
+        fallBack(fallbackAvailable) {
+            McpException(
+                code = RPCError.ErrorCode.CONNECTION_CLOSED,
+                message = "The server did not answer the server/discover probe, so it does not " +
+                    "speak a pinned request-scoped revision.",
+            )
+        }
+    } else {
+        // A deployed HTTP server answers, so silence there is an outage, not an era.
+        ProbeVerdict.Failed(
+            McpException(
+                code = RPCError.ErrorCode.REQUEST_TIMEOUT,
+                message = "The server/discover probe timed out.",
+            ),
+        )
+    }
+}
+
+private fun classifyAnswer(
+    result: DiscoverResult?,
+    clientModernVersions: List<String>,
+    fallbackAvailable: Boolean,
+): ProbeVerdict {
+    // An answer this SDK cannot read is not evidence of anything, so it falls back like silence.
+    val supported = result?.supportedVersions
+        ?: return fallBack(fallbackAvailable) {
+            McpException(
+                code = RPCError.ErrorCode.INVALID_PARAMS,
+                message = "The server/discover result did not parse, so no revision could be selected.",
+            )
+        }
+    val mutual = clientModernVersions.firstOrNull { it in supported }
+        // The server speaks discovery but advertises no revision this client has. That is an
+        // advertisement, not an incompatibility, so a client that can still handshake does.
+        ?: return fallBack(fallbackAvailable) { unsupported(supported, clientModernVersions) }
+    return ProbeVerdict.Modern(version = mutual, discover = result)
+}
+
+private fun classifyRefusal(
+    error: McpException,
+    clientModernVersions: List<String>,
+    fallbackAvailable: Boolean,
+): ProbeVerdict {
+    // Denylist, not allowlist: only the one code that carries version evidence is read as such.
+    if (error.code != RPCError.ErrorCode.UNSUPPORTED_PROTOCOL_VERSION) {
+        return fallBack(fallbackAvailable) { error }
+    }
+    val supported = error.data
+        ?.let {
+            try {
+                McpJson.decodeFromJsonElement<UnsupportedProtocolVersionData>(it).supported
+            } catch (_: SerializationException) {
+                null
+            }
+        }
+        ?: return fallBack(fallbackAvailable) { error }
+
+    clientModernVersions.firstOrNull { it in supported }?.let { return ProbeVerdict.Corrective(it) }
+    // No mutual request-scoped revision. A server still naming a handshake revision is reachable
+    // the old way; one naming only revisions this client does not have is genuinely incompatible,
+    // and saying so beats a handshake that will fail less legibly.
+    return if (supported.any { it in HANDSHAKE_PROTOCOL_VERSIONS }) {
+        fallBack(fallbackAvailable) { error }
+    } else {
+        ProbeVerdict.Failed(error)
+    }
+}
+
+/** The verdict for an outcome carrying no positive evidence: fall back, or fail where none is left. */
+private inline fun fallBack(fallbackAvailable: Boolean, cause: () -> McpException): ProbeVerdict =
+    if (fallbackAvailable) ProbeVerdict.Legacy else ProbeVerdict.Failed(cause())
+
+private fun unsupported(supported: List<String>, requested: List<String>): McpException = McpException(
+    code = RPCError.ErrorCode.UNSUPPORTED_PROTOCOL_VERSION,
+    message = "The server supports ${supported.joinToString()}, none of which this client speaks " +
+        "(${requested.joinToString()}).",
+)

--- a/kotlin-sdk-client/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/client/ClientAssertCapabilityTest.kt
+++ b/kotlin-sdk-client/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/client/ClientAssertCapabilityTest.kt
@@ -9,7 +9,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.InitializeResult
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCMessage
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCRequest
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCResponse
-import io.modelcontextprotocol.kotlin.sdk.types.LATEST_PROTOCOL_VERSION
+import io.modelcontextprotocol.kotlin.sdk.types.LATEST_HANDSHAKE_VERSION
 import io.modelcontextprotocol.kotlin.sdk.types.Method
 import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
 import kotlinx.coroutines.test.runTest
@@ -145,7 +145,7 @@ class ClientAssertCapabilityTest {
                     JSONRPCResponse(
                         id = message.id,
                         result = InitializeResult(
-                            protocolVersion = LATEST_PROTOCOL_VERSION,
+                            protocolVersion = LATEST_HANDSHAKE_VERSION,
                             capabilities = serverCapabilities,
                             serverInfo = Implementation("mock-server", "1.0.0"),
                         ),

--- a/kotlin-sdk-client/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/client/VersionNegotiationTest.kt
+++ b/kotlin-sdk-client/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/client/VersionNegotiationTest.kt
@@ -1,0 +1,136 @@
+package io.modelcontextprotocol.kotlin.sdk.client
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
+import io.modelcontextprotocol.kotlin.sdk.types.DiscoverResult
+import io.modelcontextprotocol.kotlin.sdk.types.LATEST_HANDSHAKE_VERSION
+import io.modelcontextprotocol.kotlin.sdk.types.LATEST_MODERN_VERSION
+import io.modelcontextprotocol.kotlin.sdk.types.McpException
+import io.modelcontextprotocol.kotlin.sdk.types.McpJson
+import io.modelcontextprotocol.kotlin.sdk.types.RPCError
+import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
+import io.modelcontextprotocol.kotlin.sdk.types.UnsupportedProtocolVersionData
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+/**
+ * The probe policy, outcome by outcome, driven through the pure classifier. Each verdict decides
+ * whether a connection silently downgrades, hard-fails, or re-probes, so every cell is pinned —
+ * including its no-fallback ([VersionNegotiationMode.Pin]) variant where the two differ.
+ */
+@OptIn(ExperimentalMcpApi::class)
+class VersionNegotiationTest {
+
+    private val modernVersions = listOf(LATEST_MODERN_VERSION)
+
+    private fun discover(vararg supported: String) = DiscoverResult(
+        supportedVersions = supported.toList(),
+        capabilities = ServerCapabilities(),
+    )
+
+    private fun unsupportedVersionError(vararg supported: String) = McpException(
+        code = RPCError.ErrorCode.UNSUPPORTED_PROTOCOL_VERSION,
+        message = "Unsupported protocol version",
+        data = McpJson.encodeToJsonElement(
+            UnsupportedProtocolVersionData(supported = supported.toList(), requested = LATEST_MODERN_VERSION),
+        ),
+    )
+
+    private fun classify(
+        outcome: ProbeOutcome,
+        fallbackAvailable: Boolean = true,
+        overStdio: Boolean = false,
+    ): ProbeVerdict = classifyProbeOutcome(
+        outcome = outcome,
+        clientModernVersions = modernVersions,
+        fallbackAvailable = fallbackAvailable,
+        overStdio = overStdio,
+    )
+
+    @Test
+    fun `should reject pinning a handshake revision at construction pointing at legacy`() {
+        val failure = assertFailsWith<IllegalArgumentException> {
+            VersionNegotiationMode.Pin(LATEST_HANDSHAKE_VERSION)
+        }
+        failure.message!! shouldContain "VersionNegotiationMode.Legacy"
+    }
+
+    @Test
+    fun `should adopt a discovery answer sharing a modern revision`() {
+        val answer = discover(LATEST_MODERN_VERSION, "2099-01-01")
+        val verdict = classify(ProbeOutcome.Answered(answer)).shouldBeInstanceOf<ProbeVerdict.Modern>()
+        verdict.version shouldBe LATEST_MODERN_VERSION
+        verdict.discover shouldBe answer
+    }
+
+    @Test
+    fun `should fall back on a discovery answer advertising only handshake revisions`() {
+        val answer = ProbeOutcome.Answered(discover(LATEST_HANDSHAKE_VERSION))
+        classify(answer) shouldBe ProbeVerdict.Legacy
+        classify(answer, fallbackAvailable = false).shouldBeInstanceOf<ProbeVerdict.Failed>()
+    }
+
+    @Test
+    fun `should fall back on an unparseable discovery answer`() {
+        val answer = ProbeOutcome.Answered(result = null)
+        classify(answer) shouldBe ProbeVerdict.Legacy
+        classify(answer, fallbackAvailable = false).shouldBeInstanceOf<ProbeVerdict.Failed>()
+    }
+
+    @Test
+    fun `should re-probe once at a mutual revision named by an unsupported-version refusal`() {
+        // The corrective continuation is part of negotiation, never counted as a retry — and it
+        // applies under Pin too, since the server named a revision both ends speak.
+        val refusal = ProbeOutcome.Refused(unsupportedVersionError("2099-01-01", LATEST_MODERN_VERSION))
+        classify(refusal) shouldBe ProbeVerdict.Corrective(LATEST_MODERN_VERSION)
+        classify(refusal, fallbackAvailable = false) shouldBe ProbeVerdict.Corrective(LATEST_MODERN_VERSION)
+    }
+
+    @Test
+    fun `should fail on a refusal naming only modern revisions this client does not have`() {
+        val refusal = ProbeOutcome.Refused(unsupportedVersionError("2099-01-01"))
+        classify(refusal).shouldBeInstanceOf<ProbeVerdict.Failed>()
+            .cause.code shouldBe RPCError.ErrorCode.UNSUPPORTED_PROTOCOL_VERSION
+    }
+
+    @Test
+    fun `should fall back on a refusal naming a handshake revision`() {
+        val refusal = ProbeOutcome.Refused(unsupportedVersionError("2099-01-01", LATEST_HANDSHAKE_VERSION))
+        classify(refusal) shouldBe ProbeVerdict.Legacy
+    }
+
+    @Test
+    fun `should fall back on an unsupported-version refusal whose data does not decode`() {
+        val refusal = ProbeOutcome.Refused(
+            McpException(code = RPCError.ErrorCode.UNSUPPORTED_PROTOCOL_VERSION, message = "no data"),
+        )
+        classify(refusal) shouldBe ProbeVerdict.Legacy
+    }
+
+    @Test
+    fun `should fall back on any other refusal code`() {
+        // Denylist, not allowlist: -32601 is what a server without discovery answers.
+        val refusal = ProbeOutcome.Refused(
+            McpException(code = RPCError.ErrorCode.METHOD_NOT_FOUND, message = "Method not found"),
+        )
+        classify(refusal) shouldBe ProbeVerdict.Legacy
+        classify(refusal, fallbackAvailable = false).shouldBeInstanceOf<ProbeVerdict.Failed>()
+            .cause.code shouldBe RPCError.ErrorCode.METHOD_NOT_FOUND
+    }
+
+    @Test
+    fun `should read stdio silence as a handshake-era signal`() {
+        classify(ProbeOutcome.Silent, overStdio = true) shouldBe ProbeVerdict.Legacy
+        classify(ProbeOutcome.Silent, overStdio = true, fallbackAvailable = false)
+            .shouldBeInstanceOf<ProbeVerdict.Failed>()
+    }
+
+    @Test
+    fun `should fail on http silence because an outage is never an era verdict`() {
+        classify(ProbeOutcome.Silent, overStdio = false).shouldBeInstanceOf<ProbeVerdict.Failed>()
+            .cause.code shouldBe RPCError.ErrorCode.REQUEST_TIMEOUT
+    }
+}

--- a/kotlin-sdk-client/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/client/streamable/http/StreamableHttpClientTransportTest.kt
+++ b/kotlin-sdk-client/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/client/streamable/http/StreamableHttpClientTransportTest.kt
@@ -315,9 +315,9 @@ class StreamableHttpClientTransportTest {
     }
 
     @Test
-    fun `should send MCP method header for notifications`() = runTest {
+    fun `should omit MCP standard headers for notifications`() = runTest {
         val transport = createTransport { request ->
-            assertEquals("notifications/tools/list_changed", request.headers["Mcp-Method"])
+            assertNull(request.headers["Mcp-Method"])
             assertNull(request.headers["Mcp-Name"])
             respond(content = "", status = HttpStatusCode.Accepted)
         }

--- a/kotlin-sdk-core/api/kotlin-sdk-core.api
+++ b/kotlin-sdk-core/api/kotlin-sdk-core.api
@@ -59,11 +59,16 @@ public abstract class io/modelcontextprotocol/kotlin/sdk/shared/Protocol {
 	public abstract fun assertRequestHandlerCapability (Lio/modelcontextprotocol/kotlin/sdk/types/Method;)V
 	public final fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun connect (Lio/modelcontextprotocol/kotlin/sdk/shared/Transport;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	protected fun decorateOutboundRequest (Lio/modelcontextprotocol/kotlin/sdk/types/JSONRPCRequest;)Lio/modelcontextprotocol/kotlin/sdk/types/JSONRPCRequest;
 	protected final fun enableConcurrentDispatch ()V
+	protected fun getDeclaredClientCapabilities ()Lio/modelcontextprotocol/kotlin/sdk/types/ClientCapabilities;
+	protected fun getDeclaredClientInfo ()Lio/modelcontextprotocol/kotlin/sdk/types/Implementation;
 	public final fun getFallbackNotificationHandler ()Lkotlin/jvm/functions/Function2;
 	public final fun getFallbackRequestHandler ()Lkotlin/jvm/functions/Function3;
+	protected fun getNegotiatedProtocolVersion ()Ljava/lang/String;
 	public final fun getNotificationHandlers ()Ljava/util/Map;
 	public final fun getOptions ()Lio/modelcontextprotocol/kotlin/sdk/shared/ProtocolOptions;
+	protected fun getOutboundServerInfo ()Lio/modelcontextprotocol/kotlin/sdk/types/Implementation;
 	public final fun getProgressHandlers ()Ljava/util/Map;
 	public final fun getRequestHandlers ()Ljava/util/Map;
 	public final fun getResponseHandlers ()Ljava/util/Map;
@@ -73,6 +78,7 @@ public abstract class io/modelcontextprotocol/kotlin/sdk/shared/Protocol {
 	public fun onClose ()V
 	public fun onError (Ljava/lang/Throwable;)V
 	protected fun onInitializedNotification ()V
+	protected fun onNotificationRouted (Lio/modelcontextprotocol/kotlin/sdk/types/JSONRPCNotification;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun removeNotificationHandler (Lio/modelcontextprotocol/kotlin/sdk/types/Method;)V
 	public final fun removeRequestHandler (Lio/modelcontextprotocol/kotlin/sdk/types/Method;)V
 	public final fun request (Lio/modelcontextprotocol/kotlin/sdk/types/Request;Lio/modelcontextprotocol/kotlin/sdk/shared/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -114,7 +120,13 @@ public final class io/modelcontextprotocol/kotlin/sdk/shared/ReadBufferKt {
 
 public final class io/modelcontextprotocol/kotlin/sdk/shared/RequestHandlerExtra : kotlin/coroutines/AbstractCoroutineContextElement {
 	public static final field Key Lio/modelcontextprotocol/kotlin/sdk/shared/RequestHandlerExtra$Key;
+	public synthetic fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/RequestId;Lio/modelcontextprotocol/kotlin/sdk/types/Method;Lio/modelcontextprotocol/kotlin/sdk/shared/Protocol;Lio/modelcontextprotocol/kotlin/sdk/shared/Transport;Lio/modelcontextprotocol/kotlin/sdk/types/ProtocolEra;Lkotlinx/serialization/json/JsonObject;Lio/modelcontextprotocol/kotlin/sdk/types/RequestEnvelope;Ljava/lang/String;Lio/modelcontextprotocol/kotlin/sdk/types/ClientCapabilities;Lio/modelcontextprotocol/kotlin/sdk/types/Implementation;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getClientCapabilities ()Lio/modelcontextprotocol/kotlin/sdk/types/ClientCapabilities;
+	public final fun getClientInfo ()Lio/modelcontextprotocol/kotlin/sdk/types/Implementation;
+	public final fun getEnvelope ()Lio/modelcontextprotocol/kotlin/sdk/types/RequestEnvelope;
+	public final fun getMeta-VI-3G7E ()Lkotlinx/serialization/json/JsonObject;
 	public final fun getMethod ()Lio/modelcontextprotocol/kotlin/sdk/types/Method;
+	public final fun getProtocolVersion ()Ljava/lang/String;
 	public final fun getRequestId ()Lio/modelcontextprotocol/kotlin/sdk/types/RequestId;
 	public final fun sendNotification (Lio/modelcontextprotocol/kotlin/sdk/types/Notification;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun sendRequest (Lio/modelcontextprotocol/kotlin/sdk/types/Request;Lio/modelcontextprotocol/kotlin/sdk/shared/RequestOptions;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -403,6 +415,11 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/CacheScope$Companion
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public abstract interface class io/modelcontextprotocol/kotlin/sdk/types/CacheableResult : io/modelcontextprotocol/kotlin/sdk/types/RequestResult {
+	public abstract fun getCacheScope ()Lio/modelcontextprotocol/kotlin/sdk/types/CacheScope;
+	public abstract fun getTtlMs ()J
+}
+
 public final class io/modelcontextprotocol/kotlin/sdk/types/CallToolRequest : io/modelcontextprotocol/kotlin/sdk/types/ClientRequest {
 	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/types/CallToolRequest$Companion;
 	public fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/CallToolRequestParams;)V
@@ -482,17 +499,19 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/CallToolRequestParam
 
 public final class io/modelcontextprotocol/kotlin/sdk/types/CallToolResult : io/modelcontextprotocol/kotlin/sdk/types/ServerResult {
 	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/types/CallToolResult$Companion;
-	public fun <init> (Ljava/util/List;Ljava/lang/Boolean;Lkotlinx/serialization/json/JsonObject;Lkotlinx/serialization/json/JsonObject;)V
-	public synthetic fun <init> (Ljava/util/List;Ljava/lang/Boolean;Lkotlinx/serialization/json/JsonObject;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/Boolean;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/Boolean;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Ljava/lang/Boolean;
 	public final fun component3 ()Lkotlinx/serialization/json/JsonObject;
-	public final fun component4 ()Lkotlinx/serialization/json/JsonObject;
-	public final fun copy (Ljava/util/List;Ljava/lang/Boolean;Lkotlinx/serialization/json/JsonObject;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/CallToolResult;
-	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/types/CallToolResult;Ljava/util/List;Ljava/lang/Boolean;Lkotlinx/serialization/json/JsonObject;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/CallToolResult;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy-TUI2Zhs (Ljava/util/List;Ljava/lang/Boolean;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/CallToolResult;
+	public static synthetic fun copy-TUI2Zhs$default (Lio/modelcontextprotocol/kotlin/sdk/types/CallToolResult;Ljava/util/List;Ljava/lang/Boolean;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/CallToolResult;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getContent ()Ljava/util/List;
-	public fun getMeta ()Lkotlinx/serialization/json/JsonObject;
+	public fun getMeta-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getResultType ()Ljava/lang/String;
 	public final fun getStructuredContent ()Lkotlinx/serialization/json/JsonObject;
 	public fun hashCode ()I
 	public final fun isError ()Ljava/lang/Boolean;
@@ -937,10 +956,17 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/ClientResult$Compani
 
 public final class io/modelcontextprotocol/kotlin/sdk/types/CommonKt {
 	public static final field DEFAULT_NEGOTIATED_PROTOCOL_VERSION Ljava/lang/String;
+	public static final field LATEST_HANDSHAKE_VERSION Ljava/lang/String;
+	public static final field LATEST_MODERN_VERSION Ljava/lang/String;
 	public static final field LATEST_PROTOCOL_VERSION Ljava/lang/String;
 	public static final fun ProgressToken (J)Lio/modelcontextprotocol/kotlin/sdk/types/RequestId;
 	public static final fun ProgressToken (Ljava/lang/String;)Lio/modelcontextprotocol/kotlin/sdk/types/RequestId;
+	public static final fun getHANDSHAKE_PROTOCOL_VERSIONS ()Ljava/util/List;
+	public static final fun getKNOWN_PROTOCOL_VERSIONS ()Ljava/util/List;
+	public static final fun getMODERN_PROTOCOL_VERSIONS ()Ljava/util/List;
 	public static final fun getSUPPORTED_PROTOCOL_VERSIONS ()Ljava/util/List;
+	public static final fun isModernProtocolVersion (Ljava/lang/String;)Z
+	public static final fun isVersionAtLeast (Ljava/lang/String;Ljava/lang/String;)Z
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/types/CompleteRequest : io/modelcontextprotocol/kotlin/sdk/types/ClientRequest {
@@ -1080,15 +1106,17 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/CompleteRequestParam
 
 public final class io/modelcontextprotocol/kotlin/sdk/types/CompleteResult : io/modelcontextprotocol/kotlin/sdk/types/ServerResult {
 	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/types/CompleteResult$Companion;
-	public fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/CompleteResult$Completion;Lkotlinx/serialization/json/JsonObject;)V
-	public synthetic fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/CompleteResult$Completion;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/CompleteResult$Completion;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/CompleteResult$Completion;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lio/modelcontextprotocol/kotlin/sdk/types/CompleteResult$Completion;
-	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
-	public final fun copy (Lio/modelcontextprotocol/kotlin/sdk/types/CompleteResult$Completion;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/CompleteResult;
-	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/types/CompleteResult;Lio/modelcontextprotocol/kotlin/sdk/types/CompleteResult$Completion;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/CompleteResult;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy-W1OfC-I (Lio/modelcontextprotocol/kotlin/sdk/types/CompleteResult$Completion;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/CompleteResult;
+	public static synthetic fun copy-W1OfC-I$default (Lio/modelcontextprotocol/kotlin/sdk/types/CompleteResult;Lio/modelcontextprotocol/kotlin/sdk/types/CompleteResult$Completion;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/CompleteResult;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCompletion ()Lio/modelcontextprotocol/kotlin/sdk/types/CompleteResult$Completion;
-	public fun getMeta ()Lkotlinx/serialization/json/JsonObject;
+	public fun getMeta-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getResultType ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -1287,19 +1315,21 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/CreateMessageResult 
 	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/types/CreateMessageResult$Companion;
 	public synthetic fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/Role;Lio/modelcontextprotocol/kotlin/sdk/types/SamplingMessageContent;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/Role;Lio/modelcontextprotocol/kotlin/sdk/types/SamplingMessageContent;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/Role;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/Role;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/Role;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/Role;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lio/modelcontextprotocol/kotlin/sdk/types/Role;
 	public final fun component2 ()Ljava/util/List;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4-6olV-UY ()Ljava/lang/String;
-	public final fun component5 ()Lkotlinx/serialization/json/JsonObject;
-	public final fun copy-ctVX1tw (Lio/modelcontextprotocol/kotlin/sdk/types/Role;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/CreateMessageResult;
-	public static synthetic fun copy-ctVX1tw$default (Lio/modelcontextprotocol/kotlin/sdk/types/CreateMessageResult;Lio/modelcontextprotocol/kotlin/sdk/types/Role;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/CreateMessageResult;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy-3GrNalA (Lio/modelcontextprotocol/kotlin/sdk/types/Role;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/CreateMessageResult;
+	public static synthetic fun copy-3GrNalA$default (Lio/modelcontextprotocol/kotlin/sdk/types/CreateMessageResult;Lio/modelcontextprotocol/kotlin/sdk/types/Role;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/CreateMessageResult;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getContent ()Ljava/util/List;
-	public fun getMeta ()Lkotlinx/serialization/json/JsonObject;
+	public fun getMeta-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
 	public final fun getModel ()Ljava/lang/String;
+	public final fun getResultType ()Ljava/lang/String;
 	public final fun getRole ()Lio/modelcontextprotocol/kotlin/sdk/types/Role;
 	public final fun getStopReason-6olV-UY ()Ljava/lang/String;
 	public fun hashCode ()I
@@ -1323,14 +1353,16 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/CreateMessageResult$
 
 public final class io/modelcontextprotocol/kotlin/sdk/types/CreateTaskResult : io/modelcontextprotocol/kotlin/sdk/types/ClientResult, io/modelcontextprotocol/kotlin/sdk/types/ServerResult {
 	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/types/CreateTaskResult$Companion;
-	public fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/Task;Lkotlinx/serialization/json/JsonObject;)V
-	public synthetic fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/Task;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/Task;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/Task;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lio/modelcontextprotocol/kotlin/sdk/types/Task;
-	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
-	public final fun copy (Lio/modelcontextprotocol/kotlin/sdk/types/Task;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/CreateTaskResult;
-	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/types/CreateTaskResult;Lio/modelcontextprotocol/kotlin/sdk/types/Task;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/CreateTaskResult;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy-W1OfC-I (Lio/modelcontextprotocol/kotlin/sdk/types/Task;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/CreateTaskResult;
+	public static synthetic fun copy-W1OfC-I$default (Lio/modelcontextprotocol/kotlin/sdk/types/CreateTaskResult;Lio/modelcontextprotocol/kotlin/sdk/types/Task;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/CreateTaskResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun getMeta ()Lkotlinx/serialization/json/JsonObject;
+	public fun getMeta-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getResultType ()Ljava/lang/String;
 	public final fun getTask ()Lio/modelcontextprotocol/kotlin/sdk/types/Task;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -1415,7 +1447,6 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/DiscoverRequest : io
 	public final fun copy (Lio/modelcontextprotocol/kotlin/sdk/types/DiscoverRequestParams;)Lio/modelcontextprotocol/kotlin/sdk/types/DiscoverRequest;
 	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/types/DiscoverRequest;Lio/modelcontextprotocol/kotlin/sdk/types/DiscoverRequestParams;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/DiscoverRequest;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getMeta--Khlwt8 ()Lkotlinx/serialization/json/JsonObject;
 	public fun getMethod ()Lio/modelcontextprotocol/kotlin/sdk/types/Method;
 	public fun getParams ()Lio/modelcontextprotocol/kotlin/sdk/types/DiscoverRequestParams;
 	public synthetic fun getParams ()Lio/modelcontextprotocol/kotlin/sdk/types/RequestParams;
@@ -1466,27 +1497,27 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/DiscoverRequestParam
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/modelcontextprotocol/kotlin/sdk/types/DiscoverResult : io/modelcontextprotocol/kotlin/sdk/types/ServerResult {
+public final class io/modelcontextprotocol/kotlin/sdk/types/DiscoverResult : io/modelcontextprotocol/kotlin/sdk/types/CacheableResult, io/modelcontextprotocol/kotlin/sdk/types/ServerResult {
 	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/types/DiscoverResult$Companion;
-	public fun <init> (Ljava/util/List;Lio/modelcontextprotocol/kotlin/sdk/types/ServerCapabilities;Ljava/lang/String;Ljava/lang/String;JLio/modelcontextprotocol/kotlin/sdk/types/CacheScope;Lkotlinx/serialization/json/JsonObject;)V
 	public synthetic fun <init> (Ljava/util/List;Lio/modelcontextprotocol/kotlin/sdk/types/ServerCapabilities;Ljava/lang/String;Ljava/lang/String;JLio/modelcontextprotocol/kotlin/sdk/types/CacheScope;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/List;Lio/modelcontextprotocol/kotlin/sdk/types/ServerCapabilities;Ljava/lang/String;Ljava/lang/String;JLio/modelcontextprotocol/kotlin/sdk/types/CacheScope;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Lio/modelcontextprotocol/kotlin/sdk/types/ServerCapabilities;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()J
 	public final fun component6 ()Lio/modelcontextprotocol/kotlin/sdk/types/CacheScope;
-	public final fun component7 ()Lkotlinx/serialization/json/JsonObject;
-	public final fun copy (Ljava/util/List;Lio/modelcontextprotocol/kotlin/sdk/types/ServerCapabilities;Ljava/lang/String;Ljava/lang/String;JLio/modelcontextprotocol/kotlin/sdk/types/CacheScope;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/DiscoverResult;
-	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/types/DiscoverResult;Ljava/util/List;Lio/modelcontextprotocol/kotlin/sdk/types/ServerCapabilities;Ljava/lang/String;Ljava/lang/String;JLio/modelcontextprotocol/kotlin/sdk/types/CacheScope;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/DiscoverResult;
+	public final fun component7-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy-M2F0cvQ (Ljava/util/List;Lio/modelcontextprotocol/kotlin/sdk/types/ServerCapabilities;Ljava/lang/String;Ljava/lang/String;JLio/modelcontextprotocol/kotlin/sdk/types/CacheScope;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/DiscoverResult;
+	public static synthetic fun copy-M2F0cvQ$default (Lio/modelcontextprotocol/kotlin/sdk/types/DiscoverResult;Ljava/util/List;Lio/modelcontextprotocol/kotlin/sdk/types/ServerCapabilities;Ljava/lang/String;Ljava/lang/String;JLio/modelcontextprotocol/kotlin/sdk/types/CacheScope;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/DiscoverResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getCacheScope ()Lio/modelcontextprotocol/kotlin/sdk/types/CacheScope;
+	public fun getCacheScope ()Lio/modelcontextprotocol/kotlin/sdk/types/CacheScope;
 	public final fun getCapabilities ()Lio/modelcontextprotocol/kotlin/sdk/types/ServerCapabilities;
 	public final fun getInstructions ()Ljava/lang/String;
-	public fun getMeta ()Lkotlinx/serialization/json/JsonObject;
+	public fun getMeta-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
 	public final fun getResultType ()Ljava/lang/String;
 	public final fun getSupportedVersions ()Ljava/util/List;
-	public final fun getTtlMs ()J
+	public fun getTtlMs ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -1711,17 +1742,19 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/ElicitRequestedSchem
 
 public final class io/modelcontextprotocol/kotlin/sdk/types/ElicitResult : io/modelcontextprotocol/kotlin/sdk/types/ClientResult {
 	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/types/ElicitResult$Companion;
-	public fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/ElicitResult$Action;Lkotlinx/serialization/json/JsonObject;Lkotlinx/serialization/json/JsonObject;)V
-	public synthetic fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/ElicitResult$Action;Lkotlinx/serialization/json/JsonObject;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/ElicitResult$Action;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/ElicitResult$Action;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lio/modelcontextprotocol/kotlin/sdk/types/ElicitResult$Action;
 	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
-	public final fun component3 ()Lkotlinx/serialization/json/JsonObject;
-	public final fun copy (Lio/modelcontextprotocol/kotlin/sdk/types/ElicitResult$Action;Lkotlinx/serialization/json/JsonObject;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/ElicitResult;
-	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/types/ElicitResult;Lio/modelcontextprotocol/kotlin/sdk/types/ElicitResult$Action;Lkotlinx/serialization/json/JsonObject;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/ElicitResult;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy-an5zq9Y (Lio/modelcontextprotocol/kotlin/sdk/types/ElicitResult$Action;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/ElicitResult;
+	public static synthetic fun copy-an5zq9Y$default (Lio/modelcontextprotocol/kotlin/sdk/types/ElicitResult;Lio/modelcontextprotocol/kotlin/sdk/types/ElicitResult$Action;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/ElicitResult;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAction ()Lio/modelcontextprotocol/kotlin/sdk/types/ElicitResult$Action;
 	public final fun getContent ()Lkotlinx/serialization/json/JsonObject;
-	public fun getMeta ()Lkotlinx/serialization/json/JsonObject;
+	public fun getMeta-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getResultType ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -1858,14 +1891,15 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/EmbeddedResource$Com
 
 public final class io/modelcontextprotocol/kotlin/sdk/types/EmptyResult : io/modelcontextprotocol/kotlin/sdk/types/ClientResult, io/modelcontextprotocol/kotlin/sdk/types/ServerResult {
 	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/types/EmptyResult$Companion;
-	public fun <init> ()V
-	public fun <init> (Lkotlinx/serialization/json/JsonObject;)V
-	public synthetic fun <init> (Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lkotlinx/serialization/json/JsonObject;
-	public final fun copy (Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/EmptyResult;
-	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/types/EmptyResult;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/EmptyResult;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy-cf3jV50 (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/EmptyResult;
+	public static synthetic fun copy-cf3jV50$default (Lio/modelcontextprotocol/kotlin/sdk/types/EmptyResult;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/EmptyResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun getMeta ()Lkotlinx/serialization/json/JsonObject;
+	public fun getMeta-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getResultType ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -1920,6 +1954,35 @@ public abstract interface class io/modelcontextprotocol/kotlin/sdk/types/EnumSch
 
 public final class io/modelcontextprotocol/kotlin/sdk/types/EnumSchemaDefinition$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/modelcontextprotocol/kotlin/sdk/types/EnvelopeIssue {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/modelcontextprotocol/kotlin/sdk/types/EnvelopeIssue;
+	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/types/EnvelopeIssue;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/EnvelopeIssue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getProblem ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/modelcontextprotocol/kotlin/sdk/types/EnvelopeKt {
+	public static final field CLIENT_CAPABILITIES_META_KEY Ljava/lang/String;
+	public static final field CLIENT_INFO_META_KEY Ljava/lang/String;
+	public static final field LOG_LEVEL_META_KEY Ljava/lang/String;
+	public static final field PROTOCOL_VERSION_META_KEY Ljava/lang/String;
+	public static final field SERVER_INFO_META_KEY Ljava/lang/String;
+	public static final fun getServerInfo-fbqhR10 (Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/Implementation;
+	public static final fun missingIn (Lio/modelcontextprotocol/kotlin/sdk/types/ClientCapabilities;Lio/modelcontextprotocol/kotlin/sdk/types/ClientCapabilities;)Lio/modelcontextprotocol/kotlin/sdk/types/ClientCapabilities;
+	public static final fun toEnvelope-hVVZdjo (Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/RequestEnvelope;
+	public static final fun toEnvelopeOrNull-hVVZdjo (Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/RequestEnvelope;
+	public static final fun toMeta-D-90kyg (Lio/modelcontextprotocol/kotlin/sdk/types/RequestEnvelope;Lkotlinx/serialization/json/JsonObject;)Lkotlinx/serialization/json/JsonObject;
+	public static synthetic fun toMeta-D-90kyg$default (Lio/modelcontextprotocol/kotlin/sdk/types/RequestEnvelope;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lkotlinx/serialization/json/JsonObject;
+	public static final fun validateEnvelope-hVVZdjo (Lkotlinx/serialization/json/JsonObject;)Ljava/util/List;
+	public static final fun withServerInfo-ppgKsOM (Lkotlinx/serialization/json/JsonObject;Lio/modelcontextprotocol/kotlin/sdk/types/Implementation;)Lkotlinx/serialization/json/JsonObject;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/types/GetPromptRequest : io/modelcontextprotocol/kotlin/sdk/types/ClientRequest {
@@ -1998,17 +2061,19 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/GetPromptRequestPara
 
 public final class io/modelcontextprotocol/kotlin/sdk/types/GetPromptResult : io/modelcontextprotocol/kotlin/sdk/types/ServerResult {
 	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/types/GetPromptResult$Companion;
-	public fun <init> (Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
-	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Lkotlinx/serialization/json/JsonObject;
-	public final fun copy (Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/GetPromptResult;
-	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/types/GetPromptResult;Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/GetPromptResult;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy-an5zq9Y (Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/GetPromptResult;
+	public static synthetic fun copy-an5zq9Y$default (Lio/modelcontextprotocol/kotlin/sdk/types/GetPromptResult;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/GetPromptResult;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getMessages ()Ljava/util/List;
-	public fun getMeta ()Lkotlinx/serialization/json/JsonObject;
+	public fun getMeta-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getResultType ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -2098,8 +2163,8 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/GetTaskPayloadResult
 	public static final fun equals-impl0 (Lkotlinx/serialization/json/JsonObject;Lkotlinx/serialization/json/JsonObject;)Z
 	public static final fun get-impl (Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;)Lkotlinx/serialization/json/JsonElement;
 	public final fun getJson ()Lkotlinx/serialization/json/JsonObject;
-	public fun getMeta ()Lkotlinx/serialization/json/JsonObject;
-	public static fun getMeta-impl (Lkotlinx/serialization/json/JsonObject;)Lkotlinx/serialization/json/JsonObject;
+	public fun getMeta-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
+	public static fun getMeta-ArbNjGA (Lkotlinx/serialization/json/JsonObject;)Lkotlinx/serialization/json/JsonObject;
 	public fun hashCode ()I
 	public static fun hashCode-impl (Lkotlinx/serialization/json/JsonObject;)I
 	public fun toString ()Ljava/lang/String;
@@ -2185,8 +2250,8 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/GetTaskRequestParams
 
 public final class io/modelcontextprotocol/kotlin/sdk/types/GetTaskResult : io/modelcontextprotocol/kotlin/sdk/types/ClientResult, io/modelcontextprotocol/kotlin/sdk/types/ServerResult, io/modelcontextprotocol/kotlin/sdk/types/TaskFields {
 	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/types/GetTaskResult$Companion;
-	public fun <init> (Ljava/lang/String;Lio/modelcontextprotocol/kotlin/sdk/types/TaskStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Lkotlinx/serialization/json/JsonObject;)V
-	public synthetic fun <init> (Ljava/lang/String;Lio/modelcontextprotocol/kotlin/sdk/types/TaskStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/modelcontextprotocol/kotlin/sdk/types/TaskStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/modelcontextprotocol/kotlin/sdk/types/TaskStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Lio/modelcontextprotocol/kotlin/sdk/types/TaskStatus;
 	public final fun component3 ()Ljava/lang/String;
@@ -2194,14 +2259,16 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/GetTaskResult : io/m
 	public final fun component5 ()Ljava/lang/String;
 	public final fun component6 ()Ljava/lang/Long;
 	public final fun component7 ()Ljava/lang/Long;
-	public final fun component8 ()Lkotlinx/serialization/json/JsonObject;
-	public final fun copy (Ljava/lang/String;Lio/modelcontextprotocol/kotlin/sdk/types/TaskStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/GetTaskResult;
-	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/types/GetTaskResult;Ljava/lang/String;Lio/modelcontextprotocol/kotlin/sdk/types/TaskStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/GetTaskResult;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy-8UkDJEE (Ljava/lang/String;Lio/modelcontextprotocol/kotlin/sdk/types/TaskStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/GetTaskResult;
+	public static synthetic fun copy-8UkDJEE$default (Lio/modelcontextprotocol/kotlin/sdk/types/GetTaskResult;Ljava/lang/String;Lio/modelcontextprotocol/kotlin/sdk/types/TaskStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/GetTaskResult;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getCreatedAt ()Ljava/lang/String;
 	public fun getLastUpdatedAt ()Ljava/lang/String;
-	public fun getMeta ()Lkotlinx/serialization/json/JsonObject;
+	public fun getMeta-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
 	public fun getPollInterval ()Ljava/lang/Long;
+	public final fun getResultType ()Ljava/lang/String;
 	public fun getStatus ()Lio/modelcontextprotocol/kotlin/sdk/types/TaskStatus;
 	public fun getStatusMessage ()Ljava/lang/String;
 	public fun getTaskId ()Ljava/lang/String;
@@ -2448,20 +2515,22 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/InitializeRequestPar
 
 public final class io/modelcontextprotocol/kotlin/sdk/types/InitializeResult : io/modelcontextprotocol/kotlin/sdk/types/ServerResult {
 	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/types/InitializeResult$Companion;
-	public fun <init> (Ljava/lang/String;Lio/modelcontextprotocol/kotlin/sdk/types/ServerCapabilities;Lio/modelcontextprotocol/kotlin/sdk/types/Implementation;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
-	public synthetic fun <init> (Ljava/lang/String;Lio/modelcontextprotocol/kotlin/sdk/types/ServerCapabilities;Lio/modelcontextprotocol/kotlin/sdk/types/Implementation;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/modelcontextprotocol/kotlin/sdk/types/ServerCapabilities;Lio/modelcontextprotocol/kotlin/sdk/types/Implementation;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/modelcontextprotocol/kotlin/sdk/types/ServerCapabilities;Lio/modelcontextprotocol/kotlin/sdk/types/Implementation;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Lio/modelcontextprotocol/kotlin/sdk/types/ServerCapabilities;
 	public final fun component3 ()Lio/modelcontextprotocol/kotlin/sdk/types/Implementation;
 	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Lkotlinx/serialization/json/JsonObject;
-	public final fun copy (Ljava/lang/String;Lio/modelcontextprotocol/kotlin/sdk/types/ServerCapabilities;Lio/modelcontextprotocol/kotlin/sdk/types/Implementation;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/InitializeResult;
-	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/types/InitializeResult;Ljava/lang/String;Lio/modelcontextprotocol/kotlin/sdk/types/ServerCapabilities;Lio/modelcontextprotocol/kotlin/sdk/types/Implementation;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/InitializeResult;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy-Qgttncc (Ljava/lang/String;Lio/modelcontextprotocol/kotlin/sdk/types/ServerCapabilities;Lio/modelcontextprotocol/kotlin/sdk/types/Implementation;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/InitializeResult;
+	public static synthetic fun copy-Qgttncc$default (Lio/modelcontextprotocol/kotlin/sdk/types/InitializeResult;Ljava/lang/String;Lio/modelcontextprotocol/kotlin/sdk/types/ServerCapabilities;Lio/modelcontextprotocol/kotlin/sdk/types/Implementation;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/InitializeResult;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCapabilities ()Lio/modelcontextprotocol/kotlin/sdk/types/ServerCapabilities;
 	public final fun getInstructions ()Ljava/lang/String;
-	public fun getMeta ()Lkotlinx/serialization/json/JsonObject;
+	public fun getMeta-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
 	public final fun getProtocolVersion ()Ljava/lang/String;
+	public final fun getResultType ()Ljava/lang/String;
 	public final fun getServerInfo ()Lio/modelcontextprotocol/kotlin/sdk/types/Implementation;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -2795,19 +2864,25 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/ListPromptsRequestBu
 	public synthetic fun build$io_modelcontextprotocol_kotlin_sdk_core ()Lio/modelcontextprotocol/kotlin/sdk/types/Request;
 }
 
-public final class io/modelcontextprotocol/kotlin/sdk/types/ListPromptsResult : io/modelcontextprotocol/kotlin/sdk/types/PaginatedResult, io/modelcontextprotocol/kotlin/sdk/types/ServerResult {
+public final class io/modelcontextprotocol/kotlin/sdk/types/ListPromptsResult : io/modelcontextprotocol/kotlin/sdk/types/CacheableResult, io/modelcontextprotocol/kotlin/sdk/types/PaginatedResult, io/modelcontextprotocol/kotlin/sdk/types/ServerResult {
 	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/types/ListPromptsResult$Companion;
-	public fun <init> (Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
-	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLio/modelcontextprotocol/kotlin/sdk/types/CacheScope;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLio/modelcontextprotocol/kotlin/sdk/types/CacheScope;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Lkotlinx/serialization/json/JsonObject;
-	public final fun copy (Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/ListPromptsResult;
-	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/types/ListPromptsResult;Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/ListPromptsResult;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()J
+	public final fun component5 ()Lio/modelcontextprotocol/kotlin/sdk/types/CacheScope;
+	public final fun component6-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy-Qgttncc (Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLio/modelcontextprotocol/kotlin/sdk/types/CacheScope;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/ListPromptsResult;
+	public static synthetic fun copy-Qgttncc$default (Lio/modelcontextprotocol/kotlin/sdk/types/ListPromptsResult;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLio/modelcontextprotocol/kotlin/sdk/types/CacheScope;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/ListPromptsResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun getMeta ()Lkotlinx/serialization/json/JsonObject;
+	public fun getCacheScope ()Lio/modelcontextprotocol/kotlin/sdk/types/CacheScope;
+	public fun getMeta-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
 	public fun getNextCursor ()Ljava/lang/String;
 	public final fun getPrompts ()Ljava/util/List;
+	public final fun getResultType ()Ljava/lang/String;
+	public fun getTtlMs ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -2866,19 +2941,25 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/ListResourceTemplate
 	public synthetic fun build$io_modelcontextprotocol_kotlin_sdk_core ()Lio/modelcontextprotocol/kotlin/sdk/types/Request;
 }
 
-public final class io/modelcontextprotocol/kotlin/sdk/types/ListResourceTemplatesResult : io/modelcontextprotocol/kotlin/sdk/types/PaginatedResult, io/modelcontextprotocol/kotlin/sdk/types/ServerResult {
+public final class io/modelcontextprotocol/kotlin/sdk/types/ListResourceTemplatesResult : io/modelcontextprotocol/kotlin/sdk/types/CacheableResult, io/modelcontextprotocol/kotlin/sdk/types/PaginatedResult, io/modelcontextprotocol/kotlin/sdk/types/ServerResult {
 	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/types/ListResourceTemplatesResult$Companion;
-	public fun <init> (Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
-	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLio/modelcontextprotocol/kotlin/sdk/types/CacheScope;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLio/modelcontextprotocol/kotlin/sdk/types/CacheScope;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Lkotlinx/serialization/json/JsonObject;
-	public final fun copy (Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/ListResourceTemplatesResult;
-	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/types/ListResourceTemplatesResult;Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/ListResourceTemplatesResult;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()J
+	public final fun component5 ()Lio/modelcontextprotocol/kotlin/sdk/types/CacheScope;
+	public final fun component6-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy-Qgttncc (Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLio/modelcontextprotocol/kotlin/sdk/types/CacheScope;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/ListResourceTemplatesResult;
+	public static synthetic fun copy-Qgttncc$default (Lio/modelcontextprotocol/kotlin/sdk/types/ListResourceTemplatesResult;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLio/modelcontextprotocol/kotlin/sdk/types/CacheScope;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/ListResourceTemplatesResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun getMeta ()Lkotlinx/serialization/json/JsonObject;
+	public fun getCacheScope ()Lio/modelcontextprotocol/kotlin/sdk/types/CacheScope;
+	public fun getMeta-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
 	public fun getNextCursor ()Ljava/lang/String;
 	public final fun getResourceTemplates ()Ljava/util/List;
+	public final fun getResultType ()Ljava/lang/String;
+	public fun getTtlMs ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -2937,19 +3018,25 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/ListResourcesRequest
 	public synthetic fun build$io_modelcontextprotocol_kotlin_sdk_core ()Lio/modelcontextprotocol/kotlin/sdk/types/Request;
 }
 
-public final class io/modelcontextprotocol/kotlin/sdk/types/ListResourcesResult : io/modelcontextprotocol/kotlin/sdk/types/PaginatedResult, io/modelcontextprotocol/kotlin/sdk/types/ServerResult {
+public final class io/modelcontextprotocol/kotlin/sdk/types/ListResourcesResult : io/modelcontextprotocol/kotlin/sdk/types/CacheableResult, io/modelcontextprotocol/kotlin/sdk/types/PaginatedResult, io/modelcontextprotocol/kotlin/sdk/types/ServerResult {
 	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/types/ListResourcesResult$Companion;
-	public fun <init> (Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
-	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLio/modelcontextprotocol/kotlin/sdk/types/CacheScope;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLio/modelcontextprotocol/kotlin/sdk/types/CacheScope;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Lkotlinx/serialization/json/JsonObject;
-	public final fun copy (Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/ListResourcesResult;
-	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/types/ListResourcesResult;Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/ListResourcesResult;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()J
+	public final fun component5 ()Lio/modelcontextprotocol/kotlin/sdk/types/CacheScope;
+	public final fun component6-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy-Qgttncc (Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLio/modelcontextprotocol/kotlin/sdk/types/CacheScope;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/ListResourcesResult;
+	public static synthetic fun copy-Qgttncc$default (Lio/modelcontextprotocol/kotlin/sdk/types/ListResourcesResult;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLio/modelcontextprotocol/kotlin/sdk/types/CacheScope;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/ListResourcesResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun getMeta ()Lkotlinx/serialization/json/JsonObject;
+	public fun getCacheScope ()Lio/modelcontextprotocol/kotlin/sdk/types/CacheScope;
+	public fun getMeta-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
 	public fun getNextCursor ()Ljava/lang/String;
 	public final fun getResources ()Ljava/util/List;
+	public final fun getResultType ()Ljava/lang/String;
+	public fun getTtlMs ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -3009,14 +3096,16 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/ListRootsRequestBuil
 
 public final class io/modelcontextprotocol/kotlin/sdk/types/ListRootsResult : io/modelcontextprotocol/kotlin/sdk/types/ClientResult {
 	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/types/ListRootsResult$Companion;
-	public fun <init> (Ljava/util/List;Lkotlinx/serialization/json/JsonObject;)V
-	public synthetic fun <init> (Ljava/util/List;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
-	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
-	public final fun copy (Ljava/util/List;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/ListRootsResult;
-	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/types/ListRootsResult;Ljava/util/List;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/ListRootsResult;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy-W1OfC-I (Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/ListRootsResult;
+	public static synthetic fun copy-W1OfC-I$default (Lio/modelcontextprotocol/kotlin/sdk/types/ListRootsResult;Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/ListRootsResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun getMeta ()Lkotlinx/serialization/json/JsonObject;
+	public fun getMeta-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getResultType ()Ljava/lang/String;
 	public final fun getRoots ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -3072,16 +3161,18 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/ListTasksRequest$Com
 
 public final class io/modelcontextprotocol/kotlin/sdk/types/ListTasksResult : io/modelcontextprotocol/kotlin/sdk/types/ClientResult, io/modelcontextprotocol/kotlin/sdk/types/PaginatedResult, io/modelcontextprotocol/kotlin/sdk/types/ServerResult {
 	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/types/ListTasksResult$Companion;
-	public fun <init> (Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
-	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Lkotlinx/serialization/json/JsonObject;
-	public final fun copy (Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/ListTasksResult;
-	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/types/ListTasksResult;Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/ListTasksResult;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy-an5zq9Y (Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/ListTasksResult;
+	public static synthetic fun copy-an5zq9Y$default (Lio/modelcontextprotocol/kotlin/sdk/types/ListTasksResult;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/ListTasksResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun getMeta ()Lkotlinx/serialization/json/JsonObject;
+	public fun getMeta-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
 	public fun getNextCursor ()Ljava/lang/String;
+	public final fun getResultType ()Ljava/lang/String;
 	public final fun getTasks ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -3141,19 +3232,25 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/ListToolsRequestBuil
 	public synthetic fun build$io_modelcontextprotocol_kotlin_sdk_core ()Lio/modelcontextprotocol/kotlin/sdk/types/Request;
 }
 
-public final class io/modelcontextprotocol/kotlin/sdk/types/ListToolsResult : io/modelcontextprotocol/kotlin/sdk/types/PaginatedResult, io/modelcontextprotocol/kotlin/sdk/types/ServerResult {
+public final class io/modelcontextprotocol/kotlin/sdk/types/ListToolsResult : io/modelcontextprotocol/kotlin/sdk/types/CacheableResult, io/modelcontextprotocol/kotlin/sdk/types/PaginatedResult, io/modelcontextprotocol/kotlin/sdk/types/ServerResult {
 	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/types/ListToolsResult$Companion;
-	public fun <init> (Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
-	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLio/modelcontextprotocol/kotlin/sdk/types/CacheScope;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLio/modelcontextprotocol/kotlin/sdk/types/CacheScope;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Lkotlinx/serialization/json/JsonObject;
-	public final fun copy (Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/ListToolsResult;
-	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/types/ListToolsResult;Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/ListToolsResult;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()J
+	public final fun component5 ()Lio/modelcontextprotocol/kotlin/sdk/types/CacheScope;
+	public final fun component6-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy-Qgttncc (Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLio/modelcontextprotocol/kotlin/sdk/types/CacheScope;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/ListToolsResult;
+	public static synthetic fun copy-Qgttncc$default (Lio/modelcontextprotocol/kotlin/sdk/types/ListToolsResult;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLio/modelcontextprotocol/kotlin/sdk/types/CacheScope;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/ListToolsResult;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun getMeta ()Lkotlinx/serialization/json/JsonObject;
+	public fun getCacheScope ()Lio/modelcontextprotocol/kotlin/sdk/types/CacheScope;
+	public fun getMeta-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
 	public fun getNextCursor ()Ljava/lang/String;
+	public final fun getResultType ()Ljava/lang/String;
 	public final fun getTools ()Ljava/util/List;
+	public fun getTtlMs ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -3272,6 +3369,15 @@ public class io/modelcontextprotocol/kotlin/sdk/types/McpException : java/lang/E
 	public final fun getData ()Lkotlinx/serialization/json/JsonElement;
 }
 
+public final class io/modelcontextprotocol/kotlin/sdk/types/McpHeadersKt {
+	public static final field MCP_METHOD_HEADER Ljava/lang/String;
+	public static final field MCP_NAME_HEADER Ljava/lang/String;
+	public static final field MCP_PROTOCOL_VERSION_HEADER Ljava/lang/String;
+	public static final fun decodeMcpHeaderValue (Ljava/lang/String;)Ljava/lang/String;
+	public static final fun encodeMcpHeaderValue (Ljava/lang/String;)Ljava/lang/String;
+	public static final fun getNAME_BEARING_METHODS ()Ljava/util/Map;
+}
+
 public abstract interface class io/modelcontextprotocol/kotlin/sdk/types/MediaContent : io/modelcontextprotocol/kotlin/sdk/types/ContentBlock, io/modelcontextprotocol/kotlin/sdk/types/SamplingMessageContent {
 	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/types/MediaContent$Companion;
 }
@@ -3370,6 +3476,33 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/Method$Defined : jav
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/types/Method$Defined$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/modelcontextprotocol/kotlin/sdk/types/MissingRequiredClientCapabilityData {
+	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/types/MissingRequiredClientCapabilityData$Companion;
+	public fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/ClientCapabilities;)V
+	public final fun component1 ()Lio/modelcontextprotocol/kotlin/sdk/types/ClientCapabilities;
+	public final fun copy (Lio/modelcontextprotocol/kotlin/sdk/types/ClientCapabilities;)Lio/modelcontextprotocol/kotlin/sdk/types/MissingRequiredClientCapabilityData;
+	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/types/MissingRequiredClientCapabilityData;Lio/modelcontextprotocol/kotlin/sdk/types/ClientCapabilities;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/MissingRequiredClientCapabilityData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRequiredCapabilities ()Lio/modelcontextprotocol/kotlin/sdk/types/ClientCapabilities;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/modelcontextprotocol/kotlin/sdk/types/MissingRequiredClientCapabilityData$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/types/MissingRequiredClientCapabilityData$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/types/MissingRequiredClientCapabilityData;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/types/MissingRequiredClientCapabilityData;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/modelcontextprotocol/kotlin/sdk/types/MissingRequiredClientCapabilityData$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -3871,11 +4004,13 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/RPCError$Companion {
 
 public final class io/modelcontextprotocol/kotlin/sdk/types/RPCError$ErrorCode {
 	public static final field CONNECTION_CLOSED I
+	public static final field HEADER_MISMATCH I
 	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/types/RPCError$ErrorCode;
 	public static final field INTERNAL_ERROR I
 	public static final field INVALID_PARAMS I
 	public static final field INVALID_REQUEST I
 	public static final field METHOD_NOT_FOUND I
+	public static final field MISSING_REQUIRED_CLIENT_CAPABILITY I
 	public static final field PARSE_ERROR I
 	public static final field REQUEST_TIMEOUT I
 	public static final field RESOURCE_NOT_FOUND I
@@ -3952,17 +4087,23 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/ReadResourceRequestP
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class io/modelcontextprotocol/kotlin/sdk/types/ReadResourceResult : io/modelcontextprotocol/kotlin/sdk/types/ServerResult {
+public final class io/modelcontextprotocol/kotlin/sdk/types/ReadResourceResult : io/modelcontextprotocol/kotlin/sdk/types/CacheableResult, io/modelcontextprotocol/kotlin/sdk/types/ServerResult {
 	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/types/ReadResourceResult$Companion;
-	public fun <init> (Ljava/util/List;Lkotlinx/serialization/json/JsonObject;)V
-	public synthetic fun <init> (Ljava/util/List;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;JLio/modelcontextprotocol/kotlin/sdk/types/CacheScope;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;JLio/modelcontextprotocol/kotlin/sdk/types/CacheScope;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
-	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
-	public final fun copy (Ljava/util/List;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/ReadResourceResult;
-	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/types/ReadResourceResult;Ljava/util/List;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/ReadResourceResult;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()J
+	public final fun component4 ()Lio/modelcontextprotocol/kotlin/sdk/types/CacheScope;
+	public final fun component5-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy-TUI2Zhs (Ljava/util/List;Ljava/lang/String;JLio/modelcontextprotocol/kotlin/sdk/types/CacheScope;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/ReadResourceResult;
+	public static synthetic fun copy-TUI2Zhs$default (Lio/modelcontextprotocol/kotlin/sdk/types/ReadResourceResult;Ljava/util/List;Ljava/lang/String;JLio/modelcontextprotocol/kotlin/sdk/types/CacheScope;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/ReadResourceResult;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getCacheScope ()Lio/modelcontextprotocol/kotlin/sdk/types/CacheScope;
 	public final fun getContents ()Ljava/util/List;
-	public fun getMeta ()Lkotlinx/serialization/json/JsonObject;
+	public fun getMeta-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getResultType ()Ljava/lang/String;
+	public fun getTtlMs ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -4049,6 +4190,40 @@ public abstract class io/modelcontextprotocol/kotlin/sdk/types/RequestBuilder {
 	protected final fun setMeta-mJxasco (Lkotlinx/serialization/json/JsonObject;)V
 }
 
+public final class io/modelcontextprotocol/kotlin/sdk/types/RequestEnvelope {
+	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/types/RequestEnvelope$Companion;
+	public fun <init> (Ljava/lang/String;Lio/modelcontextprotocol/kotlin/sdk/types/ClientCapabilities;Lio/modelcontextprotocol/kotlin/sdk/types/Implementation;Lio/modelcontextprotocol/kotlin/sdk/types/LoggingLevel;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/modelcontextprotocol/kotlin/sdk/types/ClientCapabilities;Lio/modelcontextprotocol/kotlin/sdk/types/Implementation;Lio/modelcontextprotocol/kotlin/sdk/types/LoggingLevel;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/modelcontextprotocol/kotlin/sdk/types/ClientCapabilities;
+	public final fun component3 ()Lio/modelcontextprotocol/kotlin/sdk/types/Implementation;
+	public final fun component4 ()Lio/modelcontextprotocol/kotlin/sdk/types/LoggingLevel;
+	public final fun copy (Ljava/lang/String;Lio/modelcontextprotocol/kotlin/sdk/types/ClientCapabilities;Lio/modelcontextprotocol/kotlin/sdk/types/Implementation;Lio/modelcontextprotocol/kotlin/sdk/types/LoggingLevel;)Lio/modelcontextprotocol/kotlin/sdk/types/RequestEnvelope;
+	public static synthetic fun copy$default (Lio/modelcontextprotocol/kotlin/sdk/types/RequestEnvelope;Ljava/lang/String;Lio/modelcontextprotocol/kotlin/sdk/types/ClientCapabilities;Lio/modelcontextprotocol/kotlin/sdk/types/Implementation;Lio/modelcontextprotocol/kotlin/sdk/types/LoggingLevel;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/RequestEnvelope;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClientCapabilities ()Lio/modelcontextprotocol/kotlin/sdk/types/ClientCapabilities;
+	public final fun getClientInfo ()Lio/modelcontextprotocol/kotlin/sdk/types/Implementation;
+	public final fun getLogLevel ()Lio/modelcontextprotocol/kotlin/sdk/types/LoggingLevel;
+	public final fun getProtocolVersion ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class io/modelcontextprotocol/kotlin/sdk/types/RequestEnvelope$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/types/RequestEnvelope$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/modelcontextprotocol/kotlin/sdk/types/RequestEnvelope;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/modelcontextprotocol/kotlin/sdk/types/RequestEnvelope;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/modelcontextprotocol/kotlin/sdk/types/RequestEnvelope$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public abstract interface class io/modelcontextprotocol/kotlin/sdk/types/RequestId {
 	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/types/RequestId$Companion;
 }
@@ -4117,6 +4292,10 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/RequestId$StringId$C
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class io/modelcontextprotocol/kotlin/sdk/types/RequestKt {
+	public static final field COMPLETE_RESULT_TYPE Ljava/lang/String;
+}
+
 public final class io/modelcontextprotocol/kotlin/sdk/types/RequestMeta {
 	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/types/RequestMeta$Companion;
 	public static final synthetic fun box-impl (Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/RequestMeta;
@@ -4125,12 +4304,9 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/RequestMeta {
 	public static fun equals-impl (Lkotlinx/serialization/json/JsonObject;Ljava/lang/Object;)Z
 	public static final fun equals-impl0 (Lkotlinx/serialization/json/JsonObject;Lkotlinx/serialization/json/JsonObject;)Z
 	public static final fun get-impl (Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;)Lkotlinx/serialization/json/JsonElement;
-	public static final fun getClientCapabilities-impl (Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/ClientCapabilities;
-	public static final fun getClientInfo-impl (Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/Implementation;
+	public static final fun getClaimedProtocolVersion-impl (Lkotlinx/serialization/json/JsonObject;)Ljava/lang/String;
 	public final fun getJson ()Lkotlinx/serialization/json/JsonObject;
-	public static final fun getLogLevel-impl (Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/LoggingLevel;
 	public static final fun getProgressToken-impl (Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/RequestId;
-	public static final fun getProtocolVersion-impl (Lkotlinx/serialization/json/JsonObject;)Ljava/lang/String;
 	public static final fun getRelatedTask-impl (Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/RelatedTaskMetadata;
 	public fun hashCode ()I
 	public static fun hashCode-impl (Lkotlinx/serialization/json/JsonObject;)I
@@ -4176,8 +4352,9 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/RequestParams$Compan
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public abstract interface class io/modelcontextprotocol/kotlin/sdk/types/RequestResult : io/modelcontextprotocol/kotlin/sdk/types/WithMeta {
+public abstract interface class io/modelcontextprotocol/kotlin/sdk/types/RequestResult {
 	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/types/RequestResult$Companion;
+	public abstract fun getMeta-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/types/RequestResult$Companion {
@@ -4457,6 +4634,37 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/Resources_dslKt {
 	public static final fun buildReadResourceRequest (Lkotlin/jvm/functions/Function1;)Lio/modelcontextprotocol/kotlin/sdk/types/ReadResourceRequest;
 	public static final fun buildSubscribeRequest (Lkotlin/jvm/functions/Function1;)Lio/modelcontextprotocol/kotlin/sdk/types/SubscribeRequest;
 	public static final fun buildUnsubscribeRequest (Lkotlin/jvm/functions/Function1;)Lio/modelcontextprotocol/kotlin/sdk/types/UnsubscribeRequest;
+}
+
+public final class io/modelcontextprotocol/kotlin/sdk/types/ResultMeta {
+	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/types/ResultMeta$Companion;
+	public static final synthetic fun box-impl (Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/ResultMeta;
+	public static fun constructor-impl (Lkotlinx/serialization/json/JsonObject;)Lkotlinx/serialization/json/JsonObject;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Lkotlinx/serialization/json/JsonObject;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Lkotlinx/serialization/json/JsonObject;Lkotlinx/serialization/json/JsonObject;)Z
+	public static final fun get-impl (Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;)Lkotlinx/serialization/json/JsonElement;
+	public final fun getJson ()Lkotlinx/serialization/json/JsonObject;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Lkotlinx/serialization/json/JsonObject;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Lkotlinx/serialization/json/JsonObject;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Lkotlinx/serialization/json/JsonObject;
+}
+
+public final synthetic class io/modelcontextprotocol/kotlin/sdk/types/ResultMeta$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/types/ResultMeta$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize-v9Z69pc (Lkotlinx/serialization/encoding/Decoder;)Lkotlinx/serialization/json/JsonObject;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize-Ybks6gI (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/serialization/json/JsonObject;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/modelcontextprotocol/kotlin/sdk/types/ResultMeta$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/types/Role : java/lang/Enum {
@@ -5739,10 +5947,10 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/ToolUseContent$Compa
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/types/ToolsKt {
-	public static final fun error (Lio/modelcontextprotocol/kotlin/sdk/types/CallToolResult$Companion;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/CallToolResult;
-	public static synthetic fun error$default (Lio/modelcontextprotocol/kotlin/sdk/types/CallToolResult$Companion;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/CallToolResult;
-	public static final fun success (Lio/modelcontextprotocol/kotlin/sdk/types/CallToolResult$Companion;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/CallToolResult;
-	public static synthetic fun success$default (Lio/modelcontextprotocol/kotlin/sdk/types/CallToolResult$Companion;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/CallToolResult;
+	public static final fun error-W1OfC-I (Lio/modelcontextprotocol/kotlin/sdk/types/CallToolResult$Companion;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/CallToolResult;
+	public static synthetic fun error-W1OfC-I$default (Lio/modelcontextprotocol/kotlin/sdk/types/CallToolResult$Companion;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/CallToolResult;
+	public static final fun success-W1OfC-I (Lio/modelcontextprotocol/kotlin/sdk/types/CallToolResult$Companion;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/CallToolResult;
+	public static synthetic fun success-W1OfC-I$default (Lio/modelcontextprotocol/kotlin/sdk/types/CallToolResult$Companion;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lio/modelcontextprotocol/kotlin/sdk/types/CallToolResult;
 }
 
 public final class io/modelcontextprotocol/kotlin/sdk/types/Tools_dslKt {
@@ -6015,6 +6223,38 @@ public final class io/modelcontextprotocol/kotlin/sdk/types/UrlElicitationRequir
 	public fun <init> (Ljava/util/List;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getElicitations ()Ljava/util/List;
+}
+
+public final class io/modelcontextprotocol/kotlin/sdk/types/WireResult : io/modelcontextprotocol/kotlin/sdk/types/ClientResult, io/modelcontextprotocol/kotlin/sdk/types/ServerResult {
+	public static final field Companion Lio/modelcontextprotocol/kotlin/sdk/types/WireResult$Companion;
+	public static final synthetic fun box-impl (Lkotlinx/serialization/json/JsonObject;)Lio/modelcontextprotocol/kotlin/sdk/types/WireResult;
+	public static fun constructor-impl (Lkotlinx/serialization/json/JsonObject;)Lkotlinx/serialization/json/JsonObject;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Lkotlinx/serialization/json/JsonObject;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Lkotlinx/serialization/json/JsonObject;Lkotlinx/serialization/json/JsonObject;)Z
+	public final fun getJson ()Lkotlinx/serialization/json/JsonObject;
+	public fun getMeta-ArbNjGA ()Lkotlinx/serialization/json/JsonObject;
+	public static fun getMeta-ArbNjGA (Lkotlinx/serialization/json/JsonObject;)Lkotlinx/serialization/json/JsonObject;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Lkotlinx/serialization/json/JsonObject;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Lkotlinx/serialization/json/JsonObject;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Lkotlinx/serialization/json/JsonObject;
+}
+
+public final synthetic class io/modelcontextprotocol/kotlin/sdk/types/WireResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/modelcontextprotocol/kotlin/sdk/types/WireResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize-gX7PZE4 (Lkotlinx/serialization/encoding/Decoder;)Lkotlinx/serialization/json/JsonObject;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize-6pbqqs8 (Lkotlinx/serialization/encoding/Encoder;Lkotlinx/serialization/json/JsonObject;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/modelcontextprotocol/kotlin/sdk/types/WireResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public abstract interface class io/modelcontextprotocol/kotlin/sdk/types/WithMeta {

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/shared/Protocol.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/shared/Protocol.kt
@@ -1,28 +1,49 @@
 package io.modelcontextprotocol.kotlin.sdk.shared
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
+import io.modelcontextprotocol.kotlin.sdk.InternalMcpApi
+import io.modelcontextprotocol.kotlin.sdk.types.COMPLETE_RESULT_TYPE
 import io.modelcontextprotocol.kotlin.sdk.types.CancelledNotification
 import io.modelcontextprotocol.kotlin.sdk.types.CancelledNotificationParams
+import io.modelcontextprotocol.kotlin.sdk.types.ClientCapabilities
+import io.modelcontextprotocol.kotlin.sdk.types.DEFAULT_NEGOTIATED_PROTOCOL_VERSION
 import io.modelcontextprotocol.kotlin.sdk.types.EmptyResult
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCEmptyMessage
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCError
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCNotification
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCRequest
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCResponse
+import io.modelcontextprotocol.kotlin.sdk.types.LATEST_MODERN_VERSION
+import io.modelcontextprotocol.kotlin.sdk.types.MODERN_PROTOCOL_VERSIONS
 import io.modelcontextprotocol.kotlin.sdk.types.McpException
 import io.modelcontextprotocol.kotlin.sdk.types.McpJson
 import io.modelcontextprotocol.kotlin.sdk.types.Method
 import io.modelcontextprotocol.kotlin.sdk.types.Notification
+import io.modelcontextprotocol.kotlin.sdk.types.PROTOCOL_VERSION_META_KEY
 import io.modelcontextprotocol.kotlin.sdk.types.PingRequest
 import io.modelcontextprotocol.kotlin.sdk.types.Progress
 import io.modelcontextprotocol.kotlin.sdk.types.ProgressNotification
 import io.modelcontextprotocol.kotlin.sdk.types.ProgressToken
+import io.modelcontextprotocol.kotlin.sdk.types.ProtocolEra
 import io.modelcontextprotocol.kotlin.sdk.types.RPCError
 import io.modelcontextprotocol.kotlin.sdk.types.Request
+import io.modelcontextprotocol.kotlin.sdk.types.RequestEnvelope
 import io.modelcontextprotocol.kotlin.sdk.types.RequestId
+import io.modelcontextprotocol.kotlin.sdk.types.RequestMeta
 import io.modelcontextprotocol.kotlin.sdk.types.RequestResult
+import io.modelcontextprotocol.kotlin.sdk.types.UnsupportedProtocolVersionData
+import io.modelcontextprotocol.kotlin.sdk.types.WireResult
+import io.modelcontextprotocol.kotlin.sdk.types.checkInboundResult
+import io.modelcontextprotocol.kotlin.sdk.types.encodeOutboundResult
 import io.modelcontextprotocol.kotlin.sdk.types.fromJSON
+import io.modelcontextprotocol.kotlin.sdk.types.isAvailableIn
+import io.modelcontextprotocol.kotlin.sdk.types.isModernProtocolVersion
+import io.modelcontextprotocol.kotlin.sdk.types.outboundErrorCode
+import io.modelcontextprotocol.kotlin.sdk.types.toEnvelopeLenient
 import io.modelcontextprotocol.kotlin.sdk.types.toJSON
+import io.modelcontextprotocol.kotlin.sdk.types.validateEnvelope
 import kotlinx.atomicfu.AtomicRef
 import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.getAndUpdate
@@ -51,7 +72,9 @@ import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.jsonObject
 import kotlin.coroutines.AbstractCoroutineContextElement
 import kotlin.coroutines.ContinuationInterceptor
 import kotlin.coroutines.CoroutineContext
@@ -172,15 +195,66 @@ public class RequestOptions(
  * handler coroutine's [CoroutineContext], so code nested anywhere under the handler can reach it
  * via [currentRequestHandlerExtra] without parameter plumbing.
  *
+ * [protocolVersion], [clientCapabilities] and [clientInfo] are always populated, whichever protocol
+ * lifecycle the request arrived under, so a handler needs no branch on it. [envelope] is there for
+ * code that does need to tell the two apart.
+ *
  * @property requestId the JSON-RPC id of the request being handled
  * @property method the request's method
+ * @property meta the `_meta` of the request being handled, exactly as received
  */
 public class RequestHandlerExtra internal constructor(
     public val requestId: RequestId,
     public val method: Method,
     private val protocol: Protocol,
     internal val capturedTransport: Transport,
+    internal val era: ProtocolEra = ProtocolEra.Legacy,
+    public val meta: RequestMeta? = null,
+    envelope: RequestEnvelope? = null,
+    handshakeProtocolVersion: String? = null,
+    handshakeClientCapabilities: ClientCapabilities? = null,
+    handshakeClientInfo: Implementation? = null,
 ) : AbstractCoroutineContextElement(Key) {
+
+    /**
+     * The per-request protocol envelope, or `null` on a request served under the connection-scoped
+     * lifecycle.
+     *
+     * The envelope's keys also stay in [meta], which reports `_meta` exactly as it arrived.
+     */
+    @ExperimentalMcpApi
+    public val envelope: RequestEnvelope? = envelope
+
+    /**
+     * The protocol version governing this request.
+     *
+     * Comes from the envelope on the request-scoped lifecycle and from the `initialize` handshake on
+     * the connection-scoped one, so it is never `null`.
+     */
+    public val protocolVersion: String = envelope?.protocolVersion
+        ?: handshakeProtocolVersion.takeIf { era == ProtocolEra.Legacy }
+        ?: DEFAULT_NEGOTIATED_PROTOCOL_VERSION
+
+    /**
+     * The capabilities the client declared for this request.
+     *
+     * On the request-scoped lifecycle these come from the request's own envelope, and never from
+     * any other request: a request whose envelope did not reach here declares nothing, rather than
+     * borrowing an earlier declaration. On the connection-scoped lifecycle they come from the
+     * `initialize` handshake, and are empty when there was none.
+     */
+    public val clientCapabilities: ClientCapabilities = envelope?.clientCapabilities
+        ?: handshakeClientCapabilities.takeIf { era == ProtocolEra.Legacy }
+        ?: ClientCapabilities()
+
+    /**
+     * The client identity, when the peer reported one.
+     *
+     * Self-reported and unverified, so confine it to display, logging and debugging rather than
+     * behavior or security decisions. Scoped to the request as [clientCapabilities] is.
+     */
+    public val clientInfo: Implementation? = envelope?.clientInfo
+        ?: handshakeClientInfo.takeIf { era == ProtocolEra.Legacy }
 
     /** Context key for retrieving the extra from a handler coroutine's context. */
     public companion object Key : CoroutineContext.Key<RequestHandlerExtra>
@@ -215,6 +289,22 @@ public class RequestHandlerExtra internal constructor(
 
 /** The [RequestHandlerExtra] of the MCP request being handled by the current coroutine, or `null` outside a handler. */
 public suspend fun currentRequestHandlerExtra(): RequestHandlerExtra? = currentCoroutineContext()[RequestHandlerExtra]
+
+/** The `_meta` this request carries, or `null` when it carries none. */
+private fun JSONRPCRequest.requestMeta(): RequestMeta? =
+    ((params as? JsonObject)?.get("_meta") as? JsonObject)?.let(::RequestMeta)
+
+/**
+ * The lifecycle [meta] asks to be served under.
+ *
+ * A request claims the request-scoped lifecycle if and only if its `_meta` carries
+ * [PROTOCOL_VERSION_META_KEY]. Presence of the key is the claim, not the shape of its value, so a
+ * malformed claim is reported rather than falling back to the connection-scoped lifecycle. Nothing
+ * an earlier request established participates, so one connection may interleave both.
+ */
+@OptIn(ExperimentalMcpApi::class)
+private fun eraOf(meta: RequestMeta?): ProtocolEra =
+    if (meta?.get(PROTOCOL_VERSION_META_KEY) != null) ProtocolEra.Modern else ProtocolEra.Legacy
 
 internal val COMPLETED = CompletableDeferred(Unit).also { it.complete(Unit) }
 
@@ -359,6 +449,14 @@ public abstract class Protocol(@PublishedApi internal val options: ProtocolOptio
     protected open fun onInitializedNotification() {}
 
     /**
+     * Router hook invoked for every inbound notification, before handler lookup.
+     *
+     * Runs whether or not a handler is registered for the method, and in addition to it, so that
+     * subclass bookkeeping cannot be disabled by replacing or omitting the handler.
+     */
+    protected open suspend fun onNotificationRouted(notification: JSONRPCNotification) {}
+
+    /**
      * Attaches to the given transport, starts it, and starts listening for messages.
      *
      * The Protocol object assumes ownership of the Transport, replacing any callbacks that have
@@ -484,6 +582,7 @@ public abstract class Protocol(@PublishedApi internal val options: ProtocolOptio
         if (notification.method == Method.Defined.NotificationsInitialized.value) {
             onInitializedNotification()
         }
+        onNotificationRouted(notification)
         if (!connection.concurrentDispatchEnabled.value) {
             onNotification(notification)
             return
@@ -574,35 +673,41 @@ public abstract class Protocol(@PublishedApi internal val options: ProtocolOptio
     private suspend fun onRequest(request: JSONRPCRequest, connection: Connection, trackCancellation: Boolean) {
         logger.trace { "Received request: ${request.method} (id: ${request.id})" }
 
-        val handler = requestHandlers[request.method] ?: fallbackRequestHandler
         val capturedTransport = connection.transport
+        val meta = request.requestMeta()
+        val era = eraOf(meta)
+        val method = Method.from(request.method)
 
+        admissionError(era, method, meta)?.let { error ->
+            sendError(capturedTransport, request.id, error)
+            return
+        }
+
+        val handler = requestHandlers[request.method] ?: fallbackRequestHandler
         if (handler === null) {
             logger.trace { "No handler found for request: ${request.method}" }
-            try {
-                capturedTransport.send(
-                    JSONRPCError(
-                        id = request.id,
-                        error = RPCError(
-                            code = RPCError.ErrorCode.METHOD_NOT_FOUND,
-                            message = "Server does not support ${request.method}",
-                        ),
-                    ),
-                )
-            } catch (e: CancellationException) {
-                throw e
-            } catch (cause: Throwable) {
-                logger.error(cause) { "Error sending method not found response" }
-                onError(cause)
-            }
+            sendError(
+                capturedTransport,
+                request.id,
+                RPCError(
+                    code = RPCError.ErrorCode.METHOD_NOT_FOUND,
+                    message = "Server does not support ${request.method}",
+                ),
+            )
             return
         }
 
         val extra = RequestHandlerExtra(
             requestId = request.id,
-            method = Method.from(request.method),
+            method = method,
             protocol = this,
             capturedTransport = capturedTransport,
+            era = era,
+            meta = meta,
+            envelope = if (era == ProtocolEra.Modern) meta?.toEnvelopeLenient() else null,
+            handshakeProtocolVersion = negotiatedProtocolVersion,
+            handshakeClientCapabilities = declaredClientCapabilities,
+            handshakeClientInfo = declaredClientInfo,
         )
 
         // Registration in the in-flight registry already happened in dispatchRequest's launch
@@ -620,7 +725,7 @@ public abstract class Protocol(@PublishedApi internal val options: ProtocolOptio
                 capturedTransport.send(
                     JSONRPCResponse(
                         id = request.id,
-                        result = result ?: EmptyResult(),
+                        result = encodeResultForEra(era, result),
                     ),
                 )
             } catch (e: CancellationException) {
@@ -629,14 +734,164 @@ public abstract class Protocol(@PublishedApi internal val options: ProtocolOptio
                 if (handlerJob.isCancelled) throw e // genuine peer or close cancel: suppress the response
                 // CE escaped a live handler job (e.g. a leaked inner withTimeout). Answer
                 // INTERNAL_ERROR so the peer does not hang until its own timeout.
-                respondWithError(capturedTransport, request, e)
+                respondWithError(capturedTransport, request, e, era)
             } catch (cause: Throwable) {
                 if (handlerJob?.isCancelled == true) {
                     logger.trace { "Suppressing error response for request cancelled by peer (id: ${request.id})" }
                     return@withContext
                 }
-                respondWithError(capturedTransport, request, cause)
+                respondWithError(capturedTransport, request, cause, era)
             }
+        }
+    }
+
+    /**
+     * The identity to stamp into outgoing results, or `null` to stamp none.
+     *
+     * Only servers report one, and only under the request-scoped lifecycle.
+     */
+    protected open val outboundServerInfo: Implementation? get() = null
+
+    /**
+     * The protocol version this connection settled on, or `null` before it has settled on one.
+     *
+     * Settled by the `initialize` handshake or by `server/discover`, whichever the peer turned out
+     * to speak. It decides the lifecycle of everything this peer sends.
+     */
+    protected open val negotiatedProtocolVersion: String? get() = null
+
+    /**
+     * The capabilities the peer declared for this connection, or `null` when it declared none.
+     *
+     * Only the connection-scoped lifecycle has such a declaration.
+     */
+    protected open val declaredClientCapabilities: ClientCapabilities? get() = null
+
+    /** The identity the peer reported for this connection, or `null` when it reported none. */
+    protected open val declaredClientInfo: Implementation? get() = null
+
+    /**
+     * The lifecycle this connection sends under, decided by what it settled on rather than by
+     * whatever it happens to be answering.
+     */
+    private val outboundEra: ProtocolEra
+        get() = if (negotiatedProtocolVersion?.let(::isModernProtocolVersion) == true) {
+            ProtocolEra.Modern
+        } else {
+            ProtocolEra.Legacy
+        }
+
+    /**
+     * Last chance to rewrite an outbound request before it is sent; a client attaches its
+     * per-request protocol envelope here. The default returns [request] untouched.
+     */
+    protected open fun decorateOutboundRequest(request: JSONRPCRequest): JSONRPCRequest = request
+
+    /**
+     * The first rung of the inbound validation ladder [request] fails, or `null` when it passes all
+     * of them.
+     *
+     * Order is the precedence, and a request failing several rungs is answered by the earliest:
+     *
+     * 1. the envelope behind a present claim is intact — `-32602`, naming every offending key at
+     *    once so a peer is not corrected one round trip at a time;
+     * 2. the claimed version is one this SDK serves — `-32022`, naming the ones it does;
+     * 3. the method exists in the lifecycle being served — `-32601`, **even where a handler is
+     *    registered**, because a revision that removes a method removes it structurally.
+     *
+     * Rung 1 covers a non-string version too: that is a defect of shape rather than an outcome of
+     * negotiation, and the distinction matters, because a negotiating client falls back from
+     * `-32602` but not from `-32022`.
+     *
+     * Transports that carry headers add their own rungs in front of this one; nothing here depends
+     * on having them.
+     */
+    @OptIn(ExperimentalMcpApi::class)
+    private fun admissionError(era: ProtocolEra, method: Method, meta: RequestMeta?): RPCError? {
+        if (era == ProtocolEra.Modern) {
+            val issues = validateEnvelope(checkNotNull(meta) { "a modern claim implies request metadata" })
+            if (issues.isNotEmpty()) {
+                return RPCError(
+                    code = RPCError.ErrorCode.INVALID_PARAMS,
+                    message = "Invalid request envelope: " +
+                        issues.joinToString(", ") { "${it.key} ${it.problem}" },
+                )
+            }
+            val claimed = checkNotNull(meta.claimedProtocolVersion) { "an intact envelope implies a string version" }
+            if (claimed !in MODERN_PROTOCOL_VERSIONS) {
+                return RPCError(
+                    code = RPCError.ErrorCode.UNSUPPORTED_PROTOCOL_VERSION,
+                    message = "Unsupported protocol version: $claimed",
+                    data = McpJson.encodeToJsonElement(
+                        UnsupportedProtocolVersionData(supported = MODERN_PROTOCOL_VERSIONS, requested = claimed),
+                    ),
+                )
+            }
+        }
+        if (!method.isAvailableIn(era)) {
+            return RPCError(
+                code = RPCError.ErrorCode.METHOD_NOT_FOUND,
+                message = "Method ${method.value} does not exist in protocol version " +
+                    "${negotiatedVersionFor(era, meta)}",
+            )
+        }
+        return null
+    }
+
+    /** The version to name when telling a peer a method does not exist in the lifecycle it asked under. */
+    @OptIn(ExperimentalMcpApi::class)
+    private fun negotiatedVersionFor(era: ProtocolEra, meta: RequestMeta?): String = when (era) {
+        ProtocolEra.Modern -> meta?.claimedProtocolVersion ?: LATEST_MODERN_VERSION
+        ProtocolEra.Legacy -> negotiatedProtocolVersion ?: DEFAULT_NEGOTIATED_PROTOCOL_VERSION
+    }
+
+    /**
+     * Renders [result] for the wire, applying everything that differs between the two lifecycles.
+     *
+     * A handler returning `null` means "nothing to report", which is an empty result — spelled with
+     * an explicit `resultType` on the request-scoped lifecycle and as a bare `{}` on the one that
+     * predates the field.
+     */
+    @OptIn(InternalMcpApi::class)
+    private fun encodeResultForEra(era: ProtocolEra, result: RequestResult?): RequestResult {
+        val payload = result ?: EmptyResult(
+            resultType = COMPLETE_RESULT_TYPE.takeIf { era == ProtocolEra.Modern },
+        )
+        val json = McpJson.encodeToJsonElement<RequestResult>(payload).jsonObject
+        return WireResult(encodeOutboundResult(era, json, outboundServerInfo))
+    }
+
+    /**
+     * Reads an inbound response back into a typed result.
+     *
+     * A transport that serializes has already done this. One that does not — an in-memory transport
+     * — hands over whatever object the peer passed to `send`, which may be a [WireResult] holding
+     * rendered JSON; reading it here makes both kinds of transport behave the same.
+     */
+    @OptIn(InternalMcpApi::class)
+    private fun decodeInboundResponse(response: JSONRPCResponse): JSONRPCResponse {
+        val result = response.result
+        val decoded = if (result is WireResult) {
+            response.copy(result = McpJson.decodeFromJsonElement<RequestResult>(result.json))
+        } else {
+            response
+        }
+        checkInboundResult(outboundEra, decoded.result)
+        return decoded
+    }
+
+    /**
+     * Answers [id] with [error]. A send failure is reported to [onError] rather than thrown: a peer
+     * that cannot be told why its request was refused is already unreachable.
+     */
+    private suspend fun sendError(transport: Transport, id: RequestId, error: RPCError) {
+        try {
+            transport.send(JSONRPCError(id = id, error = error))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (cause: Throwable) {
+            logger.error(cause) { "Error sending error response for request id: $id" }
+            onError(cause)
         }
     }
 
@@ -653,11 +908,20 @@ public abstract class Protocol(@PublishedApi internal val options: ProtocolOptio
         }
     }
 
-    private suspend fun respondWithError(transport: Transport, request: JSONRPCRequest, cause: Throwable) {
+    private suspend fun respondWithError(
+        transport: Transport,
+        request: JSONRPCRequest,
+        cause: Throwable,
+        era: ProtocolEra,
+    ) {
         logger.error(cause) { "Error handling request: ${request.method} (id: ${request.id})" }
         try {
             val rpcError = if (cause is McpException) {
-                RPCError(code = cause.code, message = cause.message.orEmpty(), data = cause.data)
+                RPCError(
+                    code = outboundErrorCode(era, cause.code),
+                    message = cause.message.orEmpty(),
+                    data = cause.data,
+                )
             } else {
                 RPCError(code = RPCError.ErrorCode.INTERNAL_ERROR, message = cause.message ?: "Internal error")
             }
@@ -727,7 +991,15 @@ public abstract class Protocol(@PublishedApi internal val options: ProtocolOptio
         }
 
         if (response != null) {
-            handler(response, null)
+            val decoded = try {
+                decodeInboundResponse(response)
+            } catch (cause: McpException) {
+                // A result this SDK cannot interpret is not an answer: failing the caller beats
+                // handing it a partial result as though it were the whole one.
+                handler(null, cause)
+                return
+            }
+            handler(decoded, null)
         } else {
             checkNotNull(error)
             val mcpException = McpException.fromError(
@@ -782,7 +1054,18 @@ public abstract class Protocol(@PublishedApi internal val options: ProtocolOptio
             assertCapabilityForMethod(request.method)
         }
 
-        val jsonRpcRequest = request.toJSON().run {
+        if (!request.method.isAvailableIn(outboundEra)) {
+            // Refused here rather than on the wire: a method the negotiated revision removed has no
+            // answer a peer could give, so failing locally reports the real cause instead of a
+            // method-not-found the caller has to interpret.
+            throw McpException(
+                code = RPCError.ErrorCode.METHOD_NOT_FOUND,
+                message = "Method ${request.method.value} does not exist in protocol version " +
+                    "${negotiatedProtocolVersion ?: DEFAULT_NEGOTIATED_PROTOCOL_VERSION}",
+            )
+        }
+
+        val withProgressToken = request.toJSON().run {
             options?.onProgress?.let { progressHandler ->
                 logger.trace { "Registering progress handler for request id: $id" }
                 _progressHandlers.update { current ->
@@ -802,6 +1085,9 @@ public abstract class Protocol(@PublishedApi internal val options: ProtocolOptio
                 this.copy(params = updatedParams)
             } ?: this
         }
+        // Decorated after the progress token is in place so a peer attaching a protocol envelope
+        // merges onto the final `_meta` rather than one that is about to be replaced.
+        val jsonRpcRequest = decorateOutboundRequest(withProgressToken)
         val jsonRpcRequestId = jsonRpcRequest.id
 
         _responseHandlers.update { current ->

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/shared/Protocol.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/shared/Protocol.kt
@@ -233,7 +233,11 @@ public class RequestHandlerExtra internal constructor(
      */
     public val protocolVersion: String = envelope?.protocolVersion
         ?: handshakeProtocolVersion.takeIf { era == ProtocolEra.Legacy }
-        ?: DEFAULT_NEGOTIATED_PROTOCOL_VERSION
+        // A request-scoped request whose envelope went missing must still read as request-scoped:
+        // a handshake-era string here would widen allowedLogLevels from "emit nothing" to every
+        // level. Unreachable while the admission gate and the envelope reader agree (§4.2), which
+        // is exactly the agreement this guards against losing.
+        ?: if (era == ProtocolEra.Modern) LATEST_MODERN_VERSION else DEFAULT_NEGOTIATED_PROTOCOL_VERSION
 
     /**
      * The capabilities the client declared for this request.
@@ -993,10 +997,24 @@ public abstract class Protocol(@PublishedApi internal val options: ProtocolOptio
         if (response != null) {
             val decoded = try {
                 decodeInboundResponse(response)
+            } catch (cause: CancellationException) {
+                throw cause
             } catch (cause: McpException) {
                 // A result this SDK cannot interpret is not an answer: failing the caller beats
                 // handing it a partial result as though it were the whole one.
                 handler(null, cause)
+                return
+            } catch (cause: Exception) {
+                // The handler is already off the map, so anything escaping here would leave the
+                // caller waiting out its full timeout with no answer at all.
+                handler(
+                    null,
+                    McpException(
+                        code = RPCError.ErrorCode.INVALID_PARAMS,
+                        message = "Failed to decode the result: ${cause.message}",
+                        cause = cause,
+                    ),
+                )
                 return
             }
             handler(decoded, null)

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/McpException.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/McpException.kt
@@ -27,6 +27,9 @@ public open class McpException @JvmOverloads public constructor(
          * otherwise returns a plain [McpException]. Never throws — a malformed payload simply
          * degrades to a plain [McpException].
          */
+        // Accepts the deprecated code: it is removed from what this SDK emits, not from what
+        // a peer predating the removal may send.
+        @Suppress("DEPRECATION")
         fun fromError(code: Int, message: String, data: JsonElement?): McpException {
             if (code == RPCError.ErrorCode.URL_ELICITATION_REQUIRED && data != null) {
                 UrlElicitationRequiredException.fromDataOrNull(message, data)?.let { return it }

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/UrlElicitationRequiredException.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/UrlElicitationRequiredException.kt
@@ -40,6 +40,9 @@ public data class UrlElicitationRequiredData(val elicitations: List<ElicitReques
  *
  * @property elicitations The required URL-mode elicitations (always non-empty).
  */
+// The error code it carries is deprecated, but the exception stays: 2026-07-28 removed
+// URL-elicitation completion, and this type is how a legacy peer still reports it.
+@Suppress("DEPRECATION")
 public class UrlElicitationRequiredException(
     public val elicitations: List<ElicitRequestURLParams>,
     message: String = defaultMessage(elicitations),

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/caching.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/caching.kt
@@ -1,0 +1,41 @@
+package io.modelcontextprotocol.kotlin.sdk.types
+
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/** Defines where a cached result may be reused. */
+@Serializable
+@ExperimentalMcpApi
+public enum class CacheScope {
+    /** The result may only be reused within the same authorization context. */
+    @SerialName("private")
+    Private,
+
+    /** The result may be shared across authorization contexts. */
+    @SerialName("public")
+    Public,
+}
+
+/**
+ * A result carrying client-side caching directives.
+ *
+ * Both fields travel on every result that carries them, and say for how long a client may reuse the
+ * result and for whom. The defaults — immediately stale, private — are conservative, so a handler
+ * that sets neither still produces a valid result without enabling shared caching by accident.
+ *
+ * The set of results that carry directives is closed: `server/discover`, the four list methods and
+ * `resources/read`.
+ */
+@ExperimentalMcpApi
+public sealed interface CacheableResult : RequestResult {
+    /**
+     * How long, in milliseconds, a client may treat this result as fresh. `0` is immediately stale.
+     *
+     * Never negative.
+     */
+    public val ttlMs: Long
+
+    /** Whether shared caches may serve this result to principals other than the one that fetched it. */
+    public val cacheScope: CacheScope
+}

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/common.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/common.kt
@@ -2,25 +2,99 @@ package io.modelcontextprotocol.kotlin.sdk.types
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlin.jvm.JvmInline
 
 // ============================================================================
 // Protocol Version Constants
 // ============================================================================
 
-/** The latest supported MCP protocol version string. */
-public const val LATEST_PROTOCOL_VERSION: String = "2025-11-25"
+/**
+ * Every released MCP protocol revision, ordered oldest to newest.
+ *
+ * Position in this list is the ordering [isVersionAtLeast] uses; revision identifiers are never
+ * compared as strings.
+ */
+public val KNOWN_PROTOCOL_VERSIONS: List<String> = listOf(
+    "2024-11-05",
+    "2025-03-26",
+    "2025-06-18",
+    "2025-11-25",
+    "2026-07-28",
+)
+
+/**
+ * The revisions reachable through the `initialize` handshake.
+ *
+ * A peer speaking one of these establishes its version, capabilities and identity once, and every
+ * later request on the connection inherits them.
+ */
+public val HANDSHAKE_PROTOCOL_VERSIONS: List<String> = listOf(
+    "2024-11-05",
+    "2025-03-26",
+    "2025-06-18",
+    "2025-11-25",
+)
+
+/**
+ * The revisions that carry the per-request `_meta` envelope.
+ *
+ * These have no handshake: every request states its own version, capabilities and identity, so a
+ * receiver serves it without consulting anything an earlier request established.
+ */
+public val MODERN_PROTOCOL_VERSIONS: List<String> = listOf("2026-07-28")
+
+/** The newest protocol revision this SDK speaks, in either lifecycle. */
+public const val LATEST_PROTOCOL_VERSION: String = "2026-07-28"
+
+/**
+ * The newest revision reachable through `initialize`.
+ *
+ * This is what a client offers in the handshake, and what a server counter-offers when it cannot
+ * meet the requested version.
+ */
+public const val LATEST_HANDSHAKE_VERSION: String = "2025-11-25"
+
+/** The newest envelope revision; the version a `server/discover` probe asks for first. */
+public const val LATEST_MODERN_VERSION: String = "2026-07-28"
 
 /** The default protocol version used when negotiation is not performed. */
 public const val DEFAULT_NEGOTIATED_PROTOCOL_VERSION: String = "2025-03-26"
 
 /** All MCP protocol versions supported by this SDK. */
-public val SUPPORTED_PROTOCOL_VERSIONS: List<String> = listOf(
-    LATEST_PROTOCOL_VERSION,
-    "2025-06-18",
-    "2025-03-26",
-    "2024-11-05",
+@Deprecated(
+    "Prefer HANDSHAKE_PROTOCOL_VERSIONS or MODERN_PROTOCOL_VERSIONS. " +
+        "This union cannot express which lifecycle a version belongs to.",
+    ReplaceWith("HANDSHAKE_PROTOCOL_VERSIONS"),
+    DeprecationLevel.WARNING,
 )
+public val SUPPORTED_PROTOCOL_VERSIONS: List<String> =
+    HANDSHAKE_PROTOCOL_VERSIONS + MODERN_PROTOCOL_VERSIONS
+
+/**
+ * Whether [version] is a known revision at least as new as [minimum].
+ *
+ * Ordering is by position in [KNOWN_PROTOCOL_VERSIONS], never lexicographic: revision identifiers
+ * are not guaranteed to stay date-shaped, and an unrecognized peer string has to compare
+ * conservatively rather than accidentally — `"zzz" > "2025-11-25"` holds for strings and is wrong
+ * for protocol versions. An unknown [version] therefore returns `false`.
+ *
+ * @throws IllegalArgumentException if [minimum] is not a known revision
+ */
+public fun isVersionAtLeast(version: String, minimum: String): Boolean {
+    val minimumIndex = KNOWN_PROTOCOL_VERSIONS.indexOf(minimum)
+    require(minimumIndex >= 0) { "Unknown protocol version: $minimum" }
+    return KNOWN_PROTOCOL_VERSIONS.indexOf(version) >= minimumIndex
+}
+
+/**
+ * Whether [version] carries the per-request `_meta` envelope.
+ *
+ * Membership, not a range test: a revision belongs to a lifecycle by declaration, and a future
+ * revision that returns to the handshake must not be classified by being newer than this one.
+ */
+public fun isModernProtocolVersion(version: String): Boolean = version in MODERN_PROTOCOL_VERSIONS
 
 // ============================================================================
 // Base Interfaces
@@ -34,6 +108,26 @@ public sealed interface WithMeta {
     /** Optional metadata attached to this entity. */
     @SerialName("_meta")
     public val meta: JsonObject?
+}
+
+/**
+ * Metadata attached to a result's `_meta` field.
+ *
+ * Counterpart of [RequestMeta] on the response side. Reserved protocol keys are read through
+ * dedicated accessors; everything else stays reachable via [get] and [json].
+ *
+ * @property json the raw JSON object containing the metadata
+ */
+@JvmInline
+@Serializable
+public value class ResultMeta(public val json: JsonObject) {
+    /**
+     * Retrieves the value associated with the specified key from the JSON object.
+     *
+     * @param key the key whose corresponding value is to be returned
+     * @return the JsonElement associated with the specified key, or null if the key does not exist
+     */
+    public operator fun get(key: String): JsonElement? = json[key]
 }
 
 // ============================================================================

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/completion.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/completion.kt
@@ -6,7 +6,6 @@ import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonObject
 
 /**
  * A request from the client to the server to ask for completion options.
@@ -87,13 +86,15 @@ public data class CompleteRequestParams(
  * along with pagination information if there are many possible completions.
  *
  * @property completion The completion options and metadata about available results.
+ * @property resultType Discriminator for the result representation.
  * @property meta Optional metadata for this response. See MCP specification for details on _meta usage.
  */
 @Serializable
 public data class CompleteResult(
     public val completion: Completion,
+    val resultType: String = COMPLETE_RESULT_TYPE,
     @SerialName("_meta")
-    override val meta: JsonObject? = null,
+    override val meta: ResultMeta? = null,
 ) : ServerResult {
 
     /**

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/discovery.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/discovery.kt
@@ -3,34 +3,25 @@ package io.modelcontextprotocol.kotlin.sdk.types
 import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
 import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.Required
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.SerializationException
-import kotlinx.serialization.json.JsonObject
 
 /**
  * Parameters for a `server/discover` request.
  *
- * Discovery belongs to the request-scoped lifecycle and therefore requires a protocol version and
- * client capabilities in [meta]. Client information is recommended by the protocol but optional.
- * Unknown metadata entries are preserved by [RequestMeta].
+ * Discovery belongs to the request-scoped lifecycle, so [meta] carries the [RequestEnvelope] rather
+ * than being optional as it is on requests that predate it. Whether the envelope is intact is
+ * checked where the request is served, not here, so a malformed one can be answered on the wire
+ * instead of failing construction.
  *
  * @property meta request-scoped protocol and client metadata
- * @throws IllegalArgumentException if required request-scoped metadata is absent
- * @throws SerializationException if required metadata is malformed
  */
 @Serializable
 @ExperimentalMcpApi
 public data class DiscoverRequestParams(
     @SerialName("_meta")
     override val meta: RequestMeta,
-) : RequestParams {
-    init {
-        requireNotNull(meta.protocolVersion) { "${RequestMetaKeys.PROTOCOL_VERSION} is required" }
-        requireNotNull(meta.clientCapabilities) { "${RequestMetaKeys.CLIENT_CAPABILITIES} is required" }
-    }
-}
+) : RequestParams
 
 /**
  * Requests the protocol versions, capabilities, and metadata advertised by a server.
@@ -43,23 +34,6 @@ public data class DiscoverRequest(override val params: DiscoverRequestParams) : 
     @OptIn(ExperimentalSerializationApi::class)
     @EncodeDefault
     override val method: Method = Method.Defined.ServerDiscover
-
-    /** Metadata for this request. */
-    public val meta: RequestMeta
-        get() = params.meta
-}
-
-/** Defines where a cached discovery result may be reused. */
-@Serializable
-@ExperimentalMcpApi
-public enum class CacheScope {
-    /** The result may only be reused within the same authorization context. */
-    @SerialName("private")
-    Private,
-
-    /** The result may be shared across authorization contexts. */
-    @SerialName("public")
-    Public,
 }
 
 /**
@@ -68,7 +42,7 @@ public enum class CacheScope {
  * @property supportedVersions protocol versions supported by the server
  * @property capabilities capabilities advertised by the server
  * @property instructions optional guidance for clients using the server
- * @property resultType discriminator for the result representation
+ * @property resultType Discriminator for the result representation.
  * @property ttlMs number of milliseconds clients may treat this result as fresh
  * @property cacheScope authorization boundary within which the result may be reused
  * @property meta optional response metadata, including optional server information
@@ -80,15 +54,13 @@ public data class DiscoverResult(
     val supportedVersions: List<String>,
     val capabilities: ServerCapabilities,
     val instructions: String? = null,
-    @EncodeDefault
     val resultType: String = COMPLETE_RESULT_TYPE,
-    @Required
-    val ttlMs: Long = 0,
-    @Required
-    val cacheScope: CacheScope = CacheScope.Private,
+    override val ttlMs: Long = 0,
+    override val cacheScope: CacheScope = CacheScope.Private,
     @SerialName("_meta")
-    override val meta: JsonObject? = null,
-) : ServerResult {
+    override val meta: ResultMeta? = null,
+) : ServerResult,
+    CacheableResult {
     init {
         require(ttlMs >= 0) { "ttlMs must be non-negative, but was $ttlMs" }
     }
@@ -103,5 +75,3 @@ public data class DiscoverResult(
 @Serializable
 @ExperimentalMcpApi
 public data class UnsupportedProtocolVersionData(val supported: List<String>, val requested: String)
-
-internal const val COMPLETE_RESULT_TYPE: String = "complete"

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/elicitation.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/elicitation.kt
@@ -168,14 +168,16 @@ public data class ElicitRequestURLParams(
  * @property content The submitted form data, only present when [action] is [Action.Accept]
  *   and mode was form. Contains values matching the requested schema. Omitted for
  *   URL mode responses.
+ * @property resultType Discriminator for the result representation.
  * @property meta Optional metadata for this response.
  */
 @Serializable
 public data class ElicitResult(
     val action: Action,
     val content: JsonObject? = null,
+    val resultType: String = COMPLETE_RESULT_TYPE,
     @SerialName("_meta")
-    override val meta: JsonObject? = null,
+    override val meta: ResultMeta? = null,
 ) : ClientResult {
 
     init {

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/envelope.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/envelope.kt
@@ -1,0 +1,272 @@
+package io.modelcontextprotocol.kotlin.sdk.types
+
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.jsonObject
+import kotlin.coroutines.cancellation.CancellationException
+
+/** `_meta` key carrying the protocol version a request is made under. */
+@ExperimentalMcpApi
+public const val PROTOCOL_VERSION_META_KEY: String = "io.modelcontextprotocol/protocolVersion"
+
+/** `_meta` key carrying the name and version of the client software issuing a request. */
+@ExperimentalMcpApi
+public const val CLIENT_INFO_META_KEY: String = "io.modelcontextprotocol/clientInfo"
+
+/** `_meta` key carrying the capabilities a client declares for a request. */
+@ExperimentalMcpApi
+public const val CLIENT_CAPABILITIES_META_KEY: String = "io.modelcontextprotocol/clientCapabilities"
+
+/** `_meta` key carrying the minimum log severity a server may emit for a request. */
+@ExperimentalMcpApi
+public const val LOG_LEVEL_META_KEY: String = "io.modelcontextprotocol/logLevel"
+
+/** `_meta` key carrying the name and version of the server software producing a result. */
+@ExperimentalMcpApi
+public const val SERVER_INFO_META_KEY: String = "io.modelcontextprotocol/serverInfo"
+
+@OptIn(ExperimentalMcpApi::class)
+private val ENVELOPE_META_KEYS: Set<String> = setOf(
+    PROTOCOL_VERSION_META_KEY,
+    CLIENT_INFO_META_KEY,
+    CLIENT_CAPABILITIES_META_KEY,
+    LOG_LEVEL_META_KEY,
+)
+
+/**
+ * The protocol fields a client attaches to every request's `_meta`.
+ *
+ * These travel per request rather than per connection, so a server can serve a request without
+ * consulting anything an earlier request established. Read one with [RequestMeta.toEnvelope],
+ * write one with [toMeta].
+ *
+ * @property protocolVersion the protocol version this request is made under
+ * @property clientCapabilities capabilities the client declares for this request. An empty value
+ * declares no optional capabilities, and a receiver must not read capabilities from any other
+ * request.
+ * @property clientInfo name and version of the client software. Self-reported and unverified, so
+ * receivers should confine it to display, logging and debugging rather than behavior or security
+ * decisions.
+ * @property logLevel minimum severity of log notifications the server may emit while serving this
+ * request. Absent means the server emits none.
+ */
+@Serializable
+@ExperimentalMcpApi
+public data class RequestEnvelope(
+    @SerialName(PROTOCOL_VERSION_META_KEY)
+    val protocolVersion: String,
+    @SerialName(CLIENT_CAPABILITIES_META_KEY)
+    val clientCapabilities: ClientCapabilities,
+    @SerialName(CLIENT_INFO_META_KEY)
+    val clientInfo: Implementation? = null,
+    @SerialName(LOG_LEVEL_META_KEY)
+    val logLevel: LoggingLevel? = null,
+)
+
+/**
+ * Renders this envelope as request metadata, preserving every non-protocol entry of [base].
+ *
+ * The envelope is authoritative: protocol entries already present in [base] are replaced, and one
+ * whose envelope counterpart is `null` is dropped rather than carried over. Unrelated entries such
+ * as `progressToken` survive untouched.
+ */
+@ExperimentalMcpApi
+public fun RequestEnvelope.toMeta(base: RequestMeta? = null): RequestMeta = RequestMeta(
+    JsonObject(
+        base?.json.orEmpty().filterKeys { it !in ENVELOPE_META_KEYS } +
+            McpJson.encodeToJsonElement(this).jsonObject,
+    ),
+)
+
+/**
+ * The protocol envelope carried by this metadata.
+ *
+ * Use [toEnvelopeOrNull] to ask whether an intact envelope is present without failing on one that
+ * is not.
+ *
+ * @throws SerializationException if a required field is absent or any field is malformed; the
+ * message names the offending `_meta` key
+ */
+@ExperimentalMcpApi
+public fun RequestMeta.toEnvelope(): RequestEnvelope = McpJson.decodeFromJsonElement(json)
+
+/**
+ * The protocol envelope carried by this metadata, or `null` when it is absent or not intact.
+ *
+ * Answers "is a complete, well-formed envelope present": metadata carrying none — a request from a
+ * peer that predates the envelope, say — yields `null` rather than failing, and so does one whose
+ * envelope is incomplete in any field. Use [toEnvelope] where an unusable envelope has to be
+ * reported rather than ignored.
+ */
+@ExperimentalMcpApi
+public fun RequestMeta.toEnvelopeOrNull(): RequestEnvelope? = try {
+    toEnvelope()
+} catch (_: SerializationException) {
+    null
+}
+
+/**
+ * One self-identifying problem found while validating a `_meta` envelope.
+ *
+ * @property key the reserved `_meta` key the problem is about
+ * @property problem what is wrong with it, phrased to be readable in an error message
+ */
+@ExperimentalMcpApi
+public data class EnvelopeIssue(val key: String, val problem: String)
+
+/** [EnvelopeIssue.problem] for a required key that is not there at all. */
+private const val MISSING_PROBLEM: String = "missing"
+
+/**
+ * Everything that stops this metadata from carrying a usable [RequestEnvelope], or an empty list
+ * when nothing does.
+ *
+ * Every problem is reported at once, so a peer is not corrected one round trip at a time. A server
+ * answers a non-empty list with `-32602`.
+ *
+ * Checked: both required keys, for presence and shape, and [LOG_LEVEL_META_KEY] when present — a
+ * level that names no known severity is rejected rather than guessed, since it decides what the
+ * server may emit. Not checked: [CLIENT_INFO_META_KEY], whatever it contains. Identity is
+ * self-reported and must not change behaviour, so a malformed one degrades to "not supplied".
+ */
+@ExperimentalMcpApi
+public fun validateEnvelope(meta: RequestMeta): List<EnvelopeIssue> {
+    val protocolVersion = meta[PROTOCOL_VERSION_META_KEY]
+    val clientCapabilities = meta[CLIENT_CAPABILITIES_META_KEY]
+    val logLevel = meta[LOG_LEVEL_META_KEY]
+
+    val missing = listOfNotNull(
+        PROTOCOL_VERSION_META_KEY.takeIf { protocolVersion == null },
+        CLIENT_CAPABILITIES_META_KEY.takeIf { clientCapabilities == null },
+    ).map { EnvelopeIssue(it, MISSING_PROBLEM) }
+
+    val malformed = listOfNotNull(
+        protocolVersion
+            ?.takeIf { it !is JsonPrimitive || !it.isString }
+            ?.let { EnvelopeIssue(PROTOCOL_VERSION_META_KEY, "must be a JSON string") },
+        clientCapabilities
+            ?.takeIf { !it.decodesAs<ClientCapabilities>() }
+            ?.let { EnvelopeIssue(CLIENT_CAPABILITIES_META_KEY, "must be a client capabilities object") },
+        logLevel
+            ?.takeIf { !it.decodesAs<LoggingLevel>() }
+            ?.let { EnvelopeIssue(LOG_LEVEL_META_KEY, "must be a known logging level") },
+    )
+
+    return missing + malformed
+}
+
+/**
+ * The protocol envelope carried by this metadata, reading each field on its own terms.
+ *
+ * Admits exactly what [validateEnvelope] admits, and is the reader to use after that check has
+ * passed: a malformed optional field reads as absent instead of discarding the whole envelope.
+ * Returns `null` only when a required field is absent or malformed.
+ *
+ * Changing what [validateEnvelope] admits requires changing this in step, or a request can be
+ * accepted and then served without the envelope it was accepted for.
+ */
+@ExperimentalMcpApi
+internal fun RequestMeta.toEnvelopeLenient(): RequestEnvelope? {
+    val protocolVersion = claimedProtocolVersion ?: return null
+    val clientCapabilities = json[CLIENT_CAPABILITIES_META_KEY]?.decodeOrNull<ClientCapabilities>() ?: return null
+    return RequestEnvelope(
+        protocolVersion = protocolVersion,
+        clientCapabilities = clientCapabilities,
+        clientInfo = json[CLIENT_INFO_META_KEY]?.decodeOrNull<Implementation>(),
+        logLevel = json[LOG_LEVEL_META_KEY]?.decodeOrNull<LoggingLevel>(),
+    )
+}
+
+/**
+ * This element decoded as [T], or `null` when it is not a valid [T].
+ *
+ * The catch is broad on purpose: kotlinx signals a structural mismatch with whichever exception the
+ * generated deserializer happens to raise, and here they all mean the same thing.
+ */
+private inline fun <reified T> JsonElement.decodeOrNull(): T? = try {
+    McpJson.decodeFromJsonElement<T>(this)
+} catch (e: CancellationException) {
+    throw e
+} catch (_: Exception) {
+    null
+}
+
+/** Whether this element is a valid [T]. */
+private inline fun <reified T> JsonElement.decodesAs(): Boolean = decodeOrNull<T>() != null
+
+/**
+ * The server identity reported alongside this result, or `null` when absent.
+ *
+ * Self-reported and unverified, so clients should confine it to display, logging and debugging
+ * rather than behavior or security decisions.
+ *
+ * @throws SerializationException if the field is present but is not a valid [Implementation]
+ */
+@ExperimentalMcpApi
+public val ResultMeta.serverInfo: Implementation?
+    get() = json[SERVER_INFO_META_KEY]?.let { McpJson.decodeFromJsonElement<Implementation>(it) }
+
+/**
+ * Renders [serverInfo] as result metadata, preserving every other entry of this metadata.
+ *
+ * Servers should identify themselves on every result unless configured otherwise, so this is the
+ * write counterpart of [ResultMeta.serverInfo]. Any identity already present is replaced.
+ */
+@ExperimentalMcpApi
+public fun ResultMeta?.withServerInfo(serverInfo: Implementation): ResultMeta = ResultMeta(
+    JsonObject(
+        this?.json.orEmpty() + (SERVER_INFO_META_KEY to McpJson.encodeToJsonElement(serverInfo)),
+    ),
+)
+
+/**
+ * Data carried by a [RPCError.ErrorCode.MISSING_REQUIRED_CLIENT_CAPABILITY] error.
+ *
+ * @property requiredCapabilities the capabilities the server needs in order to serve the request,
+ * narrowed to those the client did not declare
+ */
+@Serializable
+@ExperimentalMcpApi
+public data class MissingRequiredClientCapabilityData(val requiredCapabilities: ClientCapabilities)
+
+/**
+ * The subset of these required capabilities that [declared] does not cover, or `null` when it
+ * covers all of them.
+ *
+ * A server must not rely on a capability the client did not declare, and answers a request needing
+ * one with [RPCError.ErrorCode.MISSING_REQUIRED_CLIENT_CAPABILITY]; the return value is what that
+ * error reports as [MissingRequiredClientCapabilityData.requiredCapabilities]. A `null` [declared]
+ * means nothing was declared, so every required capability comes back as missing.
+ *
+ * Capabilities are compared one level deep: a required capability whose declared counterpart is
+ * absent is missing whole, and one that is present is narrowed to the sub-capabilities the
+ * declaration omits. A bare [ClientCapabilities.Elicitation] naming no mode counts as declaring
+ * form mode.
+ */
+@ExperimentalMcpApi
+public fun ClientCapabilities.missingIn(declared: ClientCapabilities?): ClientCapabilities? {
+    val declaredJson = declared?.let { McpJson.encodeToJsonElement(it).jsonObject }.orEmpty()
+    val missing = McpJson.encodeToJsonElement(this).jsonObject.mapNotNull { (capability, required) ->
+        val declaredValue = declaredJson[capability] ?: return@mapNotNull capability to required
+        if (required !is JsonObject || declaredValue !is JsonObject) return@mapNotNull null
+        required
+            .filterKeys { it !in declaredValue && !impliesMember(capability, it, declaredValue) }
+            .takeIf { it.isNotEmpty() }
+            ?.let { capability to JsonObject(it) }
+    }
+    return missing.takeIf { it.isNotEmpty() }?.let { McpJson.decodeFromJsonElement(JsonObject(it.toMap())) }
+}
+
+/**
+ * Whether a declaration implies a sub-capability it does not name: a bare `elicitation` naming no
+ * mode means form mode. Naming any mode removes the implication.
+ */
+private fun impliesMember(capability: String, member: String, declared: JsonObject): Boolean =
+    capability == "elicitation" && member == "form" && "form" !in declared && "url" !in declared

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/era.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/era.kt
@@ -1,0 +1,43 @@
+package io.modelcontextprotocol.kotlin.sdk.types
+
+/**
+ * Which lifecycle a message is being handled under.
+ *
+ * Revision `2026-07-28` replaced the `initialize` handshake with a per-request `_meta` envelope.
+ * The two cannot interoperate, so a server decides this per request and a client per connection.
+ *
+ * Not public: callers observe the lifecycle through facts they can act on — whether a request
+ * carried an envelope, which protocol version governs it — rather than through this enum.
+ */
+internal enum class ProtocolEra {
+    /** The connection-scoped lifecycle established by `initialize`. */
+    Legacy,
+
+    /** The request-scoped lifecycle carried by the `_meta` envelope. */
+    Modern,
+
+    ;
+
+    internal companion object {
+        /** A method that survived the transition and is reachable under either lifecycle. */
+        val BOTH: Set<ProtocolEra> = setOf(Legacy, Modern)
+
+        /** A method `2026-07-28` removed, still served for peers that predate the removal. */
+        val LEGACY_ONLY: Set<ProtocolEra> = setOf(Legacy)
+
+        /** A method `2026-07-28` introduced, which no handshake-era peer knows. */
+        val MODERN_ONLY: Set<ProtocolEra> = setOf(Modern)
+    }
+}
+
+/**
+ * Whether this method exists in [era].
+ *
+ * A method absent from the era being served is answered `-32601` even where a handler is
+ * registered. [Method.Custom] is era-blind: the protocol says nothing about methods it does not
+ * define, so they always route.
+ */
+internal fun Method.isAvailableIn(era: ProtocolEra): Boolean = when (this) {
+    is Method.Defined -> era in eras
+    is Method.Custom -> true
+}

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/initialize.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/initialize.kt
@@ -4,7 +4,6 @@ import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonObject
 
 /**
  * This request is sent from the client to the server when it first connects,
@@ -85,14 +84,16 @@ public data class InitializeRequestParams(
  * tools, resources, etc. It can be thought of as a "hint" to the model.
  * For example, this information MAY be added to the system prompt to help
  * the LLM make better use of the server's capabilities.
+ * @property resultType Discriminator for the result representation.
  * @property meta Optional metadata for this response.
  */
 @Serializable
 public data class InitializeResult(
-    val protocolVersion: String = LATEST_PROTOCOL_VERSION,
+    val protocolVersion: String = LATEST_HANDSHAKE_VERSION,
     val capabilities: ServerCapabilities,
     val serverInfo: Implementation,
     val instructions: String? = null,
+    val resultType: String = COMPLETE_RESULT_TYPE,
     @SerialName("_meta")
-    override val meta: JsonObject? = null,
+    override val meta: ResultMeta? = null,
 ) : ServerResult

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/jsonRpc.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/jsonRpc.kt
@@ -259,17 +259,51 @@ public data class RPCError(val code: Int, val message: String, val data: JsonEle
      * Standard JSON-RPC 2.0 and MCP SDK error codes.
      */
     public object ErrorCode {
-        // SDK-specific error codes
+        // SDK-specific codes in the grandfathered -32000..-32019 range. The protocol reserves
+        // -32020..-32099 for itself, so nothing new may be allocated here.
+
         /** Connection was closed */
         public const val CONNECTION_CLOSED: Int = -32000
 
-        /** Request timed out */
+        /**
+         * A request the SDK gave up waiting for.
+         *
+         * Raised locally and never sent on the wire: a timeout is this peer's own decision, and the
+         * protocol requires that a local failure not be mistakable for one the other side reported.
+         */
         public const val REQUEST_TIMEOUT: Int = -32001
 
         /** Resource not found */
+        @Deprecated(
+            "Removed as of MCP protocol version 2026-07-28; resource-not-found is reported as " +
+                "INVALID_PARAMS (-32602). Still accepted from peers that predate the removal.",
+            ReplaceWith("INVALID_PARAMS"),
+            DeprecationLevel.WARNING,
+        )
         public const val RESOURCE_NOT_FOUND: Int = -32002
 
-        /** The request selected a protocol version that the receiver does not support. */
+        // -32020..-32099 is reserved for the MCP specification.
+
+        /**
+         * A standard MCP header disagrees with the request body, or a required one is absent.
+         *
+         * Headers restate what the body already says so that an intermediary can route on them
+         * without parsing; a disagreement means one of the two is wrong and neither can be trusted.
+         */
+        public const val HEADER_MISMATCH: Int = -32020
+
+        /**
+         * Serving the request needs a client capability the request did not declare.
+         * The error [data][RPCError.data] carries the missing capabilities
+         * (see [MissingRequiredClientCapabilityData]).
+         */
+        public const val MISSING_REQUIRED_CLIENT_CAPABILITY: Int = -32021
+
+        /**
+         * The request selected a protocol version that the receiver does not support.
+         * The error [data][RPCError.data] names the versions it does support
+         * (see [UnsupportedProtocolVersionData]).
+         */
         public const val UNSUPPORTED_PROTOCOL_VERSION: Int = -32022
 
         /**
@@ -277,6 +311,11 @@ public data class RPCError(val code: Int, val message: String, val data: JsonEle
          * The error [data][RPCError.data] carries the required URL-mode elicitations
          * (see [UrlElicitationRequiredException]).
          */
+        @Deprecated(
+            "Removed as of MCP protocol version 2026-07-28 along with URL-elicitation completion. " +
+                "Still accepted from peers that predate the removal.",
+            level = DeprecationLevel.WARNING,
+        )
         public const val URL_ELICITATION_REQUIRED: Int = -32042
 
         // Standard JSON-RPC 2.0 error codes

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/mcpHeaders.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/mcpHeaders.kt
@@ -1,0 +1,74 @@
+package io.modelcontextprotocol.kotlin.sdk.types
+
+import io.modelcontextprotocol.kotlin.sdk.InternalMcpApi
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+
+/** HTTP header restating the protocol version a request is made under. */
+@InternalMcpApi
+public const val MCP_PROTOCOL_VERSION_HEADER: String = "MCP-Protocol-Version"
+
+/** HTTP header restating a request's JSON-RPC method. */
+@InternalMcpApi
+public const val MCP_METHOD_HEADER: String = "Mcp-Method"
+
+/** HTTP header restating the tool, prompt or resource a request names. */
+@InternalMcpApi
+public const val MCP_NAME_HEADER: String = "Mcp-Name"
+
+private const val MCP_BASE64_PREFIX = "=?base64?"
+private const val MCP_BASE64_SUFFIX = "?="
+
+/**
+ * The params key whose value [MCP_NAME_HEADER] restates, per method.
+ *
+ * Selected by method rather than by whichever of `name` or `uri` happens to be present, so that
+ * both ends compare the same field. A method absent from this map sends and expects no
+ * [MCP_NAME_HEADER].
+ */
+@InternalMcpApi
+public val NAME_BEARING_METHODS: Map<String, String> = mapOf(
+    Method.Defined.ToolsCall.value to "name",
+    Method.Defined.PromptsGet.value to "name",
+    Method.Defined.ResourcesRead.value to "uri",
+)
+
+/**
+ * Renders a value for an MCP HTTP header, escaping it when it cannot travel literally.
+ *
+ * HTTP field values admit only visible ASCII and tabs, and edge whitespace is not preserved across
+ * intermediaries, so anything else is wrapped in the `=?base64?…?=` sentinel. A value that already
+ * looks like the sentinel is escaped too, so a receiver can always tell the two apart.
+ */
+@OptIn(ExperimentalEncodingApi::class)
+@InternalMcpApi
+public fun String.encodeMcpHeaderValue(): String {
+    val containsUnsafeCharacters = any { it != '\t' && it.code !in 0x20..0x7e }
+    val hasEdgeWhitespace = firstOrNull()?.isWhitespace() == true || lastOrNull()?.isWhitespace() == true
+    val matchesBase64Sentinel = startsWith(MCP_BASE64_PREFIX) && endsWith(MCP_BASE64_SUFFIX)
+
+    if (!containsUnsafeCharacters && !hasEdgeWhitespace && !matchesBase64Sentinel) return this
+
+    return "$MCP_BASE64_PREFIX${Base64.encode(encodeToByteArray())}$MCP_BASE64_SUFFIX"
+}
+
+/**
+ * Reads a header value written by [encodeMcpHeaderValue], or `null` when the sentinel is malformed.
+ *
+ * Surrounding optional whitespace is stripped first, per RFC 9110 §5.5. A malformed sentinel is
+ * reported rather than compared literally, so a receiver never accepts a value the sender did not
+ * write.
+ */
+@OptIn(ExperimentalEncodingApi::class)
+@InternalMcpApi
+public fun decodeMcpHeaderValue(raw: String): String? {
+    val trimmed = raw.trim(' ', '\t')
+    if (!trimmed.startsWith(MCP_BASE64_PREFIX) || !trimmed.endsWith(MCP_BASE64_SUFFIX)) return trimmed
+    if (trimmed.length < MCP_BASE64_PREFIX.length + MCP_BASE64_SUFFIX.length) return null
+    val payload = trimmed.substring(MCP_BASE64_PREFIX.length, trimmed.length - MCP_BASE64_SUFFIX.length)
+    return try {
+        Base64.decode(payload).decodeToString()
+    } catch (_: IllegalArgumentException) {
+        null
+    }
+}

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/methods.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/methods.kt
@@ -1,5 +1,8 @@
 package io.modelcontextprotocol.kotlin.sdk.types
 
+import io.modelcontextprotocol.kotlin.sdk.types.ProtocolEra.Companion.BOTH
+import io.modelcontextprotocol.kotlin.sdk.types.ProtocolEra.Companion.LEGACY_ONLY
+import io.modelcontextprotocol.kotlin.sdk.types.ProtocolEra.Companion.MODERN_ONLY
 import kotlinx.serialization.Serializable
 
 /**
@@ -12,41 +15,57 @@ public sealed interface Method {
 
     /**
      * Enum of predefined methods supported by the protocol.
+     *
+     * Each constant declares the protocol lifecycles it exists in, so the set of methods a revision
+     * removed is a property of the table rather than a list kept somewhere else: a constant cannot
+     * be added without deciding where it is reachable. Read it through
+     * [isAvailableIn][io.modelcontextprotocol.kotlin.sdk.types.isAvailableIn].
+     *
+     * Direction is not expressible here and is enforced at the transport instead. On the
+     * request-scoped lifecycle `notifications/cancelled` travels only over stdio — over HTTP,
+     * closing the response stream *is* cancellation — while `notifications/progress` and
+     * `notifications/message` flow server-to-client on the originating request's response stream
+     * only. The three `list_changed` notifications keep their types but have no request-scoped
+     * delivery channel until `subscriptions/listen` lands, so a request-scoped server emits none.
      */
     @Serializable
-    public enum class Defined(override val value: String) : Method {
-        Initialize("initialize"),
-        ServerDiscover("server/discover"),
-        Ping("ping"),
-        ResourcesList("resources/list"),
-        ResourcesTemplatesList("resources/templates/list"),
-        ResourcesRead("resources/read"),
-        ResourcesSubscribe("resources/subscribe"),
-        ResourcesUnsubscribe("resources/unsubscribe"),
-        PromptsList("prompts/list"),
-        PromptsGet("prompts/get"),
-        NotificationsCancelled("notifications/cancelled"),
-        NotificationsInitialized("notifications/initialized"),
-        NotificationsProgress("notifications/progress"),
-        NotificationsMessage("notifications/message"),
-        NotificationsResourcesUpdated("notifications/resources/updated"),
-        NotificationsResourcesListChanged("notifications/resources/list_changed"),
-        NotificationsToolsListChanged("notifications/tools/list_changed"),
-        NotificationsRootsListChanged("notifications/roots/list_changed"),
-        NotificationsPromptsListChanged("notifications/prompts/list_changed"),
-        NotificationsElicitationComplete("notifications/elicitation/complete"),
-        NotificationsTasksStatus("notifications/tasks/status"),
-        ToolsList("tools/list"),
-        ToolsCall("tools/call"),
-        LoggingSetLevel("logging/setLevel"),
-        SamplingCreateMessage("sampling/createMessage"),
-        CompletionComplete("completion/complete"),
-        RootsList("roots/list"),
-        ElicitationCreate("elicitation/create"),
-        TasksGet("tasks/get"),
-        TasksResult("tasks/result"),
-        TasksList("tasks/list"),
-        TasksCancel("tasks/cancel"),
+    public enum class Defined(override val value: String, internal val eras: Set<ProtocolEra>) : Method {
+        Initialize("initialize", LEGACY_ONLY),
+        ServerDiscover("server/discover", MODERN_ONLY),
+        Ping("ping", LEGACY_ONLY),
+        ResourcesList("resources/list", BOTH),
+        ResourcesTemplatesList("resources/templates/list", BOTH),
+        ResourcesRead("resources/read", BOTH),
+        ResourcesSubscribe("resources/subscribe", LEGACY_ONLY),
+        ResourcesUnsubscribe("resources/unsubscribe", LEGACY_ONLY),
+        PromptsList("prompts/list", BOTH),
+        PromptsGet("prompts/get", BOTH),
+        NotificationsCancelled("notifications/cancelled", BOTH),
+        NotificationsInitialized("notifications/initialized", LEGACY_ONLY),
+        NotificationsProgress("notifications/progress", BOTH),
+        NotificationsMessage("notifications/message", BOTH),
+        NotificationsResourcesUpdated("notifications/resources/updated", LEGACY_ONLY),
+        NotificationsResourcesListChanged("notifications/resources/list_changed", BOTH),
+        NotificationsToolsListChanged("notifications/tools/list_changed", BOTH),
+        NotificationsRootsListChanged("notifications/roots/list_changed", LEGACY_ONLY),
+        NotificationsPromptsListChanged("notifications/prompts/list_changed", BOTH),
+        NotificationsElicitationComplete("notifications/elicitation/complete", LEGACY_ONLY),
+
+        // Tasks moved out of core into an extension, which needs the extensions capability map.
+        NotificationsTasksStatus("notifications/tasks/status", LEGACY_ONLY),
+        ToolsList("tools/list", BOTH),
+        ToolsCall("tools/call", BOTH),
+        LoggingSetLevel("logging/setLevel", LEGACY_ONLY),
+
+        // Server-to-client requests, replaced wholesale by multi-round-trip requests.
+        SamplingCreateMessage("sampling/createMessage", LEGACY_ONLY),
+        CompletionComplete("completion/complete", BOTH),
+        RootsList("roots/list", LEGACY_ONLY),
+        ElicitationCreate("elicitation/create", LEGACY_ONLY),
+        TasksGet("tasks/get", LEGACY_ONLY),
+        TasksResult("tasks/result", LEGACY_ONLY),
+        TasksList("tasks/list", LEGACY_ONLY),
+        TasksCancel("tasks/cancel", LEGACY_ONLY),
     }
 
     /**

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/prompts.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/prompts.kt
@@ -2,6 +2,7 @@
 
 package io.modelcontextprotocol.kotlin.sdk.types
 
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
 import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
@@ -159,14 +160,16 @@ public data class GetPromptRequestParams(
  * @property messages The list of messages that make up this prompt.
  *                   Each message has a role (e.g., "user", "assistant") and content.
  * @property description An optional description for the prompt, explaining its purpose or usage.
+ * @property resultType Discriminator for the result representation.
  * @property meta Optional metadata for this response.
  */
 @Serializable
 public data class GetPromptResult(
     val messages: List<PromptMessage>,
     val description: String? = null,
+    val resultType: String = COMPLETE_RESULT_TYPE,
     @SerialName("_meta")
-    override val meta: JsonObject? = null,
+    override val meta: ResultMeta? = null,
 ) : ServerResult
 
 // ============================================================================
@@ -200,13 +203,26 @@ public data class ListPromptsRequest(override val params: PaginatedRequestParams
  * @property nextCursor An opaque token representing the pagination position after the last returned result.
  *                     If present, there may be more results available. The client can pass this token
  *                     in a subsequent request to fetch the next page.
+ * @property resultType Discriminator for the result representation.
+ * @property ttlMs number of milliseconds clients may treat this result as fresh
+ * @property cacheScope authorization boundary within which the result may be reused
  * @property meta Optional metadata for this response.
+ * @throws IllegalArgumentException if [ttlMs] is negative
  */
 @Serializable
+@OptIn(ExperimentalMcpApi::class)
 public data class ListPromptsResult(
     val prompts: List<Prompt>,
     override val nextCursor: String? = null,
+    val resultType: String = COMPLETE_RESULT_TYPE,
+    override val ttlMs: Long = 0,
+    override val cacheScope: CacheScope = CacheScope.Private,
     @SerialName("_meta")
-    override val meta: JsonObject? = null,
+    override val meta: ResultMeta? = null,
 ) : ServerResult,
-    PaginatedResult
+    PaginatedResult,
+    CacheableResult {
+    init {
+        require(ttlMs >= 0) { "ttlMs must be non-negative, but was $ttlMs" }
+    }
+}

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/request.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/request.kt
@@ -4,7 +4,6 @@ import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -12,13 +11,6 @@ import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.long
 import kotlinx.serialization.json.longOrNull
 import kotlin.jvm.JvmInline
-
-internal object RequestMetaKeys {
-    const val PROTOCOL_VERSION: String = "io.modelcontextprotocol/protocolVersion"
-    const val CLIENT_INFO: String = "io.modelcontextprotocol/clientInfo"
-    const val CLIENT_CAPABILITIES: String = "io.modelcontextprotocol/clientCapabilities"
-    const val LOG_LEVEL: String = "io.modelcontextprotocol/logLevel"
-}
 
 /**
  * Metadata attached to a request's `_meta` field.
@@ -50,86 +42,17 @@ public value class RequestMeta(public val json: JsonObject) {
         }
 
     /**
-     * The MCP protocol version selected for this request, or `null` when absent.
+     * The protocol version this request claims to be made under, or `null` when it claims none.
      *
-     * This field is required by the request-scoped lifecycle introduced in protocol version
-     * `2026-07-28`, but remains optional here so older requests retain their wire shape.
+     * Never throws: the claim decides which protocol era a request is served on, and that decision
+     * is made before the envelope is validated. A claim carrying a non-string value therefore reads
+     * as absent here and surfaces later, from [toEnvelope].
      *
-     * @throws SerializationException if the field is present but is not a string
+     * @see PROTOCOL_VERSION_META_KEY
      */
     @ExperimentalMcpApi
-    public val protocolVersion: String?
-        get() = json[RequestMetaKeys.PROTOCOL_VERSION]?.let { element ->
-            if (element !is JsonPrimitive || !element.isString) {
-                throw SerializationException("${RequestMetaKeys.PROTOCOL_VERSION} must be a JSON string")
-            }
-            element.content
-        }
-
-    /**
-     * Information about the client making this request, or `null` when absent.
-     *
-     * Request-scoped clients should include this field unless specifically configured not to do
-     * so. The self-reported value is intended for display, logging, and debugging; servers should
-     * not use it to change behavior or rely on it for security decisions.
-     *
-     * @throws SerializationException if the field is present but is not a valid [Implementation]
-     */
-    @ExperimentalMcpApi
-    public val clientInfo: Implementation?
-        get() = json[RequestMetaKeys.CLIENT_INFO]?.let { element ->
-            try {
-                McpJson.decodeFromJsonElement<Implementation>(element)
-            } catch (cause: SerializationException) {
-                throw SerializationException(
-                    "${RequestMetaKeys.CLIENT_INFO} must be a valid client implementation",
-                    cause,
-                )
-            }
-        }
-
-    /**
-     * Capabilities declared by the client for this request, or `null` when absent.
-     *
-     * Servers using the request-scoped lifecycle must not infer capabilities from an earlier
-     * request. An empty object means the client supports no optional capabilities.
-     *
-     * @throws SerializationException if the field is present but is not valid [ClientCapabilities]
-     */
-    @ExperimentalMcpApi
-    public val clientCapabilities: ClientCapabilities?
-        get() = json[RequestMetaKeys.CLIENT_CAPABILITIES]?.let { element ->
-            try {
-                McpJson.decodeFromJsonElement<ClientCapabilities>(element)
-            } catch (cause: SerializationException) {
-                throw SerializationException(
-                    "${RequestMetaKeys.CLIENT_CAPABILITIES} must be a valid client capabilities object",
-                    cause,
-                )
-            }
-        }
-
-    /**
-     * Minimum severity of request-associated log notifications, or `null` when absent.
-     *
-     * In the request-scoped lifecycle, absence means that the server must not emit log
-     * notifications for this request.
-     *
-     * @throws SerializationException if the field is present but is not a valid [LoggingLevel]
-     */
-    @Deprecated("Per-request log levels are deprecated as of MCP protocol version 2026-07-28 (SEP-2577).")
-    @ExperimentalMcpApi
-    public val logLevel: LoggingLevel?
-        get() = json[RequestMetaKeys.LOG_LEVEL]?.let { element ->
-            try {
-                McpJson.decodeFromJsonElement<LoggingLevel>(element)
-            } catch (cause: SerializationException) {
-                throw SerializationException(
-                    "${RequestMetaKeys.LOG_LEVEL} must be a valid logging level",
-                    cause,
-                )
-            }
-        }
+    public val claimedProtocolVersion: String?
+        get() = (json[PROTOCOL_VERSION_META_KEY] as? JsonPrimitive)?.takeIf { it.isString }?.content
 
     /**
      * Retrieves the value associated with the specified key from the JSON object.
@@ -213,10 +136,23 @@ public sealed interface PaginatedRequest : Request {
 }
 
 /**
+ * The `resultType` of a result that carries the request's outcome.
+ *
+ * Every result declares this, and a receiver must read an absent `resultType` as this value: peers
+ * that predate the field send nothing at all. It is declared per concrete result rather than on
+ * [RequestResult] because [EmptyResult] has to be able to omit it.
+ */
+public const val COMPLETE_RESULT_TYPE: String = "complete"
+
+/**
  * Represents the result of a request, including additional metadata.
  */
 @Serializable(with = RequestResultPolymorphicSerializer::class)
-public sealed interface RequestResult : WithMeta
+public sealed interface RequestResult {
+    /** Optional metadata attached to this result. */
+    @SerialName("_meta")
+    public val meta: ResultMeta?
+}
 
 /**
  * Represents a result returned by the server in response to a [ClientRequest].
@@ -233,11 +169,17 @@ public sealed interface ServerResult : RequestResult
 /**
  * An empty result for a request containing optional metadata.
  *
+ * @property resultType Discriminator for the result representation. Unlike every other result this
+ * defaults to `null`, which keeps the encoded form `{}`: deployed peers validate empty results
+ * strictly and reject unknown keys, so an unconditional [COMPLETE_RESULT_TYPE] would break them.
+ * A request-scoped connection answering an empty result passes it explicitly.
  * @property meta Additional metadata for the response. Defaults to an empty JSON object.
  */
 @Serializable
-public data class EmptyResult(@SerialName("_meta") override val meta: JsonObject? = null) :
-    ClientResult,
+public data class EmptyResult(
+    val resultType: String? = null,
+    @SerialName("_meta") override val meta: ResultMeta? = null,
+) : ClientResult,
     ServerResult
 
 /**

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/resources.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/resources.kt
@@ -2,6 +2,7 @@
 
 package io.modelcontextprotocol.kotlin.sdk.types
 
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
 import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
@@ -208,16 +209,29 @@ public data class ListResourcesRequest(override val params: PaginatedRequestPara
  * @property nextCursor An opaque token representing the pagination position after the last returned result.
  * If present, there may be more results available. The client can pass this token
  * in a subsequent request to fetch the next page.
+ * @property resultType Discriminator for the result representation.
+ * @property ttlMs number of milliseconds clients may treat this result as fresh
+ * @property cacheScope authorization boundary within which the result may be reused
  * @property meta Optional metadata for this response.
+ * @throws IllegalArgumentException if [ttlMs] is negative
  */
 @Serializable
+@OptIn(ExperimentalMcpApi::class)
 public data class ListResourcesResult(
     val resources: List<Resource>,
     override val nextCursor: String? = null,
+    val resultType: String = COMPLETE_RESULT_TYPE,
+    override val ttlMs: Long = 0,
+    override val cacheScope: CacheScope = CacheScope.Private,
     @SerialName("_meta")
-    override val meta: JsonObject? = null,
+    override val meta: ResultMeta? = null,
 ) : ServerResult,
-    PaginatedResult
+    PaginatedResult,
+    CacheableResult {
+    init {
+        require(ttlMs >= 0) { "ttlMs must be non-negative, but was $ttlMs" }
+    }
+}
 
 // ============================================================================
 // resources/read
@@ -273,14 +287,27 @@ public data class ReadResourceRequestParams(
  * @property contents The contents of the resource. Can include text content (with MIME type and text data)
  * or binary/blob content (with MIME type and Base64-encoded data).
  * Multiple content blocks can be returned for resources with multiple parts.
+ * @property resultType Discriminator for the result representation.
+ * @property ttlMs number of milliseconds clients may treat this result as fresh
+ * @property cacheScope authorization boundary within which the result may be reused
  * @property meta Optional metadata for this response.
+ * @throws IllegalArgumentException if [ttlMs] is negative
  */
 @Serializable
+@OptIn(ExperimentalMcpApi::class)
 public data class ReadResourceResult(
     val contents: List<ResourceContents>,
+    val resultType: String = COMPLETE_RESULT_TYPE,
+    override val ttlMs: Long = 0,
+    override val cacheScope: CacheScope = CacheScope.Private,
     @SerialName("_meta")
-    override val meta: JsonObject? = null,
-) : ServerResult
+    override val meta: ResultMeta? = null,
+) : ServerResult,
+    CacheableResult {
+    init {
+        require(ttlMs >= 0) { "ttlMs must be non-negative, but was $ttlMs" }
+    }
+}
 
 // ============================================================================
 // resources/subscribe
@@ -411,13 +438,26 @@ public data class ListResourceTemplatesRequest(override val params: PaginatedReq
  * @property nextCursor An opaque token representing the pagination position after the last returned result.
  * If present, there may be more results available. The client can pass this token
  * in a subsequent request to fetch the next page.
+ * @property resultType Discriminator for the result representation.
+ * @property ttlMs number of milliseconds clients may treat this result as fresh
+ * @property cacheScope authorization boundary within which the result may be reused
  * @property meta Optional metadata for this response.
+ * @throws IllegalArgumentException if [ttlMs] is negative
  */
 @Serializable
+@OptIn(ExperimentalMcpApi::class)
 public data class ListResourceTemplatesResult(
     val resourceTemplates: List<ResourceTemplate>,
     override val nextCursor: String? = null,
+    val resultType: String = COMPLETE_RESULT_TYPE,
+    override val ttlMs: Long = 0,
+    override val cacheScope: CacheScope = CacheScope.Private,
     @SerialName("_meta")
-    override val meta: JsonObject? = null,
+    override val meta: ResultMeta? = null,
 ) : ServerResult,
-    PaginatedResult
+    PaginatedResult,
+    CacheableResult {
+    init {
+        require(ttlMs >= 0) { "ttlMs must be non-negative, but was $ttlMs" }
+    }
+}

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/roots.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/roots.kt
@@ -75,11 +75,13 @@ public data class ListRootsRequest(override val params: BaseRequestParams? = nul
  * @property roots The list of root URIs that the server can access.
  *                Each root represents a top-level directory, file, or other location
  *                that the server has permission to work with.
+ * @property resultType Discriminator for the result representation.
  * @property meta Optional metadata for this response.
  */
 @Serializable
 public data class ListRootsResult(
     val roots: List<Root>,
+    val resultType: String = COMPLETE_RESULT_TYPE,
     @SerialName("_meta")
-    override val meta: JsonObject? = null,
+    override val meta: ResultMeta? = null,
 ) : ClientResult

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/sampling.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/sampling.kt
@@ -274,6 +274,7 @@ public enum class IncludeContext {
  * @property stopReason The reason why sampling stopped, if known.
  * Common values: [StopReason.EndTurn], [StopReason.StopSequence], [StopReason.MaxTokens],
  * [StopReason.ToolUse].
+ * @property resultType Discriminator for the result representation.
  * @property meta Optional metadata for this response.
  */
 @Serializable
@@ -283,8 +284,9 @@ public data class CreateMessageResult(
     val content: List<SamplingMessageContent>,
     val model: String,
     val stopReason: StopReason? = null,
+    val resultType: String = COMPLETE_RESULT_TYPE,
     @SerialName("_meta")
-    override val meta: JsonObject? = null,
+    override val meta: ResultMeta? = null,
 ) : ClientResult {
     init {
         require(content.isNotEmpty()) { "content must contain at least one block" }
@@ -301,8 +303,8 @@ public data class CreateMessageResult(
         content: SamplingMessageContent,
         model: String,
         stopReason: StopReason? = null,
-        meta: JsonObject? = null,
-    ) : this(role, listOf(content), model, stopReason, meta)
+        meta: ResultMeta? = null,
+    ) : this(role, listOf(content), model, stopReason, meta = meta)
 }
 
 /**

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/serializers.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/serializers.kt
@@ -387,14 +387,20 @@ internal object ServerNotificationPolymorphicSerializer :
 // Result Serializers
 // ============================================================================
 
+/** The keys an empty result may carry; anything else makes it a result of some other shape. */
+private val EMPTY_RESULT_KEYS: Set<String> = setOf("_meta", "resultType")
+
 /**
  * Selects the appropriate deserializer for empty results.
- * Returns EmptyResult serializer if the JSON object is empty or contains only metadata.
+ *
+ * An empty result carries no payload of its own, so it is recognized by the absence of one:
+ * nothing beyond `_meta` and `resultType`. A request-scoped peer answers `{"resultType":"complete"}`
+ * where a peer predating the field answers `{}`, and both have to read as the same result.
  */
 private fun selectEmptyResult(element: JsonElement): DeserializationStrategy<EmptyResult>? {
     val jsonObject = element.jsonObject
     return when {
-        jsonObject.isEmpty() || (jsonObject.size == 1 && "_meta" in jsonObject) -> EmptyResult.serializer()
+        jsonObject.keys.all { it in EMPTY_RESULT_KEYS } -> EmptyResult.serializer()
         else -> null
     }
 }
@@ -423,14 +429,11 @@ private fun selectClientResultDeserializer(element: JsonElement): Deserializatio
 @OptIn(ExperimentalMcpApi::class)
 private fun selectServerResultDeserializer(element: JsonElement): DeserializationStrategy<ServerResult>? {
     val jsonObject = element.jsonObject
-    val isDiscoverResult =
-        "supportedVersions" in jsonObject &&
-            "capabilities" in jsonObject &&
-            "ttlMs" in jsonObject &&
-            "cacheScope" in jsonObject
+    // Initialize is matched before discovery: only it carries protocolVersion, so a result that
+    // extends it with a supportedVersions field of its own is not mistaken for discovery.
     return when {
-        isDiscoverResult -> DiscoverResult.serializer()
         "protocolVersion" in jsonObject && "capabilities" in jsonObject -> InitializeResult.serializer()
+        "supportedVersions" in jsonObject && "capabilities" in jsonObject -> DiscoverResult.serializer()
         "completion" in jsonObject -> CompleteResult.serializer()
         "tools" in jsonObject -> ListToolsResult.serializer()
         "resources" in jsonObject -> ListResourcesResult.serializer()

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/tasks.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/tasks.kt
@@ -108,13 +108,15 @@ public data class RelatedTaskMetadata(val taskId: String)
  * A response to a task-augmented request.
  *
  * @property task The task data associated with the response.
+ * @property resultType Discriminator for the result representation.
  * @property meta Optional metadata for this response.
  */
 @Serializable
 public data class CreateTaskResult(
     val task: Task,
+    val resultType: String = COMPLETE_RESULT_TYPE,
     @SerialName("_meta")
-    override val meta: JsonObject? = null,
+    override val meta: ResultMeta? = null,
 ) : ClientResult,
     ServerResult
 
@@ -174,6 +176,7 @@ public data class GetTaskRequestParams(
  * @property lastUpdatedAt ISO 8601 timestamp when the task was last updated.
  * @property ttl Actual retention duration from creation in milliseconds, null for unlimited.
  * @property pollInterval Suggested polling interval in milliseconds.
+ * @property resultType Discriminator for the result representation.
  * @property meta Optional metadata for this response.
  */
 @Serializable
@@ -185,8 +188,9 @@ public data class GetTaskResult(
     override val lastUpdatedAt: String,
     override val ttl: Long?,
     override val pollInterval: Long? = null,
+    val resultType: String = COMPLETE_RESULT_TYPE,
     @SerialName("_meta")
-    override val meta: JsonObject? = null,
+    override val meta: ResultMeta? = null,
 ) : ClientResult,
     ServerResult,
     TaskFields
@@ -249,8 +253,8 @@ public value class GetTaskPayloadResult(public val json: JsonObject) :
     ClientResult,
     ServerResult {
     /** Optional metadata for this response, extracted from the `_meta` field of [json]. */
-    override val meta: JsonObject?
-        get() = json["_meta"]?.takeIf { it is JsonObject } as? JsonObject
+    override val meta: ResultMeta?
+        get() = (json["_meta"] as? JsonObject)?.let(::ResultMeta)
 
     /**
      * Retrieves the value associated with the specified key from the result payload.
@@ -288,14 +292,16 @@ public data class ListTasksRequest(override val params: PaginatedRequestParams? 
  * @property tasks The list of tasks.
  * @property nextCursor An opaque token representing the pagination position after the last returned result.
  * If present, there may be more results available.
+ * @property resultType Discriminator for the result representation.
  * @property meta Optional metadata for this response.
  */
 @Serializable
 public data class ListTasksResult(
     val tasks: List<Task>,
     override val nextCursor: String? = null,
+    val resultType: String = COMPLETE_RESULT_TYPE,
     @SerialName("_meta")
-    override val meta: JsonObject? = null,
+    override val meta: ResultMeta? = null,
 ) : ClientResult,
     ServerResult,
     PaginatedResult

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/tools.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/tools.kt
@@ -2,6 +2,7 @@
 
 package io.modelcontextprotocol.kotlin.sdk.types
 
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
 import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
@@ -11,7 +12,7 @@ import kotlinx.serialization.json.JsonObject
 /**
  * Creates a [CallToolResult] with single [TextContent] and [meta].
  */
-public fun CallToolResult.Companion.success(content: String, meta: JsonObject? = null): CallToolResult = CallToolResult(
+public fun CallToolResult.Companion.success(content: String, meta: ResultMeta? = null): CallToolResult = CallToolResult(
     content = listOf(TextContent(content)),
     isError = false,
     meta = meta,
@@ -20,7 +21,7 @@ public fun CallToolResult.Companion.success(content: String, meta: JsonObject? =
 /**
  * Creates a [CallToolResult] with single [TextContent] and [meta], with `isError` being true.
  */
-public fun CallToolResult.Companion.error(content: String, meta: JsonObject? = null): CallToolResult = CallToolResult(
+public fun CallToolResult.Companion.error(content: String, meta: ResultMeta? = null): CallToolResult = CallToolResult(
     content = listOf(TextContent(content)),
     isError = true,
     meta = meta,
@@ -255,6 +256,7 @@ public data class CallToolRequestParams(
  * When true, the [content] should describe the error that occurred.
  * @property structuredContent An optional JSON object that represents the structured result of the tool call.
  * Provides machine-readable output in addition to the human-readable [content].
+ * @property resultType Discriminator for the result representation.
  * @property meta Optional metadata for this response.
  */
 @Serializable
@@ -262,8 +264,9 @@ public data class CallToolResult(
     val content: List<ContentBlock>,
     val isError: Boolean? = null,
     val structuredContent: JsonObject? = null,
+    val resultType: String = COMPLETE_RESULT_TYPE,
     @SerialName("_meta")
-    override val meta: JsonObject? = null,
+    override val meta: ResultMeta? = null,
 ) : ServerResult
 
 // ============================================================================
@@ -296,13 +299,26 @@ public data class ListToolsRequest(override val params: PaginatedRequestParams? 
  * @property nextCursor An opaque token representing the pagination position after the last returned result.
  * If present, there may be more results available. The client can pass this token
  * in a subsequent request to fetch the next page.
+ * @property resultType Discriminator for the result representation.
+ * @property ttlMs number of milliseconds clients may treat this result as fresh
+ * @property cacheScope authorization boundary within which the result may be reused
  * @property meta Optional metadata for this response.
+ * @throws IllegalArgumentException if [ttlMs] is negative
  */
 @Serializable
+@OptIn(ExperimentalMcpApi::class)
 public data class ListToolsResult(
     val tools: List<Tool>,
     override val nextCursor: String? = null,
+    val resultType: String = COMPLETE_RESULT_TYPE,
+    override val ttlMs: Long = 0,
+    override val cacheScope: CacheScope = CacheScope.Private,
     @SerialName("_meta")
-    override val meta: JsonObject? = null,
+    override val meta: ResultMeta? = null,
 ) : ServerResult,
-    PaginatedResult
+    PaginatedResult,
+    CacheableResult {
+    init {
+        require(ttlMs >= 0) { "ttlMs must be non-negative, but was $ttlMs" }
+    }
+}

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/wire.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/wire.kt
@@ -1,0 +1,125 @@
+@file:OptIn(ExperimentalMcpApi::class)
+
+package io.modelcontextprotocol.kotlin.sdk.types
+
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
+import io.modelcontextprotocol.kotlin.sdk.InternalMcpApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlin.jvm.JvmInline
+
+/**
+ * A result already rendered to the shape it will occupy on the wire.
+ *
+ * Lets a [RequestResult] carry JSON that has already been rendered, so that a message rewritten on
+ * its way out still travels as a typed result. It serializes as exactly the object it wraps.
+ *
+ * @property json the result exactly as it will be sent
+ */
+@JvmInline
+@Serializable
+@InternalMcpApi
+public value class WireResult(public val json: JsonObject) :
+    ClientResult,
+    ServerResult {
+    override val meta: ResultMeta?
+        get() = (json["_meta"] as? JsonObject)?.let(::ResultMeta)
+}
+
+/** Result fields introduced by the request-scoped lifecycle, which no earlier peer understands. */
+private val REQUEST_SCOPED_RESULT_KEYS: Set<String> = setOf("resultType", "ttlMs", "cacheScope")
+
+/**
+ * Renders an encoded result for the lifecycle it is being sent under.
+ *
+ * On [ProtocolEra.Legacy] the request-scoped fields are removed. On [ProtocolEra.Modern] the server
+ * identifies itself in `_meta`, unless [serverInfo] is `null` or the result already names one — an
+ * identity a handler wrote wins over the automatic one.
+ */
+internal fun encodeOutboundResult(era: ProtocolEra, json: JsonObject, serverInfo: Implementation?): JsonObject =
+    when (era) {
+        ProtocolEra.Legacy -> JsonObject(json.filterKeys { it !in REQUEST_SCOPED_RESULT_KEYS })
+        ProtocolEra.Modern -> json.withServerInfoStamp(serverInfo)
+    }
+
+private fun JsonObject.withServerInfoStamp(serverInfo: Implementation?): JsonObject {
+    if (serverInfo == null) return this
+    val meta = (this["_meta"] as? JsonObject).orEmpty()
+    if (SERVER_INFO_META_KEY in meta) return this
+    val stamped = JsonObject(meta + (SERVER_INFO_META_KEY to McpJson.encodeToJsonElement(serverInfo)))
+    return JsonObject(this + ("_meta" to stamped))
+}
+
+/**
+ * The error code to put on the wire for a locally raised [code].
+ *
+ * Retired codes are never emitted: `-32002` (resource not found) travels as invalid params under
+ * either lifecycle, and `-32042` survives only where URL elicitation does.
+ */
+@Suppress("DEPRECATION")
+internal fun outboundErrorCode(era: ProtocolEra, code: Int): Int = when {
+    code == RPCError.ErrorCode.RESOURCE_NOT_FOUND -> RPCError.ErrorCode.INVALID_PARAMS
+
+    era == ProtocolEra.Modern && code == RPCError.ErrorCode.URL_ELICITATION_REQUIRED ->
+        RPCError.ErrorCode.INTERNAL_ERROR
+
+    else -> code
+}
+
+/**
+ * The `resultType` this result declares, or `null` when it declares none.
+ *
+ * `resultType` is declared per concrete result rather than on [RequestResult], because
+ * [EmptyResult] has to be able to omit it. Results that wrap opaque JSON report whatever that JSON
+ * says, if anything.
+ */
+@OptIn(InternalMcpApi::class)
+internal val RequestResult.resultTypeOrNull: String?
+    get() = when (this) {
+        is EmptyResult -> resultType
+        is InitializeResult -> resultType
+        is DiscoverResult -> resultType
+        is CompleteResult -> resultType
+        is ListToolsResult -> resultType
+        is CallToolResult -> resultType
+        is ListPromptsResult -> resultType
+        is GetPromptResult -> resultType
+        is ListResourcesResult -> resultType
+        is ReadResourceResult -> resultType
+        is ListResourceTemplatesResult -> resultType
+        is ListRootsResult -> resultType
+        is CreateMessageResult -> resultType
+        is ElicitResult -> resultType
+        is CreateTaskResult -> resultType
+        is GetTaskResult -> resultType
+        is ListTasksResult -> resultType
+        is GetTaskPayloadResult -> json.resultTypeString()
+        is WireResult -> json.resultTypeString()
+    }
+
+private fun JsonObject.resultTypeString(): String? = (this["resultType"] as? JsonPrimitive)
+    ?.takeIf { it.isString }
+    ?.content
+
+/**
+ * Rejects a result whose `resultType` this SDK does not recognize.
+ *
+ * Checked on [ProtocolEra.Modern] only, where an unknown value means the peer is describing a
+ * result shape this SDK cannot interpret; reading it as [COMPLETE_RESULT_TYPE] would hand the caller
+ * a partial answer as though it were the whole one. An absent `resultType` always means
+ * [COMPLETE_RESULT_TYPE].
+ *
+ * @throws McpException if [era] is [ProtocolEra.Modern] and [result] declares an unknown `resultType`
+ */
+internal fun checkInboundResult(era: ProtocolEra, result: RequestResult) {
+    if (era != ProtocolEra.Modern) return
+    val declared = result.resultTypeOrNull ?: return
+    if (declared != COMPLETE_RESULT_TYPE) {
+        throw McpException(
+            code = RPCError.ErrorCode.INVALID_PARAMS,
+            message = "Unrecognized resultType \"$declared\"",
+        )
+    }
+}

--- a/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/wire.kt
+++ b/kotlin-sdk-core/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/types/wire.kt
@@ -56,11 +56,16 @@ private fun JsonObject.withServerInfoStamp(serverInfo: Implementation?): JsonObj
  * The error code to put on the wire for a locally raised [code].
  *
  * Retired codes are never emitted: `-32002` (resource not found) travels as invalid params under
- * either lifecycle, and `-32042` survives only where URL elicitation does.
+ * either lifecycle, and `-32042` survives only where URL elicitation does. Local-only codes are
+ * never emitted either: a timeout or connection failure of this side's own nested call must not
+ * read to the peer as its counterparty's verdict.
  */
 @Suppress("DEPRECATION")
 internal fun outboundErrorCode(era: ProtocolEra, code: Int): Int = when {
     code == RPCError.ErrorCode.RESOURCE_NOT_FOUND -> RPCError.ErrorCode.INVALID_PARAMS
+
+    code == RPCError.ErrorCode.REQUEST_TIMEOUT || code == RPCError.ErrorCode.CONNECTION_CLOSED ->
+        RPCError.ErrorCode.INTERNAL_ERROR
 
     era == ProtocolEra.Modern && code == RPCError.ErrorCode.URL_ELICITATION_REQUIRED ->
         RPCError.ErrorCode.INTERNAL_ERROR

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/shared/ProtocolOutboundCancellationTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/shared/ProtocolOutboundCancellationTest.kt
@@ -13,7 +13,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.InitializeRequest
 import io.modelcontextprotocol.kotlin.sdk.types.InitializeRequestParams
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCNotification
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCResponse
-import io.modelcontextprotocol.kotlin.sdk.types.LATEST_PROTOCOL_VERSION
+import io.modelcontextprotocol.kotlin.sdk.types.LATEST_HANDSHAKE_VERSION
 import io.modelcontextprotocol.kotlin.sdk.types.McpException
 import io.modelcontextprotocol.kotlin.sdk.types.McpJson
 import io.modelcontextprotocol.kotlin.sdk.types.Method
@@ -123,7 +123,7 @@ class ProtocolOutboundCancellationTest {
             protocol.request<EmptyResult>(
                 InitializeRequest(
                     InitializeRequestParams(
-                        protocolVersion = LATEST_PROTOCOL_VERSION,
+                        protocolVersion = LATEST_HANDSHAKE_VERSION,
                         capabilities = ClientCapabilities(),
                         clientInfo = Implementation(name = "t", version = "1"),
                     ),

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/CacheableResultTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/CacheableResultTest.kt
@@ -1,0 +1,100 @@
+package io.modelcontextprotocol.kotlin.sdk.types
+
+import io.kotest.matchers.shouldBe
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+
+@OptIn(ExperimentalMcpApi::class)
+class CacheableResultTest {
+
+    private fun cacheableResults(ttlMs: Long = 0, cacheScope: CacheScope = CacheScope.Private) =
+        listOf<CacheableResult>(
+            DiscoverResult(
+                supportedVersions = MODERN_PROTOCOL_VERSIONS,
+                capabilities = ServerCapabilities(),
+                ttlMs = ttlMs,
+                cacheScope = cacheScope,
+            ),
+            ListToolsResult(tools = emptyList(), ttlMs = ttlMs, cacheScope = cacheScope),
+            ListPromptsResult(prompts = emptyList(), ttlMs = ttlMs, cacheScope = cacheScope),
+            ListResourcesResult(resources = emptyList(), ttlMs = ttlMs, cacheScope = cacheScope),
+            ListResourceTemplatesResult(
+                resourceTemplates = emptyList(),
+                ttlMs = ttlMs,
+                cacheScope = cacheScope,
+            ),
+            ReadResourceResult(contents = emptyList(), ttlMs = ttlMs, cacheScope = cacheScope),
+        )
+
+    @Test
+    fun `the cacheable results should be exactly the six the spec names`() {
+        cacheableResults().map { it::class.simpleName }.toSet() shouldBe setOf(
+            "DiscoverResult",
+            "ListToolsResult",
+            "ListPromptsResult",
+            "ListResourcesResult",
+            "ListResourceTemplatesResult",
+            "ReadResourceResult",
+        )
+    }
+
+    @Test
+    fun `a result that sets no hint should be immediately stale and private`() {
+        // The conservative reading: a handler that says nothing must not accidentally authorize a
+        // shared cache to hand its answer to another principal.
+        cacheableResults().forEach { result ->
+            result.ttlMs shouldBe 0
+            result.cacheScope shouldBe CacheScope.Private
+        }
+    }
+
+    @Test
+    fun `a negative freshness window should be refused at construction`() {
+        assertFailsWith<IllegalArgumentException> {
+            DiscoverResult(MODERN_PROTOCOL_VERSIONS, ServerCapabilities(), ttlMs = -1)
+        }
+        assertFailsWith<IllegalArgumentException> { ListToolsResult(tools = emptyList(), ttlMs = -1) }
+        assertFailsWith<IllegalArgumentException> { ListPromptsResult(prompts = emptyList(), ttlMs = -1) }
+        assertFailsWith<IllegalArgumentException> { ListResourcesResult(resources = emptyList(), ttlMs = -1) }
+        assertFailsWith<IllegalArgumentException> {
+            ListResourceTemplatesResult(resourceTemplates = emptyList(), ttlMs = -1)
+        }
+        assertFailsWith<IllegalArgumentException> { ReadResourceResult(contents = emptyList(), ttlMs = -1) }
+    }
+
+    @Test
+    fun `hints should survive a round trip`() {
+        cacheableResults(ttlMs = 250, cacheScope = CacheScope.Public).forEach { result ->
+            // Encoded through RequestResult: CacheableResult is a read-side marker, and results
+            // reach the wire through the result hierarchy's own polymorphic serializer.
+            val encoded = McpJson.encodeToString<RequestResult>(result)
+            val decoded = McpJson.decodeFromString<RequestResult>(encoded)
+
+            val cacheable = assertIs<CacheableResult>(decoded)
+            cacheable.ttlMs shouldBe 250
+            cacheable.cacheScope shouldBe CacheScope.Public
+        }
+    }
+
+    @Test
+    fun `a receiver should tolerate hints the peer left out`() {
+        val terse = mapOf(
+            """{"tools": []}""" to "ListToolsResult",
+            """{"prompts": []}""" to "ListPromptsResult",
+            """{"resources": []}""" to "ListResourcesResult",
+            """{"resourceTemplates": []}""" to "ListResourceTemplatesResult",
+            """{"contents": []}""" to "ReadResourceResult",
+        )
+
+        terse.forEach { (wire, expected) ->
+            val decoded = McpJson.decodeFromString<ServerResult>(wire)
+
+            decoded::class.simpleName shouldBe expected
+            val cacheable = assertIs<CacheableResult>(decoded)
+            cacheable.ttlMs shouldBe 0
+            cacheable.cacheScope shouldBe CacheScope.Private
+        }
+    }
+}

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/CommonTypeTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/CommonTypeTest.kt
@@ -14,13 +14,17 @@ class CommonTypeTest {
 
     @Test
     fun `should have correct latest protocol version`() {
-        LATEST_PROTOCOL_VERSION shouldBe "2025-11-25"
+        LATEST_PROTOCOL_VERSION shouldBe "2026-07-28"
+        LATEST_HANDSHAKE_VERSION shouldBe "2025-11-25"
+        LATEST_MODERN_VERSION shouldBe "2026-07-28"
     }
 
     @Test
     fun `should have correct supported protocol versions`() {
+        @Suppress("DEPRECATION")
         SUPPORTED_PROTOCOL_VERSIONS shouldContainExactlyInAnyOrder listOf(
-            LATEST_PROTOCOL_VERSION,
+            "2026-07-28",
+            "2025-11-25",
             "2025-06-18",
             "2025-03-26",
             "2024-11-05",

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/CompletionTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/CompletionTest.kt
@@ -149,9 +149,11 @@ class CompletionTest {
                 total = 25,
                 hasMore = true,
             ),
-            meta = buildJsonObject {
-                put("source", "cache")
-            },
+            meta = ResultMeta(
+                buildJsonObject {
+                    put("source", "cache")
+                },
+            ),
         )
 
         verifySerialization(
@@ -167,6 +169,7 @@ class CompletionTest {
                 "total": 25,
                 "hasMore": true
               },
+              "resultType": "complete",
               "_meta": {
                 "source": "cache"
               }
@@ -184,6 +187,7 @@ class CompletionTest {
                 "total": 2,
                 "hasMore": false
               },
+              "resultType": "complete",
               "_meta": {
                 "fetchedAt": "2025-01-12T15:00:58Z"
               }
@@ -213,7 +217,8 @@ class CompletionTest {
             {
               "completion": {
                 "values": ["foo"]
-              }
+              },
+              "resultType": "complete"
             }
         """.trimIndent()
 

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/DiscoveryTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/DiscoveryTest.kt
@@ -2,6 +2,7 @@ package io.modelcontextprotocol.kotlin.sdk.types
 
 import io.kotest.assertions.json.shouldEqualJson
 import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlin.test.Test
@@ -38,9 +39,9 @@ class DiscoveryTest {
 
         val discover = assertIs<DiscoverRequest>(request)
         assertEquals(Method.Defined.ServerDiscover, discover.method)
-        assertEquals("2026-07-28", discover.meta.protocolVersion)
-        assertEquals("test-client", discover.meta.clientInfo?.name)
-        assertEquals(ClientCapabilities(), discover.meta.clientCapabilities)
+        assertEquals("2026-07-28", discover.params.meta.toEnvelope().protocolVersion)
+        assertEquals("test-client", discover.params.meta.toEnvelope().clientInfo?.name)
+        assertEquals(ClientCapabilities(), discover.params.meta.toEnvelope().clientCapabilities)
     }
 
     @Test
@@ -61,10 +62,10 @@ class DiscoveryTest {
         )
 
         val discover = assertIs<DiscoverRequest>(request)
-        assertEquals("2026-07-28", discover.meta.protocolVersion)
-        assertEquals(ClientCapabilities(), discover.meta.clientCapabilities)
-        assertNull(discover.meta.clientInfo)
-        assertNotNull(discover.meta["com.example/traceId"])
+        assertEquals("2026-07-28", discover.params.meta.toEnvelope().protocolVersion)
+        assertEquals(ClientCapabilities(), discover.params.meta.toEnvelope().clientCapabilities)
+        assertNull(discover.params.meta.toEnvelope().clientInfo)
+        assertNotNull(discover.params.meta["com.example/traceId"])
         McpJson.encodeToString<Request>(discover) shouldEqualJson """
             {
               "method": "server/discover",
@@ -80,30 +81,40 @@ class DiscoveryTest {
     }
 
     @Test
-    fun `should reject discovery requests without required request metadata`() {
-        val invalidParams = listOf(
-            "{}" to "_meta",
-            """{"_meta": {}}""" to RequestMetaKeys.PROTOCOL_VERSION,
+    fun `should reject discovery requests without request metadata`() {
+        val failure = assertFails {
+            McpJson.decodeFromString<Request>("""{"method": "server/discover", "params": {}}""")
+        }
+
+        assertTrue(
+            failure.message.orEmpty().contains("_meta"),
+            "Expected failure to identify the missing _meta, but was: $failure",
+        )
+    }
+
+    @Test
+    fun `should decode a discovery request whose envelope is incomplete and report it on read`() {
+        val incompleteEnvelopes = listOf(
+            "{}" to PROTOCOL_VERSION_META_KEY,
             """
                 {
-                  "_meta": {
-                    "${RequestMetaKeys.PROTOCOL_VERSION}": "2026-07-28",
-                    "${RequestMetaKeys.CLIENT_INFO}": {
-                      "name": "test-client",
-                      "version": "1.0.0"
-                    }
+                  "$PROTOCOL_VERSION_META_KEY": "2026-07-28",
+                  "$CLIENT_INFO_META_KEY": {
+                    "name": "test-client",
+                    "version": "1.0.0"
                   }
                 }
-            """.trimIndent() to RequestMetaKeys.CLIENT_CAPABILITIES,
+            """.trimIndent() to CLIENT_CAPABILITIES_META_KEY,
         )
 
-        invalidParams.forEach { (params, missingField) ->
-            val failure = assertFails {
-                McpJson.decodeFromString<Request>(
-                    """{"method": "server/discover", "params": $params}""",
-                )
-            }
+        incompleteEnvelopes.forEach { (meta, missingField) ->
+            val request = McpJson.decodeFromString<Request>(
+                """{"method": "server/discover", "params": {"_meta": $meta}}""",
+            )
 
+            val discover = assertIs<DiscoverRequest>(request)
+            assertNull(discover.params.meta.toEnvelopeOrNull())
+            val failure = assertFailsWith<SerializationException> { discover.params.meta.toEnvelope() }
             assertTrue(
                 failure.message.orEmpty().contains(missingField),
                 "Expected failure to identify missing field $missingField, but was: $failure",
@@ -150,7 +161,7 @@ class DiscoveryTest {
                   "com.example/source": "edge"
                 }
                 """.trimIndent(),
-            ).jsonObject,
+            ).jsonObject.let(::ResultMeta),
         )
 
         McpJson.encodeToString<ServerResult>(result) shouldEqualJson """
@@ -176,26 +187,11 @@ class DiscoveryTest {
     }
 
     @Test
-    fun `should encode required defaults independently of McpJson`() {
-        val result = DiscoverResult(
-            supportedVersions = listOf("2026-07-28"),
-            capabilities = ServerCapabilities(),
-        )
-
-        Json.encodeToString(result) shouldEqualJson """
-            {
-              "supportedVersions": ["2026-07-28"],
-              "capabilities": {},
-              "resultType": "complete",
-              "ttlMs": 0,
-              "cacheScope": "private"
-            }
-        """.trimIndent()
-    }
-
-    @Test
-    fun `should reject discovery results without required cache fields`() {
-        val invalidResults = listOf(
+    fun `should read absent cache fields as the conservative defaults`() {
+        // The cache hints and resultType carry construction defaults, so a receiver has to tolerate
+        // a peer that omits them rather than rejecting the whole result: the default reading —
+        // immediately stale, private, complete — is the safe one either way.
+        val terse = listOf(
             """
             {
               "supportedVersions": ["2026-07-28"],
@@ -210,28 +206,21 @@ class DiscoveryTest {
               "ttlMs": 0
             }
             """.trimIndent(),
-        )
-
-        invalidResults.forEach { wire ->
-            assertFails { McpJson.decodeFromString<DiscoverResult>(wire) }
-            assertFails { McpJson.decodeFromString<ServerResult>(wire) }
-        }
-    }
-
-    @Test
-    fun `should use complete when a discovery result omits resultType`() {
-        val result = McpJson.decodeFromString<ServerResult>(
             """
             {
               "supportedVersions": ["2026-07-28"],
-              "capabilities": {},
-              "ttlMs": 0,
-              "cacheScope": "private"
+              "capabilities": {}
             }
             """.trimIndent(),
         )
 
-        assertEquals(COMPLETE_RESULT_TYPE, assertIs<DiscoverResult>(result).resultType)
+        terse.forEach { wire ->
+            val result = assertIs<DiscoverResult>(McpJson.decodeFromString<ServerResult>(wire))
+
+            assertEquals(0, result.ttlMs)
+            assertEquals(CacheScope.Private, result.cacheScope)
+            assertEquals(COMPLETE_RESULT_TYPE, result.resultType)
+        }
     }
 
     @Test

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/ElicitationTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/ElicitationTest.kt
@@ -215,9 +215,11 @@ class ElicitationTest {
                 put("stars", 128)
                 put("private", false)
             },
-            meta = buildJsonObject {
-                put("submittedAt", "2025-01-12T15:00:58Z")
-            },
+            meta = ResultMeta(
+                buildJsonObject {
+                    put("submittedAt", "2025-01-12T15:00:58Z")
+                },
+            ),
         )
 
         val json = McpJson.encodeToString(result)
@@ -230,6 +232,7 @@ class ElicitationTest {
                 "stars": 128,
                 "private": false
               },
+              "resultType": "complete",
               "_meta": {
                 "submittedAt": "2025-01-12T15:00:58Z"
               }
@@ -253,6 +256,7 @@ class ElicitationTest {
         val json = """
             {
               "action": "decline",
+              "resultType": "complete",
               "_meta": {
                 "reason": "User skipped"
               }

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/EnvelopeTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/EnvelopeTest.kt
@@ -1,0 +1,492 @@
+package io.modelcontextprotocol.kotlin.sdk.types
+
+import io.kotest.assertions.json.shouldEqualJson
+import io.kotest.matchers.shouldBe
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalMcpApi::class)
+class EnvelopeTest {
+
+    private val capabilities = ClientCapabilities(sampling = ClientCapabilities.Sampling())
+    private val clientInfo = Implementation(name = "envelope-client", version = "1.0.0")
+
+    private fun metaOf(json: String) = RequestMeta(Json.parseToJsonElement(json) as JsonObject)
+
+    @Test
+    fun `should render every envelope field into request metadata`() {
+        val meta = RequestEnvelope(
+            protocolVersion = "2026-07-28",
+            clientCapabilities = capabilities,
+            clientInfo = clientInfo,
+            logLevel = LoggingLevel.Warning,
+        ).toMeta()
+
+        McpJson.encodeToString(meta) shouldEqualJson """
+            {
+              "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+              "io.modelcontextprotocol/clientCapabilities": {"sampling": {}},
+              "io.modelcontextprotocol/clientInfo": {
+                "name": "envelope-client",
+                "version": "1.0.0"
+              },
+              "io.modelcontextprotocol/logLevel": "warning"
+            }
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should omit absent optional envelope fields`() {
+        val meta = RequestEnvelope("2026-07-28", ClientCapabilities()).toMeta()
+
+        assertNull(meta[CLIENT_INFO_META_KEY])
+        assertNull(meta[LOG_LEVEL_META_KEY])
+        McpJson.encodeToString(meta) shouldEqualJson """
+            {
+              "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+              "io.modelcontextprotocol/clientCapabilities": {}
+            }
+        """.trimIndent()
+    }
+
+    @Test
+    fun `should preserve unrelated base metadata entries`() {
+        val base = RequestMeta(
+            buildJsonObject {
+                put("progressToken", "token-1")
+                put("com.example/traceId", "trace-123")
+            },
+        )
+
+        val meta = RequestEnvelope("2026-07-28", ClientCapabilities()).toMeta(base)
+
+        meta.progressToken shouldBe ProgressToken("token-1")
+        meta["com.example/traceId"] shouldBe base["com.example/traceId"]
+        meta.claimedProtocolVersion shouldBe "2026-07-28"
+    }
+
+    @Test
+    fun `should replace protocol entries already present in the base`() {
+        val base = RequestEnvelope(
+            protocolVersion = "2025-11-25",
+            clientCapabilities = capabilities,
+            clientInfo = clientInfo,
+            logLevel = LoggingLevel.Debug,
+        ).toMeta()
+
+        val meta = RequestEnvelope("2026-07-28", ClientCapabilities()).toMeta(base)
+
+        meta.toEnvelope() shouldBe RequestEnvelope("2026-07-28", ClientCapabilities())
+        assertNull(meta[CLIENT_INFO_META_KEY])
+        assertNull(meta[LOG_LEVEL_META_KEY])
+    }
+
+    @Test
+    fun `should round trip an envelope through request metadata`() {
+        val envelope = RequestEnvelope("2026-07-28", capabilities, clientInfo, LoggingLevel.Warning)
+
+        envelope.toMeta().toEnvelope() shouldBe envelope
+    }
+
+    @Test
+    fun `should read an envelope alongside unrelated metadata entries`() {
+        val meta = metaOf(
+            """
+            {
+              "progressToken": "token-1",
+              "com.example/traceId": "trace-123",
+              "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+              "io.modelcontextprotocol/clientCapabilities": {"roots": {}}
+            }
+            """.trimIndent(),
+        )
+
+        meta.toEnvelope() shouldBe RequestEnvelope(
+            protocolVersion = "2026-07-28",
+            clientCapabilities = ClientCapabilities(roots = ClientCapabilities.Roots()),
+        )
+    }
+
+    @Test
+    fun `empty client capabilities should mean no optional capabilities`() {
+        val meta = metaOf(
+            """
+            {
+              "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+              "io.modelcontextprotocol/clientCapabilities": {}
+            }
+            """.trimIndent(),
+        )
+
+        meta.toEnvelope().clientCapabilities shouldBe ClientCapabilities()
+    }
+
+    @Test
+    fun `should read no envelope from metadata that predates the request scoped lifecycle`() {
+        val meta = metaOf("""{"progressToken": "token-1"}""")
+
+        assertNull(meta.toEnvelopeOrNull())
+        assertNull(meta.claimedProtocolVersion)
+    }
+
+    @Test
+    fun `should report the offending key when a required envelope field is absent`() {
+        val required = listOf(
+            """{"io.modelcontextprotocol/clientCapabilities": {}}""" to PROTOCOL_VERSION_META_KEY,
+            """{"io.modelcontextprotocol/protocolVersion": "2026-07-28"}""" to CLIENT_CAPABILITIES_META_KEY,
+        )
+
+        required.forEach { (json, missingKey) ->
+            val meta = metaOf(json)
+
+            assertNull(meta.toEnvelopeOrNull())
+            val failure = assertFailsWith<SerializationException> { meta.toEnvelope() }
+            assertTrue(
+                failure.message.orEmpty().contains(missingKey),
+                "Expected failure to name $missingKey, but was: $failure",
+            )
+        }
+    }
+
+    @Test
+    fun `should report the offending key when an envelope field has the wrong json kind`() {
+        val illTyped = listOf(
+            PROTOCOL_VERSION_META_KEY to "{}",
+            PROTOCOL_VERSION_META_KEY to "null",
+            CLIENT_INFO_META_KEY to "\"not-an-implementation\"",
+            CLIENT_CAPABILITIES_META_KEY to "\"not-capabilities\"",
+            CLIENT_CAPABILITIES_META_KEY to "[]",
+            CLIENT_CAPABILITIES_META_KEY to "null",
+        )
+
+        illTyped.forEach { (key, value) ->
+            val meta = envelopeMetaWith(key, value)
+
+            assertNull(meta.toEnvelopeOrNull())
+            val failure = assertFailsWith<SerializationException> { meta.toEnvelope() }
+            assertTrue(
+                failure.message.orEmpty().contains(key),
+                "Expected failure to name $key, but was: $failure",
+            )
+        }
+    }
+
+    @Test
+    fun `should report what a well typed but out of domain envelope value violates`() {
+        val outOfDomain = listOf(
+            Triple(CLIENT_INFO_META_KEY, """{"name":"missing-version"}""", "version"),
+            Triple(LOG_LEVEL_META_KEY, "\"verbose\"", "verbose"),
+            Triple(LOG_LEVEL_META_KEY, "7", "7"),
+        )
+
+        outOfDomain.forEach { (key, value, expected) ->
+            val meta = envelopeMetaWith(key, value)
+
+            assertNull(meta.toEnvelopeOrNull())
+            val failure = assertFailsWith<SerializationException> { meta.toEnvelope() }
+            assertTrue(
+                failure.message.orEmpty().contains(expected),
+                "Expected failure to name $expected, but was: $failure",
+            )
+        }
+    }
+
+    private fun envelopeMetaWith(key: String, value: String) = metaOf(
+        """
+        {
+          "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+          "io.modelcontextprotocol/clientCapabilities": {},
+          "$key": $value
+        }
+        """.trimIndent(),
+    )
+
+    @Test
+    fun `should read a claimed protocol version without validating the rest of the envelope`() {
+        val meta = metaOf("""{"io.modelcontextprotocol/protocolVersion": "2026-07-28"}""")
+
+        meta.claimedProtocolVersion shouldBe "2026-07-28"
+        assertNull(meta.toEnvelopeOrNull())
+    }
+
+    @Test
+    fun `should read no claimed protocol version from a non string claim`() {
+        assertNull(metaOf("""{"io.modelcontextprotocol/protocolVersion": {}}""").claimedProtocolVersion)
+        assertNull(metaOf("""{"io.modelcontextprotocol/protocolVersion": 2026}""").claimedProtocolVersion)
+    }
+
+    @Test
+    fun `should read server info from result metadata`() {
+        val meta = ResultMeta(
+            Json.parseToJsonElement(
+                """
+                {
+                  "io.modelcontextprotocol/serverInfo": {"name": "test-server", "version": "2.0.0"},
+                  "com.example/source": "edge"
+                }
+                """.trimIndent(),
+            ) as JsonObject,
+        )
+
+        meta.serverInfo shouldBe Implementation(name = "test-server", version = "2.0.0")
+    }
+
+    @Test
+    fun `should read no server info when the result carries none`() {
+        assertNull(ResultMeta(buildJsonObject { put("com.example/source", "edge") }).serverInfo)
+    }
+
+    @Test
+    fun `should reject malformed server info`() {
+        val meta = ResultMeta(buildJsonObject { put(SERVER_INFO_META_KEY, "not-an-implementation") })
+
+        assertFailsWith<SerializationException> { meta.serverInfo }
+    }
+
+    @Test
+    fun `should write server info preserving unrelated result metadata`() {
+        val base = ResultMeta(buildJsonObject { put("com.example/source", "edge") })
+
+        val meta = base.withServerInfo(Implementation(name = "test-server", version = "2.0.0"))
+
+        meta.serverInfo shouldBe Implementation(name = "test-server", version = "2.0.0")
+        meta["com.example/source"] shouldBe base["com.example/source"]
+    }
+
+    @Test
+    fun `should replace a server info already present`() {
+        val base = ResultMeta(buildJsonObject { put("com.example/source", "edge") })
+            .withServerInfo(Implementation(name = "old", version = "1.0.0"))
+
+        val meta = base.withServerInfo(Implementation(name = "new", version = "2.0.0"))
+
+        meta.serverInfo shouldBe Implementation(name = "new", version = "2.0.0")
+    }
+
+    @Test
+    fun `should write server info onto absent result metadata`() {
+        val meta = null.withServerInfo(Implementation(name = "test-server", version = "2.0.0"))
+
+        meta.serverInfo shouldBe Implementation(name = "test-server", version = "2.0.0")
+    }
+
+    @Test
+    fun `should report every required capability as missing when nothing is declared`() {
+        val required = ClientCapabilities(
+            sampling = ClientCapabilities.Sampling(),
+            elicitation = ClientCapabilities.Elicitation(url = JsonObject(emptyMap())),
+        )
+
+        required.missingIn(null) shouldBe required
+        required.missingIn(ClientCapabilities()) shouldBe required
+    }
+
+    @Test
+    fun `should report nothing missing when every required capability is declared`() {
+        val required = ClientCapabilities(sampling = ClientCapabilities.Sampling())
+        val declared = ClientCapabilities(
+            sampling = ClientCapabilities.Sampling(tools = JsonObject(emptyMap())),
+            roots = ClientCapabilities.Roots(),
+        )
+
+        assertNull(required.missingIn(declared))
+    }
+
+    @Test
+    fun `should narrow a partially declared capability to its missing sub capabilities`() {
+        val required = ClientCapabilities(
+            sampling = ClientCapabilities.Sampling(
+                context = JsonObject(emptyMap()),
+                tools = JsonObject(emptyMap()),
+            ),
+        )
+        val declared = ClientCapabilities(
+            sampling = ClientCapabilities.Sampling(context = JsonObject(emptyMap())),
+        )
+
+        required.missingIn(declared) shouldBe ClientCapabilities(
+            sampling = ClientCapabilities.Sampling(tools = JsonObject(emptyMap())),
+        )
+    }
+
+    @Test
+    fun `a bare elicitation declaration should satisfy a form mode requirement`() {
+        val required = ClientCapabilities(elicitation = ClientCapabilities.Elicitation(form = JsonObject(emptyMap())))
+
+        assertNull(required.missingIn(ClientCapabilities(elicitation = ClientCapabilities.Elicitation())))
+    }
+
+    @Test
+    fun `a declaration naming a mode should not imply the other mode`() {
+        val required = ClientCapabilities(elicitation = ClientCapabilities.Elicitation(form = JsonObject(emptyMap())))
+        val declared = ClientCapabilities(elicitation = ClientCapabilities.Elicitation(url = JsonObject(emptyMap())))
+
+        required.missingIn(declared) shouldBe required
+    }
+
+    @Test
+    fun `should compare experimental and extension capabilities by key`() {
+        val required = ClientCapabilities(
+            experimental = buildJsonObject { put("com.example/alpha", JsonObject(emptyMap())) },
+            extensions = mapOf("com.example/beta" to JsonObject(emptyMap())),
+        )
+        val declared = ClientCapabilities(
+            experimental = buildJsonObject { put("com.example/alpha", JsonObject(emptyMap())) },
+        )
+
+        required.missingIn(declared) shouldBe ClientCapabilities(
+            extensions = mapOf("com.example/beta" to JsonObject(emptyMap())),
+        )
+    }
+
+    @Test
+    fun `should carry the missing capabilities in the error data`() {
+        val missing = ClientCapabilities(sampling = ClientCapabilities.Sampling())
+
+        McpJson.encodeToString(MissingRequiredClientCapabilityData(missing)) shouldEqualJson """
+            {"requiredCapabilities": {"sampling": {}}}
+        """.trimIndent()
+    }
+
+    @Test
+    fun `an intact envelope should report no problems`() {
+        val meta = RequestEnvelope("2026-07-28", capabilities, clientInfo, LoggingLevel.Warning).toMeta()
+
+        validateEnvelope(meta) shouldBe emptyList()
+    }
+
+    @Test
+    fun `a required key that is absent should be reported as missing`() {
+        validateEnvelope(metaOf("{}")) shouldBe listOf(
+            EnvelopeIssue(PROTOCOL_VERSION_META_KEY, "missing"),
+            EnvelopeIssue(CLIENT_CAPABILITIES_META_KEY, "missing"),
+        )
+    }
+
+    @Test
+    fun `every missing key should be reported at once`() {
+        // A peer that sent neither is told both, rather than being corrected one round trip at a time.
+        val meta = metaOf("""{"progressToken": "token-1"}""")
+
+        validateEnvelope(meta).map { it.key } shouldBe listOf(
+            PROTOCOL_VERSION_META_KEY,
+            CLIENT_CAPABILITIES_META_KEY,
+        )
+    }
+
+    @Test
+    fun `missing keys should be reported before malformed ones`() {
+        val meta = metaOf("""{"io.modelcontextprotocol/clientCapabilities": "not-capabilities"}""")
+
+        validateEnvelope(meta) shouldBe listOf(
+            EnvelopeIssue(PROTOCOL_VERSION_META_KEY, "missing"),
+            EnvelopeIssue(CLIENT_CAPABILITIES_META_KEY, "must be a client capabilities object"),
+        )
+    }
+
+    @Test
+    fun `a required key of the wrong shape should be reported`() {
+        listOf("{}", "[]", "7", "null", "true").forEach { value ->
+            validateEnvelope(envelopeMetaWith(PROTOCOL_VERSION_META_KEY, value)) shouldBe listOf(
+                EnvelopeIssue(PROTOCOL_VERSION_META_KEY, "must be a JSON string"),
+            )
+        }
+
+        listOf("\"nope\"", "[]", "7", "null", """{"sampling": 7}""").forEach { value ->
+            validateEnvelope(envelopeMetaWith(CLIENT_CAPABILITIES_META_KEY, value)) shouldBe listOf(
+                EnvelopeIssue(CLIENT_CAPABILITIES_META_KEY, "must be a client capabilities object"),
+            )
+        }
+    }
+
+    @Test
+    fun `an unknown protocol version should not be an envelope problem`() {
+        // Which versions are acceptable is a negotiation outcome answered with its own error code;
+        // the envelope is only asked whether it is shaped like an envelope.
+        validateEnvelope(envelopeMetaWith(PROTOCOL_VERSION_META_KEY, "\"1999-01-01\"")) shouldBe emptyList()
+    }
+
+    @Test
+    fun `a malformed client identity should never block a request`() {
+        // Identity is self-reported, unverified and for display only, and the revision says a
+        // receiver must not change its behaviour on account of it. Refusing to serve would be
+        // exactly that, so it reads as absent instead.
+        listOf(
+            "\"not-an-implementation\"",
+            """{"name": "missing-version"}""",
+            "7",
+            "null",
+        ).forEach { value ->
+            validateEnvelope(envelopeMetaWith(CLIENT_INFO_META_KEY, value)) shouldBe emptyList()
+        }
+    }
+
+    @Test
+    fun `a malformed log level should be an envelope problem`() {
+        // The revision has a server SHOULD answer -32602 for a level it does not recognize rather
+        // than guess: guessing either leaks messages the client never asked for, or drops ones it did.
+        listOf(
+            "\"verbose\"",
+            "\"warn\"",
+            "7",
+            "{}",
+        ).forEach { value ->
+            validateEnvelope(envelopeMetaWith(LOG_LEVEL_META_KEY, value)) shouldBe
+                listOf(EnvelopeIssue(LOG_LEVEL_META_KEY, "must be a known logging level"))
+        }
+    }
+
+    @Test
+    fun `a known log level should not be an envelope problem`() {
+        validateEnvelope(envelopeMetaWith(LOG_LEVEL_META_KEY, "\"warning\"")) shouldBe emptyList()
+    }
+
+    @Test
+    fun `the lenient reader should admit exactly what validation admits`() {
+        // The gate and the reader a receiver serves with have to agree: a request admitted by
+        // validateEnvelope must never then be served without the envelope it was admitted for.
+        listOf(
+            CLIENT_INFO_META_KEY to "\"not-an-implementation\"",
+            CLIENT_INFO_META_KEY to """{"name": "missing-version"}""",
+            CLIENT_INFO_META_KEY to "7",
+            LOG_LEVEL_META_KEY to "\"warning\"",
+            PROTOCOL_VERSION_META_KEY to "\"1999-01-01\"",
+        ).forEach { (key, value) ->
+            val meta = envelopeMetaWith(key, value)
+
+            validateEnvelope(meta) shouldBe emptyList()
+            assertTrue(
+                meta.toEnvelopeLenient() != null,
+                "Expected an envelope for $key = $value, which validation admitted",
+            )
+        }
+    }
+
+    @Test
+    fun `the lenient reader should degrade a malformed identity to absent`() {
+        val envelope = envelopeMetaWith(CLIENT_INFO_META_KEY, """{"name": "missing-version"}""")
+            .toEnvelopeLenient()
+
+        // The required fields survive: dropping them is what silently demoted the request to the
+        // connection-scoped lifecycle, taking its capabilities, version and log gating with it.
+        envelope?.protocolVersion shouldBe "2026-07-28"
+        envelope?.clientCapabilities shouldBe ClientCapabilities()
+        assertNull(envelope?.clientInfo)
+    }
+
+    @Test
+    fun `the lenient reader should refuse a missing or malformed required field`() {
+        assertNull(metaOf("""{"io.modelcontextprotocol/clientCapabilities": {}}""").toEnvelopeLenient())
+        assertNull(metaOf("""{"io.modelcontextprotocol/protocolVersion": "2026-07-28"}""").toEnvelopeLenient())
+        assertNull(envelopeMetaWith(CLIENT_CAPABILITIES_META_KEY, "\"nope\"").toEnvelopeLenient())
+        assertNull(envelopeMetaWith(PROTOCOL_VERSION_META_KEY, "7").toEnvelopeLenient())
+    }
+}

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/InitializeTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/InitializeTest.kt
@@ -149,7 +149,7 @@ class InitializeTest {
                 websiteUrl = "https://example.com/server",
             ),
             instructions = "Call the `read` tool to fetch files.",
-            meta = buildJsonObject { put("issuedAt", "2025-01-12T15:00:58Z") },
+            meta = ResultMeta(buildJsonObject { put("issuedAt", "2025-01-12T15:00:58Z") }),
         )
 
         verifySerialization(
@@ -180,6 +180,7 @@ class InitializeTest {
                 "websiteUrl": "https://example.com/server"
               },
               "instructions": "Call the `read` tool to fetch files.",
+              "resultType": "complete",
               "_meta": {
                 "issuedAt": "2025-01-12T15:00:58Z"
               }
@@ -210,7 +211,8 @@ class InitializeTest {
               "serverInfo": {
                 "name": "test-server",
                 "version": "1.0.0"
-              }
+              },
+              "resultType": "complete"
             }
             """.trimIndent(),
         )
@@ -230,7 +232,8 @@ class InitializeTest {
               "serverInfo": {
                 "name": "result-server",
                 "version": "4.0.0"
-              }
+              },
+              "resultType": "complete"
             }
         """.trimIndent()
 

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/JsonRpcTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/JsonRpcTest.kt
@@ -244,7 +244,7 @@ class JsonRpcTest {
         val response = JSONRPCResponse(
             id = RequestId("call-1"),
             result = EmptyResult(
-                meta = buildJsonObject { put("durationMs", 15) },
+                meta = ResultMeta(buildJsonObject { put("durationMs", 15) }),
             ),
         )
 

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/MethodEraTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/MethodEraTest.kt
@@ -1,0 +1,90 @@
+package io.modelcontextprotocol.kotlin.sdk.types
+
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class MethodEraTest {
+
+    @Test
+    fun `every defined method should declare where it exists`() {
+        Method.Defined.entries.forEach { method ->
+            assertTrue(method.eras.isNotEmpty(), "${method.value} declares no protocol era")
+        }
+    }
+
+    @Test
+    fun `the removed surface should be reachable only through the handshake`() {
+        val legacyOnly = setOf(
+            Method.Defined.Initialize,
+            Method.Defined.NotificationsInitialized,
+            Method.Defined.Ping,
+            Method.Defined.LoggingSetLevel,
+            Method.Defined.ResourcesSubscribe,
+            Method.Defined.ResourcesUnsubscribe,
+            Method.Defined.NotificationsResourcesUpdated,
+            Method.Defined.NotificationsRootsListChanged,
+            Method.Defined.NotificationsElicitationComplete,
+            Method.Defined.SamplingCreateMessage,
+            Method.Defined.RootsList,
+            Method.Defined.ElicitationCreate,
+            Method.Defined.TasksGet,
+            Method.Defined.TasksResult,
+            Method.Defined.TasksList,
+            Method.Defined.TasksCancel,
+            Method.Defined.NotificationsTasksStatus,
+        )
+
+        legacyOnly.forEach { method ->
+            assertTrue(method.isAvailableIn(ProtocolEra.Legacy), "${method.value} left the handshake era")
+            assertTrue(!method.isAvailableIn(ProtocolEra.Modern), "${method.value} survived into the modern era")
+        }
+    }
+
+    @Test
+    fun `discovery should exist only in the request-scoped lifecycle`() {
+        Method.Defined.ServerDiscover.isAvailableIn(ProtocolEra.Modern) shouldBe true
+        Method.Defined.ServerDiscover.isAvailableIn(ProtocolEra.Legacy) shouldBe false
+    }
+
+    @Test
+    fun `the surface that survived the transition should exist in both lifecycles`() {
+        val both = setOf(
+            Method.Defined.ToolsList,
+            Method.Defined.ToolsCall,
+            Method.Defined.PromptsList,
+            Method.Defined.PromptsGet,
+            Method.Defined.ResourcesList,
+            Method.Defined.ResourcesTemplatesList,
+            Method.Defined.ResourcesRead,
+            Method.Defined.CompletionComplete,
+            Method.Defined.NotificationsCancelled,
+            Method.Defined.NotificationsProgress,
+            Method.Defined.NotificationsMessage,
+            Method.Defined.NotificationsToolsListChanged,
+            Method.Defined.NotificationsPromptsListChanged,
+            Method.Defined.NotificationsResourcesListChanged,
+        )
+
+        both.forEach { method ->
+            ProtocolEra.entries.forEach { era ->
+                assertTrue(method.isAvailableIn(era), "${method.value} is absent from $era")
+            }
+        }
+    }
+
+    @Test
+    fun `the eras should partition the method table`() {
+        val counted = Method.Defined.entries.groupingBy { it.eras }.eachCount()
+
+        counted.values.sum() shouldBe Method.Defined.entries.size
+    }
+
+    @Test
+    fun `a custom method should route in either lifecycle`() {
+        // The protocol says nothing about methods it does not define, so no revision removed them.
+        val custom = Method.Custom("com.example/doThing")
+
+        ProtocolEra.entries.forEach { era -> custom.isAvailableIn(era) shouldBe true }
+    }
+}

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/PromptsTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/PromptsTest.kt
@@ -296,7 +296,7 @@ class PromptsTest {
                 ),
             ),
             description = "Executive summary response template.",
-            meta = buildJsonObject { put("generatedAt", "2025-01-12T15:00:58Z") },
+            meta = ResultMeta(buildJsonObject { put("generatedAt", "2025-01-12T15:00:58Z") }),
         )
 
         verifySerialization(
@@ -308,19 +308,20 @@ class PromptsTest {
                 {
                   "role": "user",
                   "content": {
-                    "type": "text",
-                    "text": "Use concise language suitable for executives."
+                    "text": "Use concise language suitable for executives.",
+                    "type": "text"
                   }
                 },
                 {
                   "role": "assistant",
                   "content": {
-                    "type": "text",
-                    "text": "Here is the summary you requested."
+                    "text": "Here is the summary you requested.",
+                    "type": "text"
                   }
                 }
               ],
               "description": "Executive summary response template.",
+              "resultType": "complete",
               "_meta": {
                 "generatedAt": "2025-01-12T15:00:58Z"
               }
@@ -337,12 +338,13 @@ class PromptsTest {
                 {
                   "role": "user",
                   "content": {
-                    "type": "text",
-                    "text": "Summarize today's standup."
+                    "text": "Summarize today's standup.",
+                    "type": "text"
                   }
                 }
               ],
-              "description": "Collect information from the team."
+              "description": "Collect information from the team.",
+              "resultType": "complete"
             }
         """.trimIndent()
 
@@ -408,7 +410,7 @@ class PromptsTest {
                 Prompt(name = "incident-response"),
             ),
             nextCursor = "cursor-2",
-            meta = buildJsonObject { put("page", 1) },
+            meta = ResultMeta(buildJsonObject { put("page", 1) }),
         )
 
         verifySerialization(
@@ -421,6 +423,9 @@ class PromptsTest {
                 {"name": "incident-response"}
               ],
               "nextCursor": "cursor-2",
+              "resultType": "complete",
+              "ttlMs": 0,
+              "cacheScope": "private",
               "_meta": {
                 "page": 1
               }
@@ -446,6 +451,9 @@ class PromptsTest {
                 }
               ],
               "nextCursor": "cursor-next",
+              "resultType": "complete",
+              "ttlMs": 0,
+              "cacheScope": "private",
               "_meta": {
                 "page": 2,
                 "latencyMs": 12.5

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/ProtocolVersionsTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/ProtocolVersionsTest.kt
@@ -1,0 +1,82 @@
+package io.modelcontextprotocol.kotlin.sdk.types
+
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ProtocolVersionsTest {
+
+    @Test
+    fun `every revision should belong to exactly one lifecycle`() {
+        (HANDSHAKE_PROTOCOL_VERSIONS + MODERN_PROTOCOL_VERSIONS) shouldContainExactly KNOWN_PROTOCOL_VERSIONS
+        HANDSHAKE_PROTOCOL_VERSIONS.intersect(MODERN_PROTOCOL_VERSIONS.toSet()).shouldBeEmptySet()
+    }
+
+    @Test
+    fun `each latest constant should be the newest of its lifecycle`() {
+        LATEST_PROTOCOL_VERSION shouldBe KNOWN_PROTOCOL_VERSIONS.last()
+        LATEST_HANDSHAKE_VERSION shouldBe HANDSHAKE_PROTOCOL_VERSIONS.last()
+        LATEST_MODERN_VERSION shouldBe MODERN_PROTOCOL_VERSIONS.last()
+    }
+
+    @Test
+    fun `the handshake default should stay reachable through the handshake`() {
+        assertTrue(DEFAULT_NEGOTIATED_PROTOCOL_VERSION in HANDSHAKE_PROTOCOL_VERSIONS)
+    }
+
+    @Test
+    fun `the deprecated union should still name every known revision`() {
+        @Suppress("DEPRECATION")
+        SUPPORTED_PROTOCOL_VERSIONS.toSet() shouldBe KNOWN_PROTOCOL_VERSIONS.toSet()
+    }
+
+    @Test
+    fun `should order revisions by release rather than alphabetically`() {
+        KNOWN_PROTOCOL_VERSIONS.forEachIndexed { index, version ->
+            KNOWN_PROTOCOL_VERSIONS.take(index + 1).forEach { older ->
+                assertTrue(
+                    isVersionAtLeast(version, older),
+                    "$version should be at least as new as $older",
+                )
+            }
+            KNOWN_PROTOCOL_VERSIONS.drop(index + 1).forEach { newer ->
+                assertFalse(
+                    isVersionAtLeast(version, newer),
+                    "$version should not be as new as $newer",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `an unrecognized revision should compare as older than anything known`() {
+        // Comparing as strings would put "zzz" and "9999-01-01" ahead of every real revision, which
+        // is how a peer sending nonsense would talk its way into features it cannot speak.
+        listOf("zzz", "9999-01-01", "", "2026-07-29").forEach { unknown ->
+            assertFalse(isVersionAtLeast(unknown, KNOWN_PROTOCOL_VERSIONS.first()))
+            assertFalse(isVersionAtLeast(unknown, LATEST_PROTOCOL_VERSION))
+        }
+    }
+
+    @Test
+    fun `should refuse to compare against a revision it does not know`() {
+        val failure = assertFailsWith<IllegalArgumentException> {
+            isVersionAtLeast(LATEST_PROTOCOL_VERSION, "2027-01-01")
+        }
+
+        assertTrue(failure.message.orEmpty().contains("2027-01-01"))
+    }
+
+    @Test
+    fun `only the request-scoped revisions should read as modern`() {
+        KNOWN_PROTOCOL_VERSIONS.forEach { version ->
+            isModernProtocolVersion(version) shouldBe (version in MODERN_PROTOCOL_VERSIONS)
+        }
+        assertFalse(isModernProtocolVersion("2027-01-01"))
+    }
+
+    private fun Set<String>.shouldBeEmptySet() = this shouldBe emptySet()
+}

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/RequestTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/RequestTest.kt
@@ -5,8 +5,6 @@ import io.kotest.matchers.shouldBe
 import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
 import io.modelcontextprotocol.kotlin.test.utils.verifyDeserialization
 import io.modelcontextprotocol.kotlin.test.utils.verifySerialization
-import kotlinx.serialization.SerializationException
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.double
@@ -14,16 +12,13 @@ import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 class RequestTest {
 
     @OptIn(ExperimentalMcpApi::class)
-    @Suppress("DEPRECATION")
     @Test
     fun `should decode typed request metadata without discarding extensions`() {
         val request = McpJson.decodeFromString<Request>(
@@ -51,56 +46,13 @@ class RequestTest {
 
         val listTools = assertIs<ListToolsRequest>(request)
         val meta = assertNotNull(listTools.params?.meta)
-        meta.protocolVersion shouldBe "2026-07-28"
-        meta.clientInfo shouldBe Implementation(name = "wire-client", version = "1.2.3")
-        assertNotNull(meta.clientCapabilities?.sampling)
-        meta.logLevel shouldBe LoggingLevel.Warning
+        val envelope = meta.toEnvelope()
+        envelope.protocolVersion shouldBe "2026-07-28"
+        envelope.clientInfo shouldBe Implementation(name = "wire-client", version = "1.2.3")
+        assertNotNull(envelope.clientCapabilities.sampling)
+        envelope.logLevel shouldBe LoggingLevel.Warning
         meta["com.example/traceId"]?.jsonPrimitive?.content shouldBe "trace-123"
-        assertNotNull(meta.json[RequestMetaKeys.CLIENT_CAPABILITIES]?.let { it as? JsonObject })
-    }
-
-    @OptIn(ExperimentalMcpApi::class)
-    @Test
-    fun `empty client capabilities should mean no optional capabilities`() {
-        val json = Json.parseToJsonElement(
-            """{"${RequestMetaKeys.CLIENT_CAPABILITIES}": {}}""",
-        ) as JsonObject
-
-        RequestMeta(json).clientCapabilities shouldBe ClientCapabilities()
-    }
-
-    @OptIn(ExperimentalMcpApi::class)
-    @Suppress("DEPRECATION")
-    @Test
-    fun `typed request metadata should reject malformed fields`() {
-        val malformedValues = listOf(
-            RequestMetaKeys.PROTOCOL_VERSION to "{}",
-            RequestMetaKeys.PROTOCOL_VERSION to "null",
-            RequestMetaKeys.CLIENT_INFO to "\"not-an-implementation\"",
-            RequestMetaKeys.CLIENT_INFO to "{\"name\":\"missing-version\"}",
-            RequestMetaKeys.CLIENT_INFO to "null",
-            RequestMetaKeys.CLIENT_CAPABILITIES to "\"not-capabilities\"",
-            RequestMetaKeys.CLIENT_CAPABILITIES to "[]",
-            RequestMetaKeys.CLIENT_CAPABILITIES to "null",
-            RequestMetaKeys.LOG_LEVEL to "\"verbose\"",
-            RequestMetaKeys.LOG_LEVEL to "7",
-            RequestMetaKeys.LOG_LEVEL to "null",
-        )
-
-        malformedValues.forEach { (key, value) ->
-            val json = Json.parseToJsonElement("""{"$key":$value}""") as JsonObject
-            val meta = RequestMeta(json)
-
-            val failure = assertFailsWith<SerializationException> {
-                when (key) {
-                    RequestMetaKeys.PROTOCOL_VERSION -> meta.protocolVersion
-                    RequestMetaKeys.CLIENT_INFO -> meta.clientInfo
-                    RequestMetaKeys.CLIENT_CAPABILITIES -> meta.clientCapabilities
-                    else -> meta.logLevel
-                }
-            }
-            assertTrue(failure.message.orEmpty().contains(key))
-        }
+        assertNotNull(meta.json[CLIENT_CAPABILITIES_META_KEY]?.let { it as? JsonObject })
     }
 
     @OptIn(ExperimentalMcpApi::class)
@@ -113,7 +65,7 @@ class RequestTest {
               "method": "tools/list"
             }
         """.trimIndent()
-        assertNull(request.params?.meta?.protocolVersion)
+        assertNull(request.params?.meta?.claimedProtocolVersion)
     }
 
     @Test
@@ -264,9 +216,11 @@ class RequestTest {
     @Test
     fun `should serialize EmptyResult with meta`() {
         val result = EmptyResult(
-            meta = buildJsonObject {
-                put("processedBy", "worker-1")
-            },
+            meta = ResultMeta(
+                buildJsonObject {
+                    put("processedBy", "worker-1")
+                },
+            ),
         )
 
         verifySerialization(

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/ResourcesTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/ResourcesTest.kt
@@ -311,7 +311,7 @@ class ResourcesTest {
                 Resource(uri = "file:///workspace/CONTRIBUTING.md", name = "CONTRIBUTING"),
             ),
             nextCursor = "cursor-2",
-            meta = buildJsonObject { put("page", 1) },
+            meta = ResultMeta(buildJsonObject { put("page", 1) }),
         )
 
         verifySerialization(
@@ -324,6 +324,9 @@ class ResourcesTest {
                 {"uri": "file:///workspace/CONTRIBUTING.md", "name": "CONTRIBUTING"}
               ],
               "nextCursor": "cursor-2",
+              "resultType": "complete",
+              "ttlMs": 0,
+              "cacheScope": "private",
               "_meta": {
                 "page": 1
               }
@@ -344,6 +347,9 @@ class ResourcesTest {
                 }
               ],
               "nextCursor": "cursor-next",
+              "resultType": "complete",
+              "ttlMs": 0,
+              "cacheScope": "private",
               "_meta": {
                 "page": 2
               }
@@ -404,6 +410,9 @@ class ResourcesTest {
                   "mimeType": "image/png"
                 }
               ],
+              "resultType": "complete",
+              "ttlMs": 0,
+              "cacheScope": "private",
               "_meta": {
                 "generatedAt": "2025-01-12T15:00:58Z"
               }
@@ -506,7 +515,7 @@ class ResourcesTest {
                 ResourceTemplate(uriTemplate = "file:///workspace/{path}", name = "workspace-file"),
             ),
             nextCursor = "cursor-templates-2",
-            meta = buildJsonObject { put("page", 3) },
+            meta = ResultMeta(buildJsonObject { put("page", 3) }),
         )
 
         verifySerialization(
@@ -521,6 +530,9 @@ class ResourcesTest {
                 }
               ],
               "nextCursor": "cursor-templates-2",
+              "resultType": "complete",
+              "ttlMs": 0,
+              "cacheScope": "private",
               "_meta": {
                 "page": 3
               }
@@ -544,6 +556,9 @@ class ResourcesTest {
                 }
               ],
               "nextCursor": "cursor-next",
+              "resultType": "complete",
+              "ttlMs": 0,
+              "cacheScope": "private",
               "_meta": {
                 "page": 1
               }

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/ResultTypeTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/ResultTypeTest.kt
@@ -1,0 +1,109 @@
+package io.modelcontextprotocol.kotlin.sdk.types
+
+import io.kotest.assertions.json.shouldEqualJson
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
+import kotlinx.serialization.json.JsonObject
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+
+@OptIn(ExperimentalMcpApi::class)
+class ResultTypeTest {
+
+    @Test
+    fun `an empty result should stay an empty object`() {
+        // Deployed peers validate empty results strictly and reject unknown keys, so this is the one
+        // result that must be able to say nothing at all.
+        McpJson.encodeToString(EmptyResult()) shouldEqualJson "{}"
+        assertNull(EmptyResult().resultType)
+    }
+
+    @Test
+    fun `an empty result should be able to declare its type explicitly`() {
+        McpJson.encodeToString(EmptyResult(resultType = COMPLETE_RESULT_TYPE)) shouldEqualJson
+            """{"resultType": "complete"}"""
+    }
+
+    @Test
+    fun `every other result should declare itself complete by default`() {
+        val results: List<RequestResult> = listOf(
+            CallToolResult(content = emptyList()),
+            ListToolsResult(tools = emptyList()),
+            GetPromptResult(messages = emptyList()),
+            ListPromptsResult(prompts = emptyList()),
+            ReadResourceResult(contents = emptyList()),
+            ListResourcesResult(resources = emptyList()),
+            ListResourceTemplatesResult(resourceTemplates = emptyList()),
+            CompleteResult(completion = CompleteResult.Completion(values = emptyList())),
+            ListRootsResult(roots = emptyList()),
+            ElicitResult(action = ElicitResult.Action.Decline),
+            ListTasksResult(tasks = emptyList()),
+            DiscoverResult(supportedVersions = MODERN_PROTOCOL_VERSIONS, capabilities = ServerCapabilities()),
+            InitializeResult(
+                capabilities = ServerCapabilities(),
+                serverInfo = Implementation(name = "s", version = "1"),
+            ),
+        )
+
+        results.forEach { result ->
+            result.resultTypeOrNull shouldBe COMPLETE_RESULT_TYPE
+        }
+    }
+
+    @Test
+    fun `a result that omits its type should read as complete`() {
+        // How every peer that predates the field reads, so absence can never mean anything else.
+        val decoded = McpJson.decodeFromString<ServerResult>("""{"tools": []}""")
+
+        assertIs<ListToolsResult>(decoded)
+        decoded.resultType shouldBe COMPLETE_RESULT_TYPE
+    }
+
+    @Test
+    fun `an empty result should be recognized whether or not it declares its type`() {
+        listOf("{}", """{"resultType": "complete"}""", """{"_meta": {"a": 1}}""").forEach { wire ->
+            assertIs<EmptyResult>(McpJson.decodeFromString<RequestResult>(wire))
+        }
+    }
+
+    @Test
+    fun `a result with a payload should never be mistaken for an empty one`() {
+        val decoded = McpJson.decodeFromString<RequestResult>("""{"resultType": "complete", "roots": []}""")
+
+        assertIs<ListRootsResult>(decoded)
+    }
+
+    @Test
+    fun `an unrecognized result type should be refused only where it can occur`() {
+        val result = CallToolResult(content = emptyList(), resultType = "input_required")
+
+        // A lifecycle that predates the field cannot carry an unknown value, so nothing to refuse.
+        checkInboundResult(ProtocolEra.Legacy, result)
+
+        val failure = assertFailsWith<McpException> { checkInboundResult(ProtocolEra.Modern, result) }
+        failure.code shouldBe RPCError.ErrorCode.INVALID_PARAMS
+        failure.message.orEmpty() shouldContain "input_required"
+    }
+
+    @Test
+    fun `a recognized or absent result type should pass in either lifecycle`() {
+        ProtocolEra.entries.forEach { era ->
+            checkInboundResult(era, CallToolResult(content = emptyList()))
+            checkInboundResult(era, EmptyResult())
+        }
+    }
+
+    @Test
+    fun `an opaque payload should report whatever type it carries`() {
+        val complete = GetTaskPayloadResult(McpJson.decodeFromString<JsonObject>("""{"resultType": "complete"}"""))
+        val silent = GetTaskPayloadResult(McpJson.decodeFromString<JsonObject>("""{"content": []}"""))
+        val illTyped = GetTaskPayloadResult(McpJson.decodeFromString<JsonObject>("""{"resultType": 7}"""))
+
+        complete.resultTypeOrNull shouldBe COMPLETE_RESULT_TYPE
+        assertNull(silent.resultTypeOrNull)
+        assertNull(illTyped.resultTypeOrNull)
+    }
+}

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/RootsTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/RootsTest.kt
@@ -117,7 +117,7 @@ class RootsTest {
                 Root(uri = "file:///workspace/project", name = "Project"),
                 Root(uri = "file:///workspace/docs", name = "Docs"),
             ),
-            meta = buildJsonObject { put("issuedAt", "2025-01-12T15:00:58Z") },
+            meta = ResultMeta(buildJsonObject { put("issuedAt", "2025-01-12T15:00:58Z") }),
         )
 
         verifySerialization(
@@ -129,6 +129,7 @@ class RootsTest {
                 {"uri": "file:///workspace/project", "name": "Project"},
                 {"uri": "file:///workspace/docs", "name": "Docs"}
               ],
+              "resultType": "complete",
               "_meta": {
                 "issuedAt": "2025-01-12T15:00:58Z"
               }
@@ -147,6 +148,7 @@ class RootsTest {
                   "name": "Code"
                 }
               ],
+              "resultType": "complete",
               "_meta": {
                 "updatedBy": "client-1"
               }

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/SamplingTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/SamplingTest.kt
@@ -236,7 +236,7 @@ class SamplingTest {
             content = TextContent(text = "Here is the requested update."),
             model = "claude-3-5-sonnet",
             stopReason = StopReason.MaxTokens,
-            meta = buildJsonObject { put("latencyMs", 850) },
+            meta = ResultMeta(buildJsonObject { put("latencyMs", 850) }),
         )
 
         verifySerialization(
@@ -246,11 +246,12 @@ class SamplingTest {
             {
               "role": "assistant",
               "content": {
-                "type": "text",
-                "text": "Here is the requested update."
+                "text": "Here is the requested update.",
+                "type": "text"
               },
               "model": "claude-3-5-sonnet",
               "stopReason": "maxTokens",
+              "resultType": "complete",
               "_meta": {
                 "latencyMs": 850
               }
@@ -265,11 +266,12 @@ class SamplingTest {
             {
               "role": "assistant",
               "content": {
-                "type": "text",
-                "text": "Summary complete."
+                "text": "Summary complete.",
+                "type": "text"
               },
               "model": "gpt-4o",
               "stopReason": "stopSequence",
+              "resultType": "complete",
               "_meta": {
                 "latencyMs": 1200.5
               }

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/TasksTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/TasksTest.kt
@@ -199,7 +199,8 @@ class TasksTest {
                 "status": "working",
                 "createdAt": "2025-01-01T00:00:00Z",
                 "lastUpdatedAt": "2025-01-01T00:00:00Z"
-              }
+              },
+              "resultType": "complete"
             }
             """.trimIndent(),
         )
@@ -215,7 +216,7 @@ class TasksTest {
                 lastUpdatedAt = "2025-01-01T00:00:00Z",
                 ttl = 60000,
             ),
-            meta = buildJsonObject { put("trace", "abc") },
+            meta = ResultMeta(buildJsonObject { put("trace", "abc") }),
         )
 
         verifySerialization(
@@ -230,6 +231,7 @@ class TasksTest {
                 "lastUpdatedAt": "2025-01-01T00:00:00Z",
                 "ttl": 60000
               },
+              "resultType": "complete",
               "_meta": {
                 "trace": "abc"
               }
@@ -249,7 +251,8 @@ class TasksTest {
                 "createdAt": "2025-01-01T00:00:00Z",
                 "lastUpdatedAt": "2025-01-01T00:01:00Z",
                 "pollInterval": 2000
-              }
+              },
+              "resultType": "complete"
             }
         """.trimIndent()
 
@@ -345,7 +348,7 @@ class TasksTest {
             lastUpdatedAt = "2025-01-01T00:05:00Z",
             ttl = 300000,
             pollInterval = 10000,
-            meta = buildJsonObject { put("server", "main") },
+            meta = ResultMeta(buildJsonObject { put("server", "main") }),
         )
 
         verifySerialization(
@@ -360,6 +363,7 @@ class TasksTest {
               "lastUpdatedAt": "2025-01-01T00:05:00Z",
               "ttl": 300000,
               "pollInterval": 10000,
+              "resultType": "complete",
               "_meta": {
                 "server": "main"
               }
@@ -375,7 +379,8 @@ class TasksTest {
               "taskId": "task-21",
               "status": "working",
               "createdAt": "2025-01-01T00:00:00Z",
-              "lastUpdatedAt": "2025-01-01T00:00:30Z"
+              "lastUpdatedAt": "2025-01-01T00:00:30Z",
+              "resultType": "complete"
             }
         """.trimIndent()
 
@@ -554,7 +559,8 @@ class TasksTest {
             McpJson,
             """
             {
-              "tasks": []
+              "tasks": [],
+              "resultType": "complete"
             }
             """.trimIndent(),
         )
@@ -602,7 +608,8 @@ class TasksTest {
                   "ttl": 60000
                 }
               ],
-              "nextCursor": "cursor-abc"
+              "nextCursor": "cursor-abc",
+              "resultType": "complete"
             }
             """.trimIndent(),
         )
@@ -620,7 +627,8 @@ class TasksTest {
                   "createdAt": "2025-01-01T00:00:00Z",
                   "lastUpdatedAt": "2025-01-01T00:03:00Z"
                 }
-              ]
+              ],
+              "resultType": "complete"
             }
         """.trimIndent()
 
@@ -698,7 +706,8 @@ class TasksTest {
               "status": "cancelled",
               "statusMessage": "Cancelled by user",
               "createdAt": "2025-01-01T00:00:00Z",
-              "lastUpdatedAt": "2025-01-01T00:02:00Z"
+              "lastUpdatedAt": "2025-01-01T00:02:00Z",
+              "resultType": "complete"
             }
             """.trimIndent(),
         )
@@ -713,7 +722,8 @@ class TasksTest {
               "createdAt": "2025-01-01T00:00:00Z",
               "lastUpdatedAt": "2025-01-01T00:04:00Z",
               "ttl": 120000,
-              "pollInterval": 3000
+              "pollInterval": 3000,
+              "resultType": "complete"
             }
         """.trimIndent()
 

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/ToolsTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/ToolsTest.kt
@@ -381,7 +381,7 @@ class ToolsTest {
                 put("count", 3)
                 put("items", buildJsonObject { put("first", "doc.md") })
             },
-            meta = buildJsonObject { put("elapsedMs", 1200) },
+            meta = ResultMeta(buildJsonObject { put("elapsedMs", 1200) }),
         )
 
         verifySerialization(
@@ -391,8 +391,8 @@ class ToolsTest {
             {
               "content": [
                 {
-                  "type": "text",
-                  "text": "Found 3 relevant documents."
+                  "text": "Found 3 relevant documents.",
+                  "type": "text"
                 }
               ],
               "isError": false,
@@ -402,6 +402,7 @@ class ToolsTest {
                   "first": "doc.md"
                 }
               },
+              "resultType": "complete",
               "_meta": {
                 "elapsedMs": 1200
               }
@@ -416,8 +417,8 @@ class ToolsTest {
             {
               "content": [
                 {
-                  "type": "text",
-                  "text": "Unable to reach server."
+                  "text": "Unable to reach server.",
+                  "type": "text"
                 }
               ],
               "isError": true,
@@ -425,6 +426,7 @@ class ToolsTest {
                 "errorCode": "NETWORK",
                 "retryable": true
               },
+              "resultType": "complete",
               "_meta": {
                 "requestId": "req-9"
               }
@@ -491,7 +493,7 @@ class ToolsTest {
                 Tool(name = "summarize", inputSchema = ToolSchema()),
             ),
             nextCursor = "cursor-2",
-            meta = buildJsonObject { put("page", 1) },
+            meta = ResultMeta(buildJsonObject { put("page", 1) }),
         )
 
         verifySerialization(
@@ -514,6 +516,9 @@ class ToolsTest {
                 }
               ],
               "nextCursor": "cursor-2",
+              "resultType": "complete",
+              "ttlMs": 0,
+              "cacheScope": "private",
               "_meta": {
                 "page": 1
               }
@@ -536,6 +541,9 @@ class ToolsTest {
                 }
               ],
               "nextCursor": "cursor-next",
+              "resultType": "complete",
+              "ttlMs": 0,
+              "cacheScope": "private",
               "_meta": {
                 "page": 3
               }
@@ -556,7 +564,7 @@ class ToolsTest {
 
     @Test
     fun `should build success CallToolResult with text content`() {
-        val meta = buildJsonObject { put("source", "toolkit") }
+        val meta = ResultMeta(buildJsonObject { put("source", "toolkit") })
 
         val result = CallToolResult.success("Operation complete", meta)
 
@@ -569,7 +577,7 @@ class ToolsTest {
 
     @Test
     fun `should build error CallToolResult with text content`() {
-        val meta = buildJsonObject { put("code", "ERR42") }
+        val meta = ResultMeta(buildJsonObject { put("code", "ERR42") })
 
         val result = CallToolResult.error("Failed to connect", meta)
 

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/WireTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/WireTest.kt
@@ -1,0 +1,169 @@
+package io.modelcontextprotocol.kotlin.sdk.types
+
+import io.kotest.assertions.json.shouldEqualJson
+import io.kotest.matchers.shouldBe
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
+import io.modelcontextprotocol.kotlin.sdk.InternalMcpApi
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+
+@OptIn(ExperimentalMcpApi::class, InternalMcpApi::class)
+class WireTest {
+
+    private val serverInfo = Implementation(name = "wire-server", version = "3.1.0")
+
+    private fun encoded(result: RequestResult): JsonObject =
+        McpJson.encodeToJsonElement<RequestResult>(result).jsonObject
+
+    @Test
+    fun `the handshake wire should carry nothing the request-scoped lifecycle added`() {
+        val result = ListToolsResult(tools = emptyList(), ttlMs = 500, cacheScope = CacheScope.Public)
+
+        val wire = encodeOutboundResult(ProtocolEra.Legacy, encoded(result), serverInfo)
+
+        wire.toString() shouldEqualJson """{"tools": []}"""
+    }
+
+    @Test
+    fun `stripping should leave everything else untouched`() {
+        val result = ListToolsResult(
+            tools = emptyList(),
+            nextCursor = "cursor-9",
+            meta = ResultMeta(buildJsonObject { put("page", 2) }),
+        )
+
+        val wire = encodeOutboundResult(ProtocolEra.Legacy, encoded(result), serverInfo)
+
+        wire.toString() shouldEqualJson """
+            {
+              "tools": [],
+              "nextCursor": "cursor-9",
+              "_meta": {"page": 2}
+            }
+        """.trimIndent()
+    }
+
+    @Test
+    fun `the handshake wire should never carry a server identity`() {
+        // Legacy peers learned who the server is from the handshake, and never expected it here.
+        val wire = encodeOutboundResult(ProtocolEra.Legacy, encoded(EmptyResult()), serverInfo)
+
+        assertNull(wire["_meta"])
+    }
+
+    @Test
+    fun `a request-scoped result should identify the server that produced it`() {
+        val wire = encodeOutboundResult(ProtocolEra.Modern, encoded(EmptyResult()), serverInfo)
+
+        ResultMeta(wire["_meta"]!!.jsonObject).serverInfo shouldBe serverInfo
+    }
+
+    @Test
+    fun `an identity the handler wrote should outrank the automatic one`() {
+        val authored = Implementation(name = "authored", version = "9.9.9")
+        val result = CallToolResult(content = emptyList(), meta = null.withServerInfo(authored))
+
+        val wire = encodeOutboundResult(ProtocolEra.Modern, encoded(result), serverInfo)
+
+        ResultMeta(wire["_meta"]!!.jsonObject).serverInfo shouldBe authored
+    }
+
+    @Test
+    fun `a server configured not to identify itself should stamp nothing`() {
+        val wire = encodeOutboundResult(ProtocolEra.Modern, encoded(EmptyResult()), serverInfo = null)
+
+        assertNull(wire["_meta"])
+    }
+
+    @Test
+    fun `stamping should preserve unrelated result metadata`() {
+        val result = CallToolResult(
+            content = emptyList(),
+            meta = ResultMeta(buildJsonObject { put("com.example/trace", "abc") }),
+        )
+
+        val wire = encodeOutboundResult(ProtocolEra.Modern, encoded(result), serverInfo)
+
+        val meta = ResultMeta(wire["_meta"]!!.jsonObject)
+        meta.serverInfo shouldBe serverInfo
+        meta["com.example/trace"].toString() shouldBe "\"abc\""
+    }
+
+    @Test
+    fun `a request-scoped result should keep the fields the lifecycle added`() {
+        val result = ListToolsResult(tools = emptyList(), ttlMs = 500, cacheScope = CacheScope.Public)
+
+        val wire = encodeOutboundResult(ProtocolEra.Modern, encoded(result), serverInfo = null)
+
+        wire.toString() shouldEqualJson """
+            {
+              "tools": [],
+              "resultType": "complete",
+              "ttlMs": 500,
+              "cacheScope": "public"
+            }
+        """.trimIndent()
+    }
+
+    @Test
+    fun `a rendered result should read back as the result it was rendered from`() {
+        // What a transport that serializes does for free, and what Protocol does for one that does not.
+        val result = ListToolsResult(tools = emptyList(), nextCursor = "cursor-1")
+
+        val wire = WireResult(encodeOutboundResult(ProtocolEra.Legacy, encoded(result), serverInfo = null))
+        val readBack = McpJson.decodeFromString<RequestResult>(McpJson.encodeToString(wire))
+
+        assertIs<ListToolsResult>(readBack)
+        readBack shouldBe result
+    }
+
+    @Test
+    fun `a rendered result should serialize as the object it holds and nothing more`() {
+        val wire = WireResult(buildJsonObject { put("tools", McpJson.encodeToJsonElement(emptyList<Tool>())) })
+
+        McpJson.encodeToString<RequestResult>(wire) shouldEqualJson """{"tools": []}"""
+        assertNull(wire.meta)
+    }
+
+    @Test
+    fun `a retired error code should never reach the wire`() {
+        @Suppress("DEPRECATION")
+        ProtocolEra.entries.forEach { era ->
+            outboundErrorCode(era, RPCError.ErrorCode.RESOURCE_NOT_FOUND) shouldBe
+                RPCError.ErrorCode.INVALID_PARAMS
+        }
+    }
+
+    @Test
+    fun `url elicitation should survive only where url elicitation does`() {
+        @Suppress("DEPRECATION")
+        val urlElicitationRequired = RPCError.ErrorCode.URL_ELICITATION_REQUIRED
+
+        outboundErrorCode(ProtocolEra.Legacy, urlElicitationRequired) shouldBe urlElicitationRequired
+        outboundErrorCode(ProtocolEra.Modern, urlElicitationRequired) shouldBe
+            RPCError.ErrorCode.INTERNAL_ERROR
+    }
+
+    @Test
+    fun `every other error code should pass through unchanged`() {
+        val untouched = listOf(
+            RPCError.ErrorCode.INVALID_PARAMS,
+            RPCError.ErrorCode.INTERNAL_ERROR,
+            RPCError.ErrorCode.METHOD_NOT_FOUND,
+            RPCError.ErrorCode.HEADER_MISMATCH,
+            RPCError.ErrorCode.MISSING_REQUIRED_CLIENT_CAPABILITY,
+            RPCError.ErrorCode.UNSUPPORTED_PROTOCOL_VERSION,
+            RPCError.ErrorCode.CONNECTION_CLOSED,
+        )
+
+        ProtocolEra.entries.forEach { era ->
+            untouched.forEach { code -> outboundErrorCode(era, code) shouldBe code }
+        }
+    }
+}

--- a/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/WireTest.kt
+++ b/kotlin-sdk-core/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/types/WireTest.kt
@@ -151,6 +151,16 @@ class WireTest {
     }
 
     @Test
+    fun `a local-only error code should never reach the wire`() {
+        // A timeout or connection failure is this side's own verdict on its own nested call; a peer
+        // reading it as the counterparty's answer would be misled.
+        ProtocolEra.entries.forEach { era ->
+            outboundErrorCode(era, RPCError.ErrorCode.REQUEST_TIMEOUT) shouldBe RPCError.ErrorCode.INTERNAL_ERROR
+            outboundErrorCode(era, RPCError.ErrorCode.CONNECTION_CLOSED) shouldBe RPCError.ErrorCode.INTERNAL_ERROR
+        }
+    }
+
+    @Test
     fun `every other error code should pass through unchanged`() {
         val untouched = listOf(
             RPCError.ErrorCode.INVALID_PARAMS,
@@ -159,7 +169,6 @@ class WireTest {
             RPCError.ErrorCode.HEADER_MISMATCH,
             RPCError.ErrorCode.MISSING_REQUIRED_CLIENT_CAPABILITY,
             RPCError.ErrorCode.UNSUPPORTED_PROTOCOL_VERSION,
-            RPCError.ErrorCode.CONNECTION_CLOSED,
         )
 
         ProtocolEra.entries.forEach { era ->

--- a/kotlin-sdk-server/api/kotlin-sdk-server.api
+++ b/kotlin-sdk-server/api/kotlin-sdk-server.api
@@ -171,10 +171,13 @@ public final class io/modelcontextprotocol/kotlin/sdk/server/ServerOptions : io/
 	public fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/ServerCapabilities;)V
 	public fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/ServerCapabilities;Z)V
 	public synthetic fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/ServerCapabilities;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/ServerCapabilities;ZLio/modelcontextprotocol/kotlin/sdk/utils/ResourceTemplateMatcherFactory;Lkotlin/coroutines/CoroutineContext;)V
-	public synthetic fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/ServerCapabilities;ZLio/modelcontextprotocol/kotlin/sdk/utils/ResourceTemplateMatcherFactory;Lkotlin/coroutines/CoroutineContext;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/ServerCapabilities;ZLio/modelcontextprotocol/kotlin/sdk/utils/ResourceTemplateMatcherFactory;Lkotlin/coroutines/CoroutineContext;ZJLio/modelcontextprotocol/kotlin/sdk/types/CacheScope;)V
+	public synthetic fun <init> (Lio/modelcontextprotocol/kotlin/sdk/types/ServerCapabilities;ZLio/modelcontextprotocol/kotlin/sdk/utils/ResourceTemplateMatcherFactory;Lkotlin/coroutines/CoroutineContext;ZJLio/modelcontextprotocol/kotlin/sdk/types/CacheScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getCapabilities ()Lio/modelcontextprotocol/kotlin/sdk/types/ServerCapabilities;
+	public final fun getDiscoverCacheScope ()Lio/modelcontextprotocol/kotlin/sdk/types/CacheScope;
+	public final fun getDiscoverTtlMs ()J
 	public final fun getResourceTemplateMatcherFactory ()Lio/modelcontextprotocol/kotlin/sdk/utils/ResourceTemplateMatcherFactory;
+	public final fun getSendServerInfo ()Z
 }
 
 public class io/modelcontextprotocol/kotlin/sdk/server/ServerSession : io/modelcontextprotocol/kotlin/sdk/shared/Protocol {
@@ -191,7 +194,12 @@ public class io/modelcontextprotocol/kotlin/sdk/server/ServerSession : io/modelc
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getClientCapabilities ()Lio/modelcontextprotocol/kotlin/sdk/types/ClientCapabilities;
 	public final fun getClientVersion ()Lio/modelcontextprotocol/kotlin/sdk/types/Implementation;
+	protected final fun getDeclaredClientCapabilities ()Lio/modelcontextprotocol/kotlin/sdk/types/ClientCapabilities;
+	protected final fun getDeclaredClientInfo ()Lio/modelcontextprotocol/kotlin/sdk/types/Implementation;
 	protected final fun getInstructions ()Ljava/lang/String;
+	protected final fun getNegotiatedProtocolVersion ()Ljava/lang/String;
+	protected final fun getOutboundServerInfo ()Lio/modelcontextprotocol/kotlin/sdk/types/Implementation;
+	public final fun getProtocolVersion ()Ljava/lang/String;
 	protected final fun getServerInfo ()Lio/modelcontextprotocol/kotlin/sdk/types/Implementation;
 	public final fun getSessionId ()Ljava/lang/String;
 	public fun hashCode ()I

--- a/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ClientConnection.kt
+++ b/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ClientConnection.kt
@@ -1,7 +1,10 @@
 package io.modelcontextprotocol.kotlin.sdk.server
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
 import io.modelcontextprotocol.kotlin.sdk.shared.RequestOptions
+import io.modelcontextprotocol.kotlin.sdk.shared.currentRequestHandlerExtra
+import io.modelcontextprotocol.kotlin.sdk.types.ClientCapabilities
 import io.modelcontextprotocol.kotlin.sdk.types.CreateMessageRequest
 import io.modelcontextprotocol.kotlin.sdk.types.CreateMessageResult
 import io.modelcontextprotocol.kotlin.sdk.types.ElicitRequest
@@ -18,8 +21,12 @@ import io.modelcontextprotocol.kotlin.sdk.types.ListRootsResult
 import io.modelcontextprotocol.kotlin.sdk.types.LoggingLevel
 import io.modelcontextprotocol.kotlin.sdk.types.LoggingMessageNotification
 import io.modelcontextprotocol.kotlin.sdk.types.McpException
+import io.modelcontextprotocol.kotlin.sdk.types.McpJson
+import io.modelcontextprotocol.kotlin.sdk.types.Method
+import io.modelcontextprotocol.kotlin.sdk.types.MissingRequiredClientCapabilityData
 import io.modelcontextprotocol.kotlin.sdk.types.PingRequest
 import io.modelcontextprotocol.kotlin.sdk.types.PromptListChangedNotification
+import io.modelcontextprotocol.kotlin.sdk.types.RPCError
 import io.modelcontextprotocol.kotlin.sdk.types.Request
 import io.modelcontextprotocol.kotlin.sdk.types.RequestId
 import io.modelcontextprotocol.kotlin.sdk.types.RequestResult
@@ -27,7 +34,10 @@ import io.modelcontextprotocol.kotlin.sdk.types.ResourceListChangedNotification
 import io.modelcontextprotocol.kotlin.sdk.types.ResourceUpdatedNotification
 import io.modelcontextprotocol.kotlin.sdk.types.ServerNotification
 import io.modelcontextprotocol.kotlin.sdk.types.ToolListChangedNotification
+import io.modelcontextprotocol.kotlin.sdk.types.isModernProtocolVersion
+import io.modelcontextprotocol.kotlin.sdk.types.missingIn
 import io.modelcontextprotocol.kotlin.sdk.types.supportsUrl
+import kotlinx.serialization.json.encodeToJsonElement
 
 private val logger = KotlinLogging.logger {}
 
@@ -70,7 +80,8 @@ public interface ClientConnection {
      * @param request The parameters for creating a message.
      * @param options Optional request options.
      * @return The created message result.
-     * @throws IllegalStateException If the server does not support sampling or if the request fails.
+     * @throws McpException with [RPCError.ErrorCode.MISSING_REQUIRED_CLIENT_CAPABILITY] if the
+     * client did not declare the sampling capability this request needs.
      */
     public suspend fun createMessage(
         request: CreateMessageRequest,
@@ -86,7 +97,8 @@ public interface ClientConnection {
      * @param request Optional request parameters containing metadata for the list roots operation.
      * @param options Optional request options, such as timeout or progress callback settings.
      * @return The list of roots.
-     * @throws IllegalStateException If the server or client does not support roots.
+     * @throws McpException with [RPCError.ErrorCode.MISSING_REQUIRED_CLIENT_CAPABILITY] if the
+     * client did not declare the roots capability.
      */
     public suspend fun listRoots(
         request: ListRootsRequest = ListRootsRequest(),
@@ -106,8 +118,9 @@ public interface ClientConnection {
      * Influences the form displayed to the user.
      * @param options Optional request options.
      * @return The result of the elicitation request.
-     * @throws IllegalStateException If the server or client does not support elicitation.
-     * @throws McpException If an accepted response does not match [requestedSchema].
+     * @throws McpException with [RPCError.ErrorCode.MISSING_REQUIRED_CLIENT_CAPABILITY] if the
+     * client did not declare the elicitation mode this request needs, or if an accepted response
+     * does not match [requestedSchema].
      */
     public suspend fun createElicitation(
         message: String,
@@ -124,7 +137,8 @@ public interface ClientConnection {
      * @param url The URL that the user should navigate to.
      * @param options Optional request options.
      * @return The result of the elicitation request.
-     * @throws IllegalStateException If the server or client does not support elicitation.
+     * @throws McpException with [RPCError.ErrorCode.MISSING_REQUIRED_CLIENT_CAPABILITY] if the
+     * client did not declare the elicitation mode this request needs.
      */
     public suspend fun createElicitation(
         message: String,
@@ -144,8 +158,9 @@ public interface ClientConnection {
      * @param request The elicitation request parameters.
      * @param options Optional request options.
      * @return The result of the elicitation request.
-     * @throws IllegalStateException If the server or client does not support elicitation.
-     * @throws McpException If an accepted form-mode response does not match its requested schema.
+     * @throws McpException with [RPCError.ErrorCode.MISSING_REQUIRED_CLIENT_CAPABILITY] if the
+     * client did not declare the elicitation mode this request needs, or if an accepted form-mode
+     * response does not match its requested schema.
      */
     public suspend fun createElicitation(request: ElicitRequest, options: RequestOptions? = null): ElicitResult
 
@@ -188,6 +203,7 @@ public interface ClientConnection {
     public suspend fun sendElicitationComplete(notification: ElicitationCompleteNotification)
 }
 
+@OptIn(ExperimentalMcpApi::class)
 internal class ClientConnectionImpl(private val session: ServerSession) : ClientConnection {
 
     override val sessionId: String get() = session.sessionId
@@ -212,16 +228,17 @@ internal class ClientConnectionImpl(private val session: ServerSession) : Client
     }
 
     override suspend fun createMessage(request: CreateMessageRequest, options: RequestOptions?): CreateMessageResult {
-        val caps = session.clientCapabilities
         val params = request.params
 
-        if (params.tools != null || params.toolChoice != null) {
-            requireNotNull(caps?.sampling?.tools) {
-                "Client did not advertise sampling.tools capability; cannot send " +
-                    "tools/toolChoice in sampling/createMessage request."
-            }
-        }
+        val needsTools = params.tools != null || params.toolChoice != null
+        requireClientCapabilities(
+            ClientCapabilities(
+                sampling = ClientCapabilities.Sampling(tools = EmptyJsonObject.takeIf { needsTools }),
+            ),
+        )
+        requireBackChannel(Method.Defined.SamplingCreateMessage)
 
+        val caps = governingClientCapabilities()
         if (params.includeContext != null && params.includeContext != IncludeContext.None) {
             if (caps?.sampling?.context == null) {
                 logger.warn {
@@ -245,17 +262,23 @@ internal class ClientConnectionImpl(private val session: ServerSession) : Client
     }
 
     override suspend fun listRoots(request: ListRootsRequest, options: RequestOptions?): ListRootsResult {
+        requireClientCapabilities(ClientCapabilities(roots = ClientCapabilities.Roots()))
+        requireBackChannel(Method.Defined.RootsList)
         logger.debug { "Listing roots" }
         return request(request, options)
     }
 
     override suspend fun createElicitation(request: ElicitRequest, options: RequestOptions?): ElicitResult {
         val params = request.params
-        if (params is ElicitRequestURLParams) {
-            require(session.clientCapabilities?.elicitation.supportsUrl) {
-                "Client did not advertise elicitation.url capability; cannot send a URL-mode elicitation."
-            }
-        }
+        requireClientCapabilities(
+            ClientCapabilities(
+                elicitation = when (params) {
+                    is ElicitRequestURLParams -> ClientCapabilities.Elicitation(url = EmptyJsonObject)
+                    is ElicitRequestFormParams -> ClientCapabilities.Elicitation(form = EmptyJsonObject)
+                },
+            ),
+        )
+        requireBackChannel(Method.Defined.ElicitationCreate)
         logger.debug {
             when (params) {
                 is ElicitRequestFormParams ->
@@ -339,9 +362,62 @@ internal class ClientConnectionImpl(private val session: ServerSession) : Client
      *         the current session's logging level), or if no current logging
      *         level is set. Otherwise, false.
      */
-    private fun isMessageAccepted(level: LoggingLevel): Boolean {
+    private suspend fun isMessageAccepted(level: LoggingLevel): Boolean {
+        val extra = currentRequestHandlerExtra()
+            // Outside a handler there is no request to have opted in, so nothing is deliverable on
+            // the request-scoped lifecycle and the connection-scoped filter applies on the other.
+            ?: return session.protocolVersion?.let { isModernProtocolVersion(it) } != true &&
+                acceptedByLevelSetting(level)
+        if (level !in allowedLogLevels(extra.protocolVersion, extra.meta)) return false
+        return acceptedByLevelSetting(level)
+    }
+
+    /** Whether a `logging/setLevel` the client issued on this connection admits [level]. */
+    private fun acceptedByLevelSetting(level: LoggingLevel): Boolean {
         val current = session.currentLoggingLevel.value ?: return true // If no level is set, don't filter
 
         return level >= current
+    }
+
+    /**
+     * The capabilities governing the request being served, or the connection's declaration outside
+     * a handler.
+     *
+     * Under the request-scoped lifecycle every request carries its own declaration; reading the
+     * connection's would let one request borrow another's.
+     */
+    private suspend fun governingClientCapabilities(): ClientCapabilities? =
+        currentRequestHandlerExtra()?.clientCapabilities ?: session.clientCapabilities
+
+    /**
+     * Refuses a server-initiated request on a connection whose revision has none.
+     *
+     * Protocol revision `2026-07-28` removed sampling, elicitation and roots as server-initiated
+     * requests. A server that needs them must be reached over `2025-11-25` or earlier.
+     */
+    private suspend fun requireBackChannel(method: Method) {
+        val extra = currentRequestHandlerExtra() ?: return
+        if (extra.envelope == null) return
+        throw McpException(
+            code = RPCError.ErrorCode.METHOD_NOT_FOUND,
+            message = "${method.value} was removed in protocol version ${extra.protocolVersion}: " +
+                "server-initiated requests are replaced by multi-round-trip requests, which this " +
+                "SDK does not implement yet. Serve peers that need it over 2025-11-25 or earlier.",
+        )
+    }
+
+    /**
+     * Demands [required] of the client governing this request.
+     *
+     * @throws McpException [RPCError.ErrorCode.MISSING_REQUIRED_CLIENT_CAPABILITY], carrying the
+     * capabilities the declaration did not cover, when it does not cover them all
+     */
+    private suspend fun requireClientCapabilities(required: ClientCapabilities) {
+        val missing = required.missingIn(governingClientCapabilities()) ?: return
+        throw McpException(
+            code = RPCError.ErrorCode.MISSING_REQUIRED_CLIENT_CAPABILITY,
+            message = "Client did not declare the capabilities required to serve this request",
+            data = McpJson.encodeToJsonElement(MissingRequiredClientCapabilityData(missing)),
+        )
     }
 }

--- a/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ClientConnection.kt
+++ b/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ClientConnection.kt
@@ -36,7 +36,6 @@ import io.modelcontextprotocol.kotlin.sdk.types.ServerNotification
 import io.modelcontextprotocol.kotlin.sdk.types.ToolListChangedNotification
 import io.modelcontextprotocol.kotlin.sdk.types.isModernProtocolVersion
 import io.modelcontextprotocol.kotlin.sdk.types.missingIn
-import io.modelcontextprotocol.kotlin.sdk.types.supportsUrl
 import kotlinx.serialization.json.encodeToJsonElement
 
 private val logger = KotlinLogging.logger {}
@@ -199,6 +198,10 @@ public interface ClientConnection {
      * Sends a notification to the client indicating that an out-of-band elicitation has completed.
      *
      * @param notification Details of the completed elicitation.
+     * @throws McpException [RPCError.ErrorCode.METHOD_NOT_FOUND] on a request-scoped request —
+     * protocol revision `2026-07-28` removed URL-elicitation completion — or
+     * [RPCError.ErrorCode.MISSING_REQUIRED_CLIENT_CAPABILITY] when the governing client
+     * declaration does not cover `elicitation.url`
      */
     public suspend fun sendElicitationComplete(notification: ElicitationCompleteNotification)
 }
@@ -346,9 +349,10 @@ internal class ClientConnectionImpl(private val session: ServerSession) : Client
     }
 
     override suspend fun sendElicitationComplete(notification: ElicitationCompleteNotification) {
-        require(session.clientCapabilities?.elicitation.supportsUrl) {
-            "Client did not advertise elicitation.url capability; cannot send an elicitation completion notification."
-        }
+        requireLegacyNotification(Method.Defined.NotificationsElicitationComplete)
+        requireClientCapabilities(
+            ClientCapabilities(elicitation = ClientCapabilities.Elicitation(url = EmptyJsonObject)),
+        )
         logger.debug { "Sending elicitation complete notification for: ${notification.params.elicitationId}" }
         notification(notification)
     }
@@ -403,6 +407,23 @@ internal class ClientConnectionImpl(private val session: ServerSession) : Client
             message = "${method.value} was removed in protocol version ${extra.protocolVersion}: " +
                 "server-initiated requests are replaced by multi-round-trip requests, which this " +
                 "SDK does not implement yet. Serve peers that need it over 2025-11-25 or earlier.",
+        )
+    }
+
+    /**
+     * Refuses a legacy-only notification on a request whose revision removed it.
+     *
+     * Protocol revision `2026-07-28` removed URL-elicitation completion along with the
+     * `elicitationId` it references, so the refusal fires before anything reaches the transport.
+     */
+    private suspend fun requireLegacyNotification(method: Method) {
+        val extra = currentRequestHandlerExtra() ?: return
+        if (extra.envelope == null) return
+        throw McpException(
+            code = RPCError.ErrorCode.METHOD_NOT_FOUND,
+            message = "${method.value} was removed in protocol version ${extra.protocolVersion}: " +
+                "URL-elicitation completion and its elicitationId do not exist on this revision. " +
+                "Serve peers that need it over 2025-11-25 or earlier.",
         )
     }
 

--- a/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/InboundClassification.kt
+++ b/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/InboundClassification.kt
@@ -1,0 +1,227 @@
+package io.modelcontextprotocol.kotlin.sdk.server
+
+import io.ktor.http.Headers
+import io.ktor.http.HttpStatusCode
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
+import io.modelcontextprotocol.kotlin.sdk.InternalMcpApi
+import io.modelcontextprotocol.kotlin.sdk.types.CLIENT_CAPABILITIES_META_KEY
+import io.modelcontextprotocol.kotlin.sdk.types.MCP_METHOD_HEADER
+import io.modelcontextprotocol.kotlin.sdk.types.MCP_NAME_HEADER
+import io.modelcontextprotocol.kotlin.sdk.types.MCP_PROTOCOL_VERSION_HEADER
+import io.modelcontextprotocol.kotlin.sdk.types.MODERN_PROTOCOL_VERSIONS
+import io.modelcontextprotocol.kotlin.sdk.types.McpJson
+import io.modelcontextprotocol.kotlin.sdk.types.NAME_BEARING_METHODS
+import io.modelcontextprotocol.kotlin.sdk.types.PROTOCOL_VERSION_META_KEY
+import io.modelcontextprotocol.kotlin.sdk.types.RPCError
+import io.modelcontextprotocol.kotlin.sdk.types.RequestId
+import io.modelcontextprotocol.kotlin.sdk.types.RequestMeta
+import io.modelcontextprotocol.kotlin.sdk.types.UnsupportedProtocolVersionData
+import io.modelcontextprotocol.kotlin.sdk.types.decodeMcpHeaderValue
+import io.modelcontextprotocol.kotlin.sdk.types.validateEnvelope
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.encodeToJsonElement
+
+/**
+ * HTTP status for a JSON-RPC error code.
+ *
+ * A code absent from this map travels in-band on `200`. `-32602` is absent on purpose: a handler
+ * called with bad arguments is not an HTTP failure.
+ */
+internal val HTTP_STATUS_BY_ERROR_CODE: Map<Int, HttpStatusCode> = mapOf(
+    RPCError.ErrorCode.PARSE_ERROR to HttpStatusCode.BadRequest,
+    RPCError.ErrorCode.INVALID_REQUEST to HttpStatusCode.BadRequest,
+    RPCError.ErrorCode.METHOD_NOT_FOUND to HttpStatusCode.NotFound,
+    RPCError.ErrorCode.HEADER_MISMATCH to HttpStatusCode.BadRequest,
+    RPCError.ErrorCode.MISSING_REQUIRED_CLIENT_CAPABILITY to HttpStatusCode.BadRequest,
+    RPCError.ErrorCode.UNSUPPORTED_PROTOCOL_VERSION to HttpStatusCode.BadRequest,
+)
+
+/** What one inbound HTTP body turned out to be. */
+internal sealed interface InboundOutcome {
+    /** Handshake-era traffic, served exactly as a handshake-only transport would serve it. */
+    data class Legacy(val reason: String) : InboundOutcome
+
+    /** A request claiming the request-scoped lifecycle, with its envelope already validated. */
+    data class Modern(val method: String, val id: RequestId, val protocolVersion: String) : InboundOutcome
+
+    /** A request-scoped notification, which this wire acknowledges and drops. */
+    data class ModernNotification(val method: String) : InboundOutcome
+
+    /** The body failed a rung of the inbound ladder. */
+    data class Reject(val error: RPCError, val status: HttpStatusCode, val id: RequestId?) : InboundOutcome
+}
+
+/**
+ * Classifies one inbound HTTP body, body-primary, and runs the ladder rungs an HTTP entry owns.
+ *
+ * A body **claims** the request-scoped lifecycle if and only if its `params._meta` carries
+ * [PROTOCOL_VERSION_META_KEY]. Nothing else counts as a claim, and no connection state
+ * participates, so one endpoint can serve both lifecycles interleaved.
+ *
+ * The rungs, in precedence order, each answering the earliest failure:
+ *
+ * 1. **jsonrpc-shape** — a batch containing a claim, and a body that is neither request nor
+ *    notification, are refused [RPCError.ErrorCode.INVALID_REQUEST]. An all-handshake batch and a
+ *    posted response stay handshake traffic.
+ * 2. **headers** — on requests only, [MCP_PROTOCOL_VERSION_HEADER] and [MCP_METHOD_HEADER] must be
+ *    present and agree with the body, and [MCP_NAME_HEADER] must agree for the methods that mirror
+ *    a param, else [RPCError.ErrorCode.HEADER_MISMATCH]. Ahead of the version rung, so a client
+ *    that disagrees with itself is told that rather than told its version is unsupported.
+ * 3. **envelope** — a present claim whose envelope is not intact is
+ *    [RPCError.ErrorCode.INVALID_PARAMS], naming every offending key at once.
+ * 4. **version** — a claim naming a revision this server does not serve is
+ *    [RPCError.ErrorCode.UNSUPPORTED_PROTOCOL_VERSION], naming the ones it does.
+ *
+ * Method existence is not a rung here: dispatch owns it, so a custom-registered method still routes.
+ */
+@OptIn(ExperimentalMcpApi::class, InternalMcpApi::class)
+internal fun classifyInboundRequest(body: JsonElement, headers: Headers): InboundOutcome {
+    if (body is JsonArray) {
+        // Element-wise: a batch is handshake traffic unless some element claims otherwise, and the
+        // request-scoped lifecycle has no batching for such an element to belong to.
+        return if (body.any { it is JsonObject && claimOf(it) != null }) {
+            InboundOutcome.Reject(
+                error = RPCError(
+                    code = RPCError.ErrorCode.INVALID_REQUEST,
+                    message = "A JSON-RPC batch cannot carry a request-scoped protocol envelope",
+                ),
+                status = HttpStatusCode.BadRequest,
+                id = null,
+            )
+        } else {
+            InboundOutcome.Legacy("batch")
+        }
+    }
+    if (body !is JsonObject) {
+        return InboundOutcome.Reject(
+            error = RPCError(
+                code = RPCError.ErrorCode.INVALID_REQUEST,
+                message = "Body must be a single JSON-RPC request or notification object",
+            ),
+            status = HttpStatusCode.BadRequest,
+            id = null,
+        )
+    }
+
+    val meta = claimOf(body) ?: return noClaim(body, headers)
+    val method = body.stringOf("method")
+        // A claim on something that is not a request or a notification: no method to route it by.
+        ?: return InboundOutcome.Reject(
+            error = RPCError(
+                code = RPCError.ErrorCode.INVALID_REQUEST,
+                message = "Body must be a single JSON-RPC request or notification object",
+            ),
+            status = HttpStatusCode.BadRequest,
+            id = null,
+        )
+    val id = body["id"]?.let { McpJson.decodeFromJsonElement(RequestId.serializer(), it) }
+
+    if (id != null) {
+        headerMismatch(body, method, meta, headers)?.let {
+            return InboundOutcome.Reject(it, HttpStatusCode.BadRequest, id)
+        }
+    }
+
+    val issues = validateEnvelope(meta)
+    if (issues.isNotEmpty()) {
+        return InboundOutcome.Reject(
+            error = RPCError(
+                code = RPCError.ErrorCode.INVALID_PARAMS,
+                message = "Invalid request envelope: " + issues.joinToString(", ") { "${it.key} ${it.problem}" },
+            ),
+            status = HttpStatusCode.BadRequest,
+            id = id,
+        )
+    }
+
+    val claimed = checkNotNull(meta.claimedProtocolVersion) { "an intact envelope implies a string version" }
+    if (claimed !in MODERN_PROTOCOL_VERSIONS) {
+        return InboundOutcome.Reject(
+            error = RPCError(
+                code = RPCError.ErrorCode.UNSUPPORTED_PROTOCOL_VERSION,
+                message = "Unsupported protocol version: $claimed",
+                data = McpJson.encodeToJsonElement(
+                    UnsupportedProtocolVersionData(supported = MODERN_PROTOCOL_VERSIONS, requested = claimed),
+                ),
+            ),
+            status = HttpStatusCode.BadRequest,
+            id = id,
+        )
+    }
+
+    return if (id == null) {
+        InboundOutcome.ModernNotification(method)
+    } else {
+        InboundOutcome.Modern(method = method, id = id, protocolVersion = claimed)
+    }
+}
+
+/**
+ * What a body making no claim is.
+ *
+ * Handshake traffic, unless [MCP_PROTOCOL_VERSION_HEADER] names a request-scoped revision. The
+ * header never upgrades a classification, so that case is a rejection naming the envelope keys the
+ * body is missing, rather than a route into request-scoped serving.
+ */
+@OptIn(ExperimentalMcpApi::class, InternalMcpApi::class)
+private fun noClaim(body: JsonObject, headers: Headers): InboundOutcome {
+    val version = headers[MCP_PROTOCOL_VERSION_HEADER]
+    if (version == null || version !in MODERN_PROTOCOL_VERSIONS) return InboundOutcome.Legacy("no-claim")
+    val present = (body["params"] as? JsonObject)?.get("_meta") as? JsonObject
+    val missing = listOf(PROTOCOL_VERSION_META_KEY, CLIENT_CAPABILITIES_META_KEY)
+        .filter { present?.containsKey(it) != true }
+    return InboundOutcome.Reject(
+        error = RPCError(
+            code = RPCError.ErrorCode.INVALID_PARAMS,
+            message = "Invalid request envelope: " + missing.joinToString(", ") { "$it missing" },
+        ),
+        status = HttpStatusCode.BadRequest,
+        id = body["id"]?.let { McpJson.decodeFromJsonElement(RequestId.serializer(), it) },
+    )
+}
+
+/** The request metadata carrying a request-scoped claim, or `null` when this body makes none. */
+@OptIn(ExperimentalMcpApi::class)
+private fun claimOf(body: JsonObject): RequestMeta? {
+    val meta = (body["params"] as? JsonObject)?.get("_meta") as? JsonObject ?: return null
+    return RequestMeta(meta).takeIf { PROTOCOL_VERSION_META_KEY in meta }
+}
+
+/**
+ * The first standard header that is absent or disagrees with [body], or `null` when they all agree.
+ *
+ * Presence is checked explicitly rather than by comparison: an absent header and an absent body
+ * value would otherwise compare equal and mask each other.
+ */
+@OptIn(ExperimentalMcpApi::class, InternalMcpApi::class)
+private fun headerMismatch(
+    body: JsonObject,
+    method: String,
+    meta: RequestMeta,
+    headers: Headers,
+): RPCError? {
+    val version = headers[MCP_PROTOCOL_VERSION_HEADER]
+    if (version == null || version != meta.claimedProtocolVersion) {
+        return mismatch("$MCP_PROTOCOL_VERSION_HEADER does not match the request envelope's protocol version")
+    }
+    if (headers[MCP_METHOD_HEADER] != method) {
+        return mismatch("$MCP_METHOD_HEADER does not match the request body's method")
+    }
+    val nameKey = NAME_BEARING_METHODS[method] ?: return null
+    val expected = (body["params"] as? JsonObject)?.stringOf(nameKey) ?: return null
+    val raw = headers[MCP_NAME_HEADER]
+        ?: return mismatch("$MCP_NAME_HEADER is missing but the request body carries a '$nameKey' parameter")
+    // A malformed sentinel is itself a mismatch: comparing it literally would accept a value the
+    // sender never wrote.
+    if (decodeMcpHeaderValue(raw) != expected) {
+        return mismatch("$MCP_NAME_HEADER does not match the request body's '$nameKey' parameter")
+    }
+    return null
+}
+
+private fun mismatch(message: String): RPCError = RPCError(code = RPCError.ErrorCode.HEADER_MISMATCH, message = message)
+
+private fun JsonObject.stringOf(key: String): String? = (this[key] as? JsonPrimitive)?.takeIf { it.isString }?.content

--- a/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/InboundClassification.kt
+++ b/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/InboundClassification.kt
@@ -18,6 +18,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.RequestMeta
 import io.modelcontextprotocol.kotlin.sdk.types.UnsupportedProtocolVersionData
 import io.modelcontextprotocol.kotlin.sdk.types.decodeMcpHeaderValue
 import io.modelcontextprotocol.kotlin.sdk.types.validateEnvelope
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -57,15 +58,18 @@ internal sealed interface InboundOutcome {
 /**
  * Classifies one inbound HTTP body, body-primary, and runs the ladder rungs an HTTP entry owns.
  *
- * A body **claims** the request-scoped lifecycle if and only if its `params._meta` carries
- * [PROTOCOL_VERSION_META_KEY]. Nothing else counts as a claim, and no connection state
- * participates, so one endpoint can serve both lifecycles interleaved.
+ * An id-bearing body **claims** the request-scoped lifecycle if and only if its `params._meta`
+ * carries [PROTOCOL_VERSION_META_KEY]. Nothing else counts as a claim, and no connection state
+ * participates, so one endpoint can serve both lifecycles interleaved. An id-less body — a
+ * notification — carries no claim at this revision and is routed by the version header alone;
+ * see [classifyNotification].
  *
  * The rungs, in precedence order, each answering the earliest failure:
  *
- * 1. **jsonrpc-shape** — a batch containing a claim, and a body that is neither request nor
- *    notification, are refused [RPCError.ErrorCode.INVALID_REQUEST]. An all-handshake batch and a
- *    posted response stay handshake traffic.
+ * 1. **jsonrpc-shape** — a batch containing a claim, a body that is neither request nor
+ *    notification, and an `id` that is not a string or an integer are refused
+ *    [RPCError.ErrorCode.INVALID_REQUEST]. An all-handshake batch and a posted response stay
+ *    handshake traffic.
  * 2. **headers** — on requests only, [MCP_PROTOCOL_VERSION_HEADER] and [MCP_METHOD_HEADER] must be
  *    present and agree with the body, and [MCP_NAME_HEADER] must agree for the methods that mirror
  *    a param, else [RPCError.ErrorCode.HEADER_MISMATCH]. Ahead of the version rung, so a client
@@ -106,7 +110,12 @@ internal fun classifyInboundRequest(body: JsonElement, headers: Headers): Inboun
         )
     }
 
-    val meta = claimOf(body) ?: return noClaim(body, headers)
+    val idElement = body["id"]
+    val id = idElement?.toRequestIdOrNull()
+    if (idElement != null && id == null) return invalidIdReject()
+    if (id == null) return classifyNotification(body, headers)
+
+    val meta = claimOf(body) ?: return noClaim(id, body, headers)
     val method = body.stringOf("method")
         // A claim on something that is not a request or a notification: no method to route it by.
         ?: return InboundOutcome.Reject(
@@ -117,12 +126,9 @@ internal fun classifyInboundRequest(body: JsonElement, headers: Headers): Inboun
             status = HttpStatusCode.BadRequest,
             id = null,
         )
-    val id = body["id"]?.let { McpJson.decodeFromJsonElement(RequestId.serializer(), it) }
 
-    if (id != null) {
-        headerMismatch(body, method, meta, headers)?.let {
-            return InboundOutcome.Reject(it, HttpStatusCode.BadRequest, id)
-        }
+    headerMismatch(body, method, meta, headers)?.let {
+        return InboundOutcome.Reject(it, HttpStatusCode.BadRequest, id)
     }
 
     val issues = validateEnvelope(meta)
@@ -152,22 +158,48 @@ internal fun classifyInboundRequest(body: JsonElement, headers: Headers): Inboun
         )
     }
 
-    return if (id == null) {
-        InboundOutcome.ModernNotification(method)
-    } else {
-        InboundOutcome.Modern(method = method, id = id, protocolVersion = claimed)
-    }
+    return InboundOutcome.Modern(method = method, id = id, protocolVersion = claimed)
 }
 
 /**
- * What a body making no claim is.
+ * An id-less body, routed by [MCP_PROTOCOL_VERSION_HEADER] alone: notifications carry no body
+ * claim at this revision, so the header is determinative for them (as in the reference SDKs). A
+ * served modern version routes the notification to the `202` acknowledgement; anything else stays
+ * handshake traffic. Header presence is not required for notifications, but a present
+ * [MCP_METHOD_HEADER] must still agree with the body.
+ */
+private fun classifyNotification(body: JsonObject, headers: Headers): InboundOutcome {
+    val version = headers[MCP_PROTOCOL_VERSION_HEADER]
+    if (version == null || version !in MODERN_PROTOCOL_VERSIONS) return InboundOutcome.Legacy("notification")
+    val method = body.stringOf("method")
+        ?: return InboundOutcome.Reject(
+            error = RPCError(
+                code = RPCError.ErrorCode.INVALID_REQUEST,
+                message = "Body must be a single JSON-RPC request or notification object",
+            ),
+            status = HttpStatusCode.BadRequest,
+            id = null,
+        )
+    val methodHeader = headers[MCP_METHOD_HEADER]
+    if (methodHeader != null && methodHeader != method) {
+        return InboundOutcome.Reject(
+            error = mismatch("$MCP_METHOD_HEADER does not match the notification body's method"),
+            status = HttpStatusCode.BadRequest,
+            id = null,
+        )
+    }
+    return InboundOutcome.ModernNotification(method)
+}
+
+/**
+ * What an id-bearing body making no claim is.
  *
  * Handshake traffic, unless [MCP_PROTOCOL_VERSION_HEADER] names a request-scoped revision. The
  * header never upgrades a classification, so that case is a rejection naming the envelope keys the
  * body is missing, rather than a route into request-scoped serving.
  */
 @OptIn(ExperimentalMcpApi::class, InternalMcpApi::class)
-private fun noClaim(body: JsonObject, headers: Headers): InboundOutcome {
+private fun noClaim(id: RequestId, body: JsonObject, headers: Headers): InboundOutcome {
     val version = headers[MCP_PROTOCOL_VERSION_HEADER]
     if (version == null || version !in MODERN_PROTOCOL_VERSIONS) return InboundOutcome.Legacy("no-claim")
     val present = (body["params"] as? JsonObject)?.get("_meta") as? JsonObject
@@ -179,9 +211,29 @@ private fun noClaim(body: JsonObject, headers: Headers): InboundOutcome {
             message = "Invalid request envelope: " + missing.joinToString(", ") { "$it missing" },
         ),
         status = HttpStatusCode.BadRequest,
-        id = body["id"]?.let { McpJson.decodeFromJsonElement(RequestId.serializer(), it) },
+        id = id,
     )
 }
+
+/**
+ * [this] as a [RequestId], or `null` for any shape the JSON-RPC id grammar does not admit —
+ * `null`, booleans, fractional numbers, objects, arrays. The classifier answers those `-32600`
+ * rather than letting the serializer's exception escape the route as an HTTP 500.
+ */
+private fun JsonElement.toRequestIdOrNull(): RequestId? = try {
+    McpJson.decodeFromJsonElement(RequestId.serializer(), this)
+} catch (_: SerializationException) {
+    null
+}
+
+private fun invalidIdReject(): InboundOutcome.Reject = InboundOutcome.Reject(
+    error = RPCError(
+        code = RPCError.ErrorCode.INVALID_REQUEST,
+        message = "Invalid Request: id must be a string or an integer",
+    ),
+    status = HttpStatusCode.BadRequest,
+    id = null,
+)
 
 /** The request metadata carrying a request-scoped claim, or `null` when this body makes none. */
 @OptIn(ExperimentalMcpApi::class)

--- a/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/KtorServer.kt
+++ b/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/KtorServer.kt
@@ -27,8 +27,11 @@ import io.ktor.server.sse.ServerSSESession
 import io.ktor.server.sse.heartbeat
 import io.ktor.server.sse.sse
 import io.ktor.utils.io.KtorDsl
+import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCRequest
+import io.modelcontextprotocol.kotlin.sdk.types.McpJson
 import io.modelcontextprotocol.kotlin.sdk.types.RPCError
 import kotlinx.coroutines.awaitCancellation
+import kotlinx.serialization.SerializationException
 
 private val logger = KotlinLogging.logger {}
 
@@ -276,7 +279,7 @@ private fun Application.mcpStatelessStreamableHttp(
             installDnsRebindingProtection(enableDnsRebindingProtection, allowedHosts, allowedOrigins)
 
             post {
-                mcpStatelessStreamableHttpEndpoint(
+                mcpDualEraStreamableHttpEndpoint(
                     configuration = configuration,
                     block = block,
                 )
@@ -394,6 +397,58 @@ private fun ServerSSESession.mcpSseTransport(
     logger.info { "New SSE connection established and stored with sessionId: ${transport.sessionId}" }
 
     return transport
+}
+
+/**
+ * Routes one POST to the lifecycle its body asks for, then serves it.
+ *
+ * Body-primary and stateless, so a single endpoint serves both lifecycles interleaved, exactly as
+ * the reference SDKs do. The body is read once here — Ktor's request channel is single-use — and
+ * handed to whichever leg serves it.
+ */
+private suspend fun RoutingContext.mcpDualEraStreamableHttpEndpoint(
+    configuration: StreamableHttpServerTransport.Configuration,
+    block: RoutingContext.() -> Server,
+) {
+    val body = try {
+        call.receiveTextWithLimit(configuration.maxRequestBodySize)
+    } catch (e: RequestBodyTooLargeException) {
+        call.respondJsonRpcError(
+            error = RPCError(
+                code = RPCError.ErrorCode.INVALID_REQUEST,
+                message = "Invalid Request: message size exceeds maximum of ${e.maxBodySize} bytes",
+            ),
+            status = HttpStatusCode.PayloadTooLarge,
+            id = null,
+        )
+        return
+    }
+    call.attributes.put(PRE_READ_BODY, body)
+
+    val parsed = try {
+        McpJson.parseToJsonElement(body)
+    } catch (e: SerializationException) {
+        logger.debug(e) { "Rejected an unparseable request body" }
+        call.respondJsonRpcError(
+            error = RPCError(code = RPCError.ErrorCode.PARSE_ERROR, message = "Parse error"),
+            status = HttpStatusCode.BadRequest,
+            id = null,
+        )
+        return
+    }
+
+    when (val outcome = classifyInboundRequest(parsed, call.request.headers)) {
+        is InboundOutcome.Legacy -> mcpStatelessStreamableHttpEndpoint(configuration, block)
+
+        is InboundOutcome.Reject -> call.respondJsonRpcError(outcome.error, outcome.status, outcome.id)
+
+        is InboundOutcome.ModernNotification -> call.acknowledgeModernNotification(outcome.method)
+
+        is InboundOutcome.Modern -> call.serveModernRequest(
+            request = McpJson.decodeFromJsonElement(JSONRPCRequest.serializer(), parsed),
+            server = block(),
+        )
+    }
 }
 
 private suspend fun RoutingContext.mcpStatelessStreamableHttpEndpoint(

--- a/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/LoggingLevels.kt
+++ b/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/LoggingLevels.kt
@@ -1,0 +1,37 @@
+package io.modelcontextprotocol.kotlin.sdk.server
+
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
+import io.modelcontextprotocol.kotlin.sdk.types.LOG_LEVEL_META_KEY
+import io.modelcontextprotocol.kotlin.sdk.types.LoggingLevel
+import io.modelcontextprotocol.kotlin.sdk.types.McpJson
+import io.modelcontextprotocol.kotlin.sdk.types.RequestMeta
+import io.modelcontextprotocol.kotlin.sdk.types.isModernProtocolVersion
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.decodeFromJsonElement
+
+/**
+ * The `notifications/message` severities a server may emit while serving one request.
+ *
+ * The two lifecycles read opposite defaults, which is why this is computed per request:
+ *
+ * - Connection-scoped: every level is allowed here, and narrowing them stays the application's
+ *   `logging/setLevel` concern.
+ * - Request-scoped: a request opts in by carrying [LOG_LEVEL_META_KEY] and gets that level and
+ *   everything more severe. A request that does not carry it gets nothing, and a level some earlier
+ *   request set never leaks into it.
+ */
+@OptIn(ExperimentalMcpApi::class)
+internal fun allowedLogLevels(protocolVersion: String, meta: RequestMeta?): Set<LoggingLevel> {
+    if (!isModernProtocolVersion(protocolVersion)) return LoggingLevel.entries.toSet()
+    val requested = meta?.get(LOG_LEVEL_META_KEY)?.let { level ->
+        try {
+            McpJson.decodeFromJsonElement<LoggingLevel>(level)
+        } catch (_: SerializationException) {
+            null
+        } catch (_: IllegalArgumentException) {
+            // kotlinx reports some structural mismatches this way; either shape is unusable.
+            null
+        }
+    } ?: return emptySet()
+    return LoggingLevel.entries.filterTo(mutableSetOf()) { it >= requested }
+}

--- a/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ModernStreamableHttp.kt
+++ b/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ModernStreamableHttp.kt
@@ -1,0 +1,238 @@
+package io.modelcontextprotocol.kotlin.sdk.server
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.response.header
+import io.ktor.server.response.respond
+import io.ktor.server.response.respondBytesWriter
+import io.ktor.server.response.respondText
+import io.ktor.utils.io.writeString
+import io.modelcontextprotocol.kotlin.sdk.shared.AbstractTransport
+import io.modelcontextprotocol.kotlin.sdk.shared.TransportSendOptions
+import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCError
+import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCMessage
+import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCRequest
+import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCResponse
+import io.modelcontextprotocol.kotlin.sdk.types.McpJson
+import io.modelcontextprotocol.kotlin.sdk.types.RPCError
+import io.modelcontextprotocol.kotlin.sdk.types.RequestId
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.selects.select
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * How long a silent handler may run before the response commits to `text/event-stream`.
+ *
+ * Long enough that an ordinary request answers as JSON, short enough that a slow one starts its
+ * keepalive before a proxy's idle-read timeout closes the connection under it.
+ */
+private val SSE_PING_INTERVAL: Duration = 15.seconds
+
+/** Serves one request-scoped POST end to end, and answers with JSON or SSE as the handler dictates. */
+internal suspend fun ApplicationCall.serveModernRequest(request: JSONRPCRequest, server: Server) {
+    val transport = SingleExchangeTransport(request.id)
+    val session = server.createSession(transport)
+    try {
+        coroutineScope {
+            // Delivery blocks until the handler answers, so it gets its own coroutine: the deferral
+            // below has to watch the handler rather than wait behind it. Closing the response
+            // cancels this scope, which cancels the handler — on this wire that *is* cancellation.
+            val delivery = launch { transport.deliver(request) }
+            respondModern(transport, delivery)
+        }
+    } finally {
+        // One request, one session: nothing here outlives the exchange, and the revision forbids
+        // treating anything about it as continuity for the next one.
+        session.close()
+    }
+}
+
+/** Acknowledges a request-scoped notification POST, which this wire defines none of. */
+internal suspend fun ApplicationCall.acknowledgeModernNotification(method: String) {
+    // Cancellation is closing the response stream, and a per-request entry holds no cross-request
+    // state for a notification to act on — but clients in the field still post them, and a
+    // fire-and-forget message is better acknowledged than answered with an error nobody reads.
+    logger.debug { "Acknowledged and dropped request-scoped client notification $method" }
+    respond(HttpStatusCode.Accepted)
+}
+
+/** Answers [error] on [status], as a JSON-RPC error body correlated to [id] where there is one. */
+internal suspend fun ApplicationCall.respondJsonRpcError(error: RPCError, status: HttpStatusCode, id: RequestId?) {
+    respondText(
+        text = McpJson.encodeToString(JSONRPCError(id = id, error = error)),
+        contentType = ContentType.Application.Json,
+        status = status,
+    )
+}
+
+/**
+ * Waits out the deferral window and answers however it ends.
+ *
+ * A handler that answers — or fails — before emitting anything gets a plain JSON response, which is
+ * what keeps the revision's `404` and `400` requirements reachable for dispatch-time errors: once
+ * `text/event-stream` headers are written the status is locked to `200` and those become
+ * unsatisfiable. A handler that emits, or that runs silent past the window, commits to SSE.
+ */
+private suspend fun ApplicationCall.respondModern(transport: SingleExchangeTransport, delivery: Job) {
+    val first = withTimeoutOrNull(SSE_PING_INTERVAL) {
+        select<FirstEvent> {
+            // Notifications are offered first: a handler that emits and then answers in one breath
+            // leaves both ready at once, and select takes the earliest ready clause. Answering from
+            // the response would silently drop everything the handler emitted.
+            transport.notifications.onReceive { FirstEvent.Emitted(it) }
+            transport.outcome.onAwait { FirstEvent.Answered(it) }
+            // Delivery ending is only news when it ended without answering; the answer is written
+            // before delivery returns, so reading it here settles the tie rather than racing it.
+            delivery.onJoin { transport.answered()?.let(FirstEvent::Answered) ?: FirstEvent.Abandoned }
+        }
+    }
+
+    if (first is FirstEvent.Abandoned) {
+        respondText(
+            text = McpJson.encodeToString(
+                JSONRPCError(
+                    id = transport.requestId,
+                    error = RPCError(
+                        code = RPCError.ErrorCode.INTERNAL_ERROR,
+                        message = "The request handler returned without producing a response",
+                    ),
+                ),
+            ),
+            contentType = ContentType.Application.Json,
+            status = HttpStatusCode.OK,
+        )
+        return
+    }
+
+    if (first is FirstEvent.Answered) {
+        // Nothing raced the response into the channel, so this exchange never needed a stream.
+        val buffered = transport.notifications.tryReceive().getOrNull()
+        if (buffered == null) {
+            respondText(
+                text = McpJson.encodeToString(first.message),
+                contentType = ContentType.Application.Json,
+                status = statusOf(first.message),
+            )
+            return
+        }
+        commitSse(transport, pending = buffered)
+        return
+    }
+
+    commitSse(transport, pending = (first as? FirstEvent.Emitted)?.message)
+}
+
+/** Streams notifications, keepalives and finally the response over `text/event-stream`. */
+private suspend fun ApplicationCall.commitSse(transport: SingleExchangeTransport, pending: JSONRPCMessage?) {
+    response.header(HttpHeaders.CacheControl, "no-cache, no-transform")
+    // Tells reverse proxies not to buffer, which would hold every event until the response ends.
+    response.header("X-Accel-Buffering", "no")
+    respondBytesWriter(contentType = ContentType.Text.EventStream) {
+        pending?.let { writeString(sseEvent(it)) }
+        flush()
+        while (true) {
+            val next = withTimeoutOrNull(SSE_PING_INTERVAL) {
+                select<JSONRPCMessage?> {
+                    // Same bias as above: drain what the handler emitted before ending the stream.
+                    transport.notifications.onReceive { it }
+                    transport.outcome.onAwait { it }
+                }
+            }
+            when {
+                next == null -> writeString(": ping\r\n\r\n")
+
+                next.isFinal(transport.requestId) -> {
+                    writeString(sseEvent(next))
+                    flush()
+                    return@respondBytesWriter
+                }
+
+                else -> writeString(sseEvent(next))
+            }
+            flush()
+        }
+    }
+}
+
+/** Whether [this] is the response that ends the exchange rather than a notification within it. */
+private fun JSONRPCMessage.isFinal(requestId: RequestId): Boolean = when (this) {
+    is JSONRPCResponse -> id == requestId
+    is JSONRPCError -> id == requestId
+    else -> false
+}
+
+/**
+ * The HTTP status [message] travels on.
+ *
+ * `200`, unless it is an error whose code has an entry in [HTTP_STATUS_BY_ERROR_CODE].
+ */
+private fun statusOf(message: JSONRPCMessage): HttpStatusCode = when (message) {
+    is JSONRPCError -> HTTP_STATUS_BY_ERROR_CODE[message.error.code] ?: HttpStatusCode.OK
+    else -> HttpStatusCode.OK
+}
+
+private fun sseEvent(message: JSONRPCMessage): String = "data: ${McpJson.encodeToString(message)}\n\n"
+
+/** What ended the deferral window. */
+private sealed interface FirstEvent {
+    /** The handler answered. */
+    data class Answered(val message: JSONRPCMessage) : FirstEvent
+
+    /** The handler emitted a notification before answering. */
+    data class Emitted(val message: JSONRPCMessage) : FirstEvent
+
+    /** Delivery ended without an answer — a handler that neither returned nor failed. */
+    data object Abandoned : FirstEvent
+}
+
+/**
+ * The transport behind one request-scoped exchange.
+ *
+ * There is no session, no stream registry and no resumability to keep: one request goes in, its
+ * notifications and then its response come out. A message that is neither is dropped, because the
+ * revision requires every notification on a response stream to relate to its originating request and
+ * there is no other stream to put one on.
+ */
+private class SingleExchangeTransport(val requestId: RequestId) : AbstractTransport() {
+
+    val outcome: CompletableDeferred<JSONRPCMessage> = CompletableDeferred()
+
+    val notifications: Channel<JSONRPCMessage> = Channel(Channel.BUFFERED)
+
+    override suspend fun start() = Unit
+
+    override suspend fun send(message: JSONRPCMessage, options: TransportSendOptions?) {
+        if (message.isFinal(requestId)) {
+            outcome.complete(message)
+            return
+        }
+        if (notifications.trySend(message).isFailure) {
+            logger.debug { "Dropped a notification: the response stream is closed" }
+        }
+    }
+
+    override suspend fun close() {
+        notifications.close()
+        outcome.cancel()
+        invokeOnCloseCallback()
+    }
+
+    /** The answer to this exchange, or `null` while there is none yet. */
+    fun answered(): JSONRPCMessage? = if (outcome.isCompleted && !outcome.isCancelled) outcome.getCompleted() else null
+
+    /** Hands [message] to the session and returns once it has been answered. */
+    suspend fun deliver(message: JSONRPCMessage) {
+        _onMessage(message)
+    }
+}

--- a/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ModernStreamableHttp.kt
+++ b/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ModernStreamableHttp.kt
@@ -5,10 +5,14 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
+import io.ktor.server.http.HttpRequestCloseHandlerKey
+import io.ktor.server.request.ApplicationRequest
+import io.ktor.server.request.httpVersion
 import io.ktor.server.response.header
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondBytesWriter
 import io.ktor.server.response.respondText
+import io.ktor.utils.io.InternalAPI
 import io.ktor.utils.io.writeString
 import io.modelcontextprotocol.kotlin.sdk.shared.AbstractTransport
 import io.modelcontextprotocol.kotlin.sdk.shared.TransportSendOptions
@@ -19,13 +23,19 @@ import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCResponse
 import io.modelcontextprotocol.kotlin.sdk.types.McpJson
 import io.modelcontextprotocol.kotlin.sdk.types.RPCError
 import io.modelcontextprotocol.kotlin.sdk.types.RequestId
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ClosedSendChannelException
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.select
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.concurrent.Volatile
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -42,19 +52,74 @@ private val SSE_PING_INTERVAL: Duration = 15.seconds
 /** Serves one request-scoped POST end to end, and answers with JSON or SSE as the handler dictates. */
 internal suspend fun ApplicationCall.serveModernRequest(request: JSONRPCRequest, server: Server) {
     val transport = SingleExchangeTransport(request.id)
-    val session = server.createSession(transport)
+    // A request-scoped session serves one exchange and emits nothing that is not its own answer, so
+    // it stays off the feature-notification bus (§10: notifications on a response stream must relate
+    // to its originating request).
+    val session = server.createSession(transport, subscribeToFeatureNotifications = false)
+    val clientGone = DisconnectSignal()
     try {
         coroutineScope {
+            val exchange = this
+            // Closing the response stream is this wire's only cancellation channel, and nothing is
+            // written to the socket during the deferral window — the engine's close signal is the
+            // one place a disconnect shows up before a write fails.
+            onClientDisconnect {
+                clientGone.fired = true
+                exchange.cancel("The client closed the response stream")
+            }
             // Delivery blocks until the handler answers, so it gets its own coroutine: the deferral
             // below has to watch the handler rather than wait behind it. Closing the response
             // cancels this scope, which cancels the handler — on this wire that *is* cancellation.
             val delivery = launch { transport.deliver(request) }
             respondModern(transport, delivery)
         }
+    } catch (e: CancellationException) {
+        // Only the disconnect watch's own cancellation ends here; server shutdown and any outer
+        // cancellation must keep unwinding.
+        if (!clientGone.fired) throw e
+        logger.debug { "Abandoned exchange ${request.id}: the client closed the response stream" }
     } finally {
         // One request, one session: nothing here outlives the exchange, and the revision forbids
-        // treating anything about it as continuity for the next one.
-        session.close()
+        // treating anything about it as continuity for the next one. NonCancellable because this
+        // cleanup is what un-registers the session, disconnect or not.
+        withContext(NonCancellable) { session.close() }
+    }
+}
+
+/**
+ * Runs [block] when the engine learns the client closed this call's connection mid-request.
+ *
+ * The signal rides the per-call callback Ktor's `HttpRequestLifecycle` plugin consumes. CIO also
+ * fires it — falsely, for this purpose — the moment it knows a request is the last one on its
+ * connection, so an `HTTP/1.0` or `Connection: close` request would read as an instant disconnect;
+ * those requests keep write-failure detection instead, which is what every request got before this
+ * watch existed. So do engines that never fire the callback (Jetty, the test host).
+ */
+@OptIn(InternalAPI::class)
+private fun ApplicationCall.onClientDisconnect(block: () -> Unit) {
+    if (request.closesConnection()) return
+    val previous = attributes.getOrNull(HttpRequestCloseHandlerKey)
+    attributes.put(HttpRequestCloseHandlerKey) {
+        previous?.invoke()
+        block()
+    }
+}
+
+/** Set from the engine's close callback, read after cancellation — visibility, not contention. */
+private class DisconnectSignal {
+    @Volatile
+    var fired: Boolean = false
+}
+
+/** Whether this request itself asks the server to close the connection after answering. */
+private fun ApplicationRequest.closesConnection(): Boolean {
+    val options = headers.getAll(HttpHeaders.Connection).orEmpty()
+        .flatMap { it.split(',') }
+        .map { it.trim().lowercase() }
+    return when {
+        "keep-alive" in options -> false
+        "close" in options -> true
+        else -> httpVersion != "HTTP/1.1"
     }
 }
 
@@ -217,7 +282,12 @@ private class SingleExchangeTransport(val requestId: RequestId) : AbstractTransp
             outcome.complete(message)
             return
         }
-        if (notifications.trySend(message).isFailure) {
+        try {
+            // Suspends rather than drops when the buffer fills: on this wire a notification the
+            // handler emitted is part of the response, so backpressure into the handler is correct
+            // where silent loss is not. Only a genuinely closed stream drops, and says so honestly.
+            notifications.send(message)
+        } catch (_: ClosedSendChannelException) {
             logger.debug { "Dropped a notification: the response stream is closed" }
         }
     }

--- a/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/Server.kt
+++ b/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/Server.kt
@@ -1,14 +1,18 @@
 package io.modelcontextprotocol.kotlin.sdk.server
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
 import io.modelcontextprotocol.kotlin.sdk.server.utils.warnIfInvalidToolName
 import io.modelcontextprotocol.kotlin.sdk.shared.ProtocolOptions
 import io.modelcontextprotocol.kotlin.sdk.shared.RequestOptions
 import io.modelcontextprotocol.kotlin.sdk.shared.Transport
+import io.modelcontextprotocol.kotlin.sdk.types.CacheScope
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolRequest
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.types.CreateMessageRequest
 import io.modelcontextprotocol.kotlin.sdk.types.CreateMessageResult
+import io.modelcontextprotocol.kotlin.sdk.types.DiscoverRequest
+import io.modelcontextprotocol.kotlin.sdk.types.DiscoverResult
 import io.modelcontextprotocol.kotlin.sdk.types.ElicitRequestParams
 import io.modelcontextprotocol.kotlin.sdk.types.ElicitResult
 import io.modelcontextprotocol.kotlin.sdk.types.ElicitationCompleteNotification
@@ -27,6 +31,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.ListRootsResult
 import io.modelcontextprotocol.kotlin.sdk.types.ListToolsRequest
 import io.modelcontextprotocol.kotlin.sdk.types.ListToolsResult
 import io.modelcontextprotocol.kotlin.sdk.types.LoggingMessageNotification
+import io.modelcontextprotocol.kotlin.sdk.types.MODERN_PROTOCOL_VERSIONS
 import io.modelcontextprotocol.kotlin.sdk.types.McpException
 import io.modelcontextprotocol.kotlin.sdk.types.Method
 import io.modelcontextprotocol.kotlin.sdk.types.Notification
@@ -72,16 +77,33 @@ private val logger = KotlinLogging.logger {}
  * @property resourceTemplateMatcherFactory The factory used to create [ResourceTemplateMatcher] instances
  *   for matching resource URIs against registered templates. Defaults to [PathSegmentTemplateMatcher.factory].
  * @param handlerCoroutineContext Coroutine context for inbound handlers. See [ProtocolOptions.handlerCoroutineContext].
+ * @property sendServerInfo Whether results served under the request-scoped lifecycle identify this
+ *   server in their `_meta`. Results served under the handshake lifecycle are never stamped,
+ *   whatever this says.
+ * @property discoverTtlMs How long, in milliseconds, clients may treat this server's `server/discover`
+ *   result as fresh. `0`, the default, is immediately stale.
+ * @property discoverCacheScope Whether shared caches may serve this server's `server/discover` result
+ *   to principals other than the one that fetched it. Private by default.
+ * @throws IllegalArgumentException if [discoverTtlMs] is negative
  */
 public class ServerOptions(
     public val capabilities: ServerCapabilities,
     enforceStrictCapabilities: Boolean = true,
     public val resourceTemplateMatcherFactory: ResourceTemplateMatcherFactory = PathSegmentTemplateMatcher.factory,
     handlerCoroutineContext: CoroutineContext = Dispatchers.Default,
+    public val sendServerInfo: Boolean = true,
+    public val discoverTtlMs: Long = 0,
+    public val discoverCacheScope: CacheScope = CacheScope.Private,
 ) : ProtocolOptions(
     enforceStrictCapabilities = enforceStrictCapabilities,
     handlerCoroutineContext = handlerCoroutineContext,
 ) {
+    init {
+        // Checked here rather than where the result is built, so a misconfigured server fails at
+        // startup instead of on the first request that would have carried the hint.
+        require(discoverTtlMs >= 0) { "discoverTtlMs must be non-negative, but was $discoverTtlMs" }
+    }
+
     @JvmOverloads
     public constructor(
         capabilities: ServerCapabilities,
@@ -213,8 +235,22 @@ public open class Server(
      * @param transport The transport layer to connect the session with.
      * @return The initialized and connected server session.
      */
+    @OptIn(ExperimentalMcpApi::class)
     public suspend fun createSession(transport: Transport): ServerSession {
-        val session = ServerSession(serverInfo, options, instructionsProvider?.invoke())
+        val instructions = instructionsProvider?.invoke()
+        val session = ServerSession(serverInfo, options, instructions)
+
+        // Discovery is what replaces the initialize handshake, so every server answers it — there is
+        // no capability to gate it on, and a server that did not would be undiscoverable.
+        session.setRequestHandler<DiscoverRequest>(Method.Defined.ServerDiscover) { _, _ ->
+            DiscoverResult(
+                supportedVersions = MODERN_PROTOCOL_VERSIONS,
+                capabilities = options.capabilities,
+                instructions = instructions,
+                ttlMs = options.discoverTtlMs,
+                cacheScope = options.discoverCacheScope,
+            )
+        }
 
         // Internal handlers for tools
         if (options.capabilities.tools != null) {
@@ -662,6 +698,16 @@ public open class Server(
         } catch (e: UrlElicitationRequiredException) {
             // Surface a required URL-mode elicitation as a JSON-RPC error (-32042)
             throw e
+        } catch (e: McpException) {
+            // A tool that fails is a result marked isError, but a capability the client never
+            // declared is a defect of the request rather than of the run — the revision answers
+            // that as a JSON-RPC error, and on HTTP it is the one in-band code that is not 200.
+            if (e.code == RPCError.ErrorCode.MISSING_REQUIRED_CLIENT_CAPABILITY) throw e
+            logger.error(e) { "Error executing tool ${requestParams.name}" }
+            CallToolResult(
+                content = listOf(TextContent(text = "Error executing tool ${requestParams.name}: ${e.message}")),
+                isError = true,
+            )
         } catch (e: Exception) {
             logger.error(e) { "Error executing tool ${requestParams.name}" }
             CallToolResult(
@@ -713,8 +759,11 @@ public open class Server(
             )
             ?: run {
                 logger.error { "Resource not found: $uri" }
+                // Reported as INVALID_PARAMS rather than the retired RESOURCE_NOT_FOUND (-32002),
+                // which 2026-07-28 removed and which the reference SDKs stopped emitting on both
+                // eras. The offending URI stays in the error data either way.
                 throw McpException(
-                    code = RPCError.ErrorCode.RESOURCE_NOT_FOUND,
+                    code = RPCError.ErrorCode.INVALID_PARAMS,
                     message = "Resource not found",
                     data = buildJsonObject { put("uri", uri) },
                 )

--- a/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/Server.kt
+++ b/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/Server.kt
@@ -235,8 +235,18 @@ public open class Server(
      * @param transport The transport layer to connect the session with.
      * @return The initialized and connected server session.
      */
+    public suspend fun createSession(transport: Transport): ServerSession =
+        createSession(transport, subscribeToFeatureNotifications = true)
+
+    /**
+     * @param subscribeToFeatureNotifications whether the session joins the shared bus that fans
+     *   `list_changed` / `resources/updated` out to every connection. A request-scoped session must
+     *   not: the request-scoped wire requires every notification on a response stream to relate to
+     *   its originating request, and one arriving unrelated would also commit the SSE stream early
+     *   and lock its status. Such a session is unsubscribed and emits none.
+     */
     @OptIn(ExperimentalMcpApi::class)
-    public suspend fun createSession(transport: Transport): ServerSession {
+    internal suspend fun createSession(transport: Transport, subscribeToFeatureNotifications: Boolean): ServerSession {
         val instructions = instructionsProvider?.invoke()
         val session = ServerSession(serverInfo, options, instructions)
 
@@ -300,7 +310,7 @@ public open class Server(
         // Register cleanup handler to remove session from list when it closes
         session.onClose {
             logger.debug { "Removing closed session from active sessions list" }
-            notificationService.unsubscribeSession(session)
+            if (subscribeToFeatureNotifications) notificationService.unsubscribeSession(session)
             sessionRegistry.removeSession(session.sessionId)
         }
 
@@ -308,7 +318,7 @@ public open class Server(
         session.connect(transport)
         logger.debug { "Server session successfully connected to transport" }
         sessionRegistry.addSession(session)
-        notificationService.subscribeSession(session)
+        if (subscribeToFeatureNotifications) notificationService.subscribeSession(session)
 
         _onConnect()
         return session

--- a/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ServerSession.kt
+++ b/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ServerSession.kt
@@ -12,11 +12,12 @@ import io.modelcontextprotocol.kotlin.sdk.types.ElicitResult
 import io.modelcontextprotocol.kotlin.sdk.types.ElicitationCompleteNotification
 import io.modelcontextprotocol.kotlin.sdk.types.EmptyJsonObject
 import io.modelcontextprotocol.kotlin.sdk.types.EmptyResult
+import io.modelcontextprotocol.kotlin.sdk.types.HANDSHAKE_PROTOCOL_VERSIONS
 import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import io.modelcontextprotocol.kotlin.sdk.types.InitializeRequest
 import io.modelcontextprotocol.kotlin.sdk.types.InitializeResult
 import io.modelcontextprotocol.kotlin.sdk.types.InitializedNotification
-import io.modelcontextprotocol.kotlin.sdk.types.LATEST_PROTOCOL_VERSION
+import io.modelcontextprotocol.kotlin.sdk.types.LATEST_HANDSHAKE_VERSION
 import io.modelcontextprotocol.kotlin.sdk.types.ListRootsRequest
 import io.modelcontextprotocol.kotlin.sdk.types.ListRootsResult
 import io.modelcontextprotocol.kotlin.sdk.types.LoggingLevel
@@ -27,7 +28,6 @@ import io.modelcontextprotocol.kotlin.sdk.types.Method.Defined
 import io.modelcontextprotocol.kotlin.sdk.types.RPCError
 import io.modelcontextprotocol.kotlin.sdk.types.RequestMeta
 import io.modelcontextprotocol.kotlin.sdk.types.ResourceUpdatedNotification
-import io.modelcontextprotocol.kotlin.sdk.types.SUPPORTED_PROTOCOL_VERSIONS
 import io.modelcontextprotocol.kotlin.sdk.types.SetLevelRequest
 import kotlinx.atomicfu.AtomicRef
 import kotlinx.atomicfu.atomic
@@ -70,6 +70,7 @@ public open class ServerSession(
 
     private val _clientCapabilities: AtomicRef<ClientCapabilities?> = atomic(null)
     private val _clientVersion: AtomicRef<Implementation?> = atomic(null)
+    private val _negotiatedProtocolVersion: AtomicRef<String?> = atomic(null)
 
     /** Capabilities reported by the client during initialization, or `null` before the handshake completes. */
     public val clientCapabilities: ClientCapabilities? get() = _clientCapabilities.value
@@ -78,9 +79,32 @@ public open class ServerSession(
     public val clientVersion: Implementation? get() = _clientVersion.value
 
     /**
+     * The protocol version agreed during initialization, or `null` before the handshake completes.
+     *
+     * Describes only requests served under the handshake lifecycle. A request carrying its own
+     * protocol envelope reports its version through
+     * [RequestHandlerExtra.protocolVersion][io.modelcontextprotocol.kotlin.sdk.shared.RequestHandlerExtra.protocolVersion].
+     */
+    public val protocolVersion: String? get() = _negotiatedProtocolVersion.value
+
+    final override val negotiatedProtocolVersion: String? get() = _negotiatedProtocolVersion.value
+
+    final override val declaredClientCapabilities: ClientCapabilities? get() = _clientCapabilities.value
+
+    final override val declaredClientInfo: Implementation? get() = _clientVersion.value
+
+    /**
+     * The identity stamped into every result served under the request-scoped lifecycle, unless
+     * [ServerOptions.sendServerInfo] turns it off. Handshake-era results are untouched either way.
+     */
+    final override val outboundServerInfo: Implementation? get() = serverInfo.takeIf { sendServerInfo }
+
+    /**
      * The capabilities supported by the server, related to the session.
      */
     private val serverCapabilities = options.capabilities
+
+    private val sendServerInfo = options.sendServerInfo
 
     /**
      * The current logging level set by the client.
@@ -352,15 +376,16 @@ public open class ServerSession(
         _clientVersion.value = request.params.clientInfo
 
         val requestedVersion = request.params.protocolVersion
-        val protocolVersion = if (SUPPORTED_PROTOCOL_VERSIONS.contains(requestedVersion)) {
+        val protocolVersion = if (HANDSHAKE_PROTOCOL_VERSIONS.contains(requestedVersion)) {
             requestedVersion
         } else {
             logger.warn {
                 "Client requested unsupported protocol version $requestedVersion, " +
-                    "falling back to $LATEST_PROTOCOL_VERSION"
+                    "falling back to $LATEST_HANDSHAKE_VERSION"
             }
-            LATEST_PROTOCOL_VERSION
+            LATEST_HANDSHAKE_VERSION
         }
+        _negotiatedProtocolVersion.value = protocolVersion
 
         return InitializeResult(
             protocolVersion = protocolVersion,

--- a/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/StreamableHttpServerTransport.kt
+++ b/kotlin-sdk-server/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/server/StreamableHttpServerTransport.kt
@@ -14,11 +14,13 @@ import io.ktor.server.response.header
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondText
 import io.ktor.server.sse.ServerSSESession
+import io.ktor.util.AttributeKey
 import io.ktor.util.collections.ConcurrentMap
 import io.modelcontextprotocol.kotlin.sdk.shared.AbstractTransport
 import io.modelcontextprotocol.kotlin.sdk.shared.TransportSendOptions
 import io.modelcontextprotocol.kotlin.sdk.types.CancelledNotificationParams
 import io.modelcontextprotocol.kotlin.sdk.types.DEFAULT_NEGOTIATED_PROTOCOL_VERSION
+import io.modelcontextprotocol.kotlin.sdk.types.HANDSHAKE_PROTOCOL_VERSIONS
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCEmptyMessage
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCError
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCMessage
@@ -30,7 +32,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.Method
 import io.modelcontextprotocol.kotlin.sdk.types.RPCError
 import io.modelcontextprotocol.kotlin.sdk.types.RPCError.ErrorCode.REQUEST_TIMEOUT
 import io.modelcontextprotocol.kotlin.sdk.types.RequestId
-import io.modelcontextprotocol.kotlin.sdk.types.SUPPORTED_PROTOCOL_VERSIONS
+import io.modelcontextprotocol.kotlin.sdk.types.isVersionAtLeast
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.awaitCancellation
@@ -50,6 +52,9 @@ import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
 internal const val MCP_SESSION_ID_HEADER = "mcp-session-id"
+
+/** The request body, already read by an entry that had to classify it before routing. */
+internal val PRE_READ_BODY: AttributeKey<String> = AttributeKey("mcp-pre-read-body")
 private const val MCP_PROTOCOL_VERSION_HEADER = "mcp-protocol-version"
 private const val MCP_RESUMPTION_TOKEN_HEADER = "Last-Event-ID"
 private const val MIN_PRIMING_EVENT_PROTOCOL_VERSION = "2025-11-25"
@@ -782,12 +787,12 @@ public class StreamableHttpServerTransport(private val configuration: Configurat
         val version = call.request.headers[MCP_PROTOCOL_VERSION_HEADER] ?: return true
 
         return when (version) {
-            !in SUPPORTED_PROTOCOL_VERSIONS -> {
+            !in HANDSHAKE_PROTOCOL_VERSIONS -> {
                 call.reject(
                     HttpStatusCode.BadRequest,
                     RPCError.ErrorCode.CONNECTION_CLOSED,
                     "Bad Request: Unsupported protocol version (supported versions: ${
-                        SUPPORTED_PROTOCOL_VERSIONS.joinToString(
+                        HANDSHAKE_PROTOCOL_VERSIONS.joinToString(
                             ", ",
                         )
                     })",
@@ -840,7 +845,9 @@ public class StreamableHttpServerTransport(private val configuration: Configurat
 
     private suspend fun parseBody(call: ApplicationCall): List<JSONRPCMessage>? {
         val body = try {
-            call.receiveTextWithLimit(configuration.maxRequestBodySize)
+            // A dual-era entry has already read the body to classify it; Ktor's request channel is
+            // single-use, so it hands the text over rather than letting this read it again.
+            call.attributes.getOrNull(PRE_READ_BODY) ?: call.receiveTextWithLimit(configuration.maxRequestBodySize)
         } catch (e: RequestBodyTooLargeException) {
             call.reject(
                 HttpStatusCode.PayloadTooLarge,
@@ -914,7 +921,7 @@ public class StreamableHttpServerTransport(private val configuration: Configurat
         // Priming events have empty data which older clients cannot handle.
         // Only send priming events to clients with protocol version >= 2025-11-25
         // which includes the fix for handling empty SSE data.
-        if (clientProtocolVersion < MIN_PRIMING_EVENT_PROTOCOL_VERSION) return
+        if (!isVersionAtLeast(clientProtocolVersion, MIN_PRIMING_EVENT_PROTOCOL_VERSION)) return
         try {
             val primingEventId = store.storeEvent(streamId, JSONRPCEmptyMessage)
             session.send(

--- a/kotlin-sdk-server/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/InboundClassificationTest.kt
+++ b/kotlin-sdk-server/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/InboundClassificationTest.kt
@@ -1,0 +1,211 @@
+package io.modelcontextprotocol.kotlin.sdk.server
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.http.Headers
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.modelcontextprotocol.kotlin.sdk.InternalMcpApi
+import io.modelcontextprotocol.kotlin.sdk.types.CLIENT_CAPABILITIES_META_KEY
+import io.modelcontextprotocol.kotlin.sdk.types.LATEST_HANDSHAKE_VERSION
+import io.modelcontextprotocol.kotlin.sdk.types.LATEST_MODERN_VERSION
+import io.modelcontextprotocol.kotlin.sdk.types.MCP_METHOD_HEADER
+import io.modelcontextprotocol.kotlin.sdk.types.MCP_NAME_HEADER
+import io.modelcontextprotocol.kotlin.sdk.types.MCP_PROTOCOL_VERSION_HEADER
+import io.modelcontextprotocol.kotlin.sdk.types.McpJson
+import io.modelcontextprotocol.kotlin.sdk.types.RPCError
+import io.modelcontextprotocol.kotlin.sdk.types.RequestId
+import io.modelcontextprotocol.kotlin.sdk.types.UnsupportedProtocolVersionData
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlin.test.Test
+import kotlin.test.assertNull
+
+/**
+ * The inbound ladder, cell by cell, driven through the pure classifier — one test per rung
+ * behavior, so a rung cannot be reordered or dropped without a named failure here.
+ */
+@OptIn(InternalMcpApi::class)
+class InboundClassificationTest {
+
+    private fun envelope(version: String = LATEST_MODERN_VERSION): String =
+        """
+        "_meta": {
+          "io.modelcontextprotocol/protocolVersion": "$version",
+          "io.modelcontextprotocol/clientCapabilities": {}
+        }
+        """.trimIndent()
+
+    private fun request(id: String = "1", method: String = "tools/list", meta: String? = envelope()): String {
+        val params = meta?.let { """, "params": {$it}""" } ?: ""
+        return """{"jsonrpc": "2.0", "id": $id, "method": "$method"$params}"""
+    }
+
+    private fun modernHeaders(
+        version: String = LATEST_MODERN_VERSION,
+        method: String? = "tools/list",
+        name: String? = null,
+    ): Headers {
+        val pairs = buildList {
+            add(MCP_PROTOCOL_VERSION_HEADER to listOf(version))
+            method?.let { add(MCP_METHOD_HEADER to listOf(it)) }
+            name?.let { add(MCP_NAME_HEADER to listOf(it)) }
+        }
+        return headersOf(*pairs.toTypedArray())
+    }
+
+    private fun classify(body: String, headers: Headers = modernHeaders()): InboundOutcome =
+        classifyInboundRequest(McpJson.parseToJsonElement(body), headers)
+
+    private fun InboundOutcome.shouldReject(code: Int, status: HttpStatusCode): InboundOutcome.Reject {
+        val reject = shouldBeInstanceOf<InboundOutcome.Reject>()
+        reject.error.code shouldBe code
+        reject.status shouldBe status
+        return reject
+    }
+
+    // Rung 1 — jsonrpc-shape.
+
+    @Test
+    fun `should refuse a batch carrying a claim`() {
+        val body = """[${request()}, ${request(id = "2", meta = null)}]"""
+        classify(body).shouldReject(RPCError.ErrorCode.INVALID_REQUEST, HttpStatusCode.BadRequest)
+    }
+
+    @Test
+    fun `should keep an all-handshake batch as legacy traffic`() {
+        val body = """[${request(meta = null)}, ${request(id = "2", meta = null)}]"""
+        classify(body, headers = headersOf()).shouldBeInstanceOf<InboundOutcome.Legacy>()
+    }
+
+    @Test
+    fun `should refuse a body that is not an object or an array`() {
+        classify("42").shouldReject(RPCError.ErrorCode.INVALID_REQUEST, HttpStatusCode.BadRequest)
+    }
+
+    @Test
+    fun `should refuse an id that is not a string or an integer`() {
+        // Each shape previously escaped the classifier as a serializer exception, i.e. an HTTP 500.
+        for (id in listOf("null", "true", "1.5", "{}", "[]")) {
+            val reject = classify(request(id = id))
+                .shouldReject(RPCError.ErrorCode.INVALID_REQUEST, HttpStatusCode.BadRequest)
+            assertNull(reject.id, "an unusable id cannot be echoed")
+        }
+    }
+
+    // Rung 2 — standard headers, requests only.
+
+    @Test
+    fun `should classify an intact enveloped request as modern`() {
+        val outcome = classify(request()).shouldBeInstanceOf<InboundOutcome.Modern>()
+        outcome.method shouldBe "tools/list"
+        outcome.id shouldBe RequestId(1L)
+        outcome.protocolVersion shouldBe LATEST_MODERN_VERSION
+    }
+
+    @Test
+    fun `should report a self-disagreement ahead of an unsupported version`() {
+        // Spec precedence: a client disagreeing with itself is told so, not told its version is
+        // unsupported — the envelope here names a revision the server would also refuse.
+        val body = request(meta = envelope(version = LATEST_HANDSHAKE_VERSION))
+        classify(body, modernHeaders(version = LATEST_MODERN_VERSION))
+            .shouldReject(RPCError.ErrorCode.HEADER_MISMATCH, HttpStatusCode.BadRequest)
+    }
+
+    @Test
+    fun `should refuse a modern request without the version header`() {
+        classify(request(), headersOf(MCP_METHOD_HEADER, "tools/list"))
+            .shouldReject(RPCError.ErrorCode.HEADER_MISMATCH, HttpStatusCode.BadRequest)
+    }
+
+    @Test
+    fun `should refuse a modern request without the method header`() {
+        classify(request(), modernHeaders(method = null))
+            .shouldReject(RPCError.ErrorCode.HEADER_MISMATCH, HttpStatusCode.BadRequest)
+    }
+
+    @Test
+    fun `should refuse a name header disagreeing with the body`() {
+        val body = """
+            {"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+             "params": {"name": "add", ${envelope()}}}
+        """.trimIndent()
+        classify(body, modernHeaders(method = "tools/call", name = "subtract"))
+            .shouldReject(RPCError.ErrorCode.HEADER_MISMATCH, HttpStatusCode.BadRequest)
+    }
+
+    // Rung 3 — envelope.
+
+    @Test
+    fun `should refuse a claim whose envelope is missing a required key`() {
+        val meta = """"_meta": {"io.modelcontextprotocol/protocolVersion": "$LATEST_MODERN_VERSION"}"""
+        val reject = classify(request(meta = meta))
+            .shouldReject(RPCError.ErrorCode.INVALID_PARAMS, HttpStatusCode.BadRequest)
+        reject.id shouldBe RequestId(1L)
+        reject.error.message shouldContain CLIENT_CAPABILITIES_META_KEY
+    }
+
+    @Test
+    fun `should refuse a claim-free request under a modern version header naming the missing keys`() {
+        val reject = classify(request(meta = null))
+            .shouldReject(RPCError.ErrorCode.INVALID_PARAMS, HttpStatusCode.BadRequest)
+        reject.id shouldBe RequestId(1L)
+    }
+
+    @Test
+    fun `should keep a claim-free request without a modern header as legacy traffic`() {
+        classify(request(meta = null), headers = headersOf()).shouldBeInstanceOf<InboundOutcome.Legacy>()
+    }
+
+    // Rung 4 — version.
+
+    @Test
+    fun `should refuse an envelope naming a handshake revision as unsupported`() {
+        val body = request(meta = envelope(version = LATEST_HANDSHAKE_VERSION))
+        val reject = classify(body, modernHeaders(version = LATEST_HANDSHAKE_VERSION))
+            .shouldReject(RPCError.ErrorCode.UNSUPPORTED_PROTOCOL_VERSION, HttpStatusCode.BadRequest)
+        val data = McpJson.decodeFromJsonElement<UnsupportedProtocolVersionData>(reject.error.data!!)
+        data.requested shouldBe LATEST_HANDSHAKE_VERSION
+        data.supported shouldBe listOf(LATEST_MODERN_VERSION)
+    }
+
+    // Notifications — id-less bodies are routed by the version header alone, as in the reference
+    // SDKs; the spec answers them 202 on this wire.
+
+    @Test
+    fun `should acknowledge a claim-free notification under a modern version header`() {
+        val outcome = classify(
+            """{"jsonrpc": "2.0", "method": "notifications/cancelled"}""",
+            modernHeaders(method = null),
+        ).shouldBeInstanceOf<InboundOutcome.ModernNotification>()
+        outcome.method shouldBe "notifications/cancelled"
+    }
+
+    @Test
+    fun `should route a notification by the header even when its body carries a claim`() {
+        // The claim — malformed here — is ignored: notifications carry no body claim at this
+        // revision, so nothing in the body can reclassify or refuse one.
+        val meta = """"_meta": {"io.modelcontextprotocol/protocolVersion": 7}"""
+        val body = """{"jsonrpc": "2.0", "method": "notifications/cancelled", "params": {$meta}}"""
+        classify(body, modernHeaders(method = null)).shouldBeInstanceOf<InboundOutcome.ModernNotification>()
+    }
+
+    @Test
+    fun `should keep a notification without a modern header as legacy traffic`() {
+        classify("""{"jsonrpc": "2.0", "method": "notifications/initialized"}""", headers = headersOf())
+            .shouldBeInstanceOf<InboundOutcome.Legacy>()
+    }
+
+    @Test
+    fun `should refuse a notification method header disagreeing with the body`() {
+        classify(
+            """{"jsonrpc": "2.0", "method": "notifications/cancelled"}""",
+            modernHeaders(method = "notifications/progress"),
+        ).shouldReject(RPCError.ErrorCode.HEADER_MISMATCH, HttpStatusCode.BadRequest)
+    }
+
+    @Test
+    fun `should refuse an id-less body without a method`() {
+        classify("""{"jsonrpc": "2.0"}""").shouldReject(RPCError.ErrorCode.INVALID_REQUEST, HttpStatusCode.BadRequest)
+    }
+}

--- a/kotlin-sdk-server/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ServerSessionAssertCapabilityTest.kt
+++ b/kotlin-sdk-server/src/commonTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ServerSessionAssertCapabilityTest.kt
@@ -8,7 +8,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import io.modelcontextprotocol.kotlin.sdk.types.InitializeRequest
 import io.modelcontextprotocol.kotlin.sdk.types.InitializeRequestParams
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCMessage
-import io.modelcontextprotocol.kotlin.sdk.types.LATEST_PROTOCOL_VERSION
+import io.modelcontextprotocol.kotlin.sdk.types.LATEST_HANDSHAKE_VERSION
 import io.modelcontextprotocol.kotlin.sdk.types.Method
 import io.modelcontextprotocol.kotlin.sdk.types.RequestId
 import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
@@ -120,7 +120,7 @@ class ServerSessionAssertCapabilityTest {
         override suspend fun start() {
             val initializeRequest = InitializeRequest(
                 params = InitializeRequestParams(
-                    protocolVersion = LATEST_PROTOCOL_VERSION,
+                    protocolVersion = LATEST_HANDSHAKE_VERSION,
                     capabilities = clientCapabilities,
                     clientInfo = Implementation("mock-client", "1.0.0"),
                 ),

--- a/kotlin-sdk-server/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ModernStreamableHttpTest.kt
+++ b/kotlin-sdk-server/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/ModernStreamableHttpTest.kt
@@ -1,0 +1,262 @@
+package io.modelcontextprotocol.kotlin.sdk.server
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.preparePost
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import io.modelcontextprotocol.kotlin.sdk.ExperimentalMcpApi
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.EmptyJsonObject
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCError
+import io.modelcontextprotocol.kotlin.sdk.types.LATEST_MODERN_VERSION
+import io.modelcontextprotocol.kotlin.sdk.types.LoggingLevel
+import io.modelcontextprotocol.kotlin.sdk.types.LoggingMessageNotification
+import io.modelcontextprotocol.kotlin.sdk.types.LoggingMessageNotificationParams
+import io.modelcontextprotocol.kotlin.sdk.types.McpJson
+import io.modelcontextprotocol.kotlin.sdk.types.NAME_BEARING_METHODS
+import io.modelcontextprotocol.kotlin.sdk.types.RPCError
+import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+
+/**
+ * The HTTP contract of the request-scoped lifecycle (protocol revision 2026-07-28, SEP-2575): the
+ * status each rejection travels on, notification handling, and the deferral before a response
+ * commits to `text/event-stream`.
+ *
+ * Driven over raw HTTP rather than through [io.modelcontextprotocol.kotlin.sdk.client.Client]
+ * because every assertion here is about a status code, a header or the response media type — none of
+ * which the typed client surface can observe. Bodies are built by hand for the same reason: several
+ * of these requests are ones a conforming client cannot produce.
+ *
+ * All statuses are spec-mandated (revision §Transports, Streamable HTTP).
+ */
+@OptIn(ExperimentalMcpApi::class, io.modelcontextprotocol.kotlin.sdk.InternalMcpApi::class)
+class ModernStreamableHttpTest {
+
+    @Test
+    fun `a request-scoped tool call answers 200 with the tool result`() = testApplication {
+        serve()
+
+        val response = post(callTool("echo"))
+
+        response.status shouldBe HttpStatusCode.OK
+        response.bodyAsText() shouldContain "echoed"
+    }
+
+    @Test
+    fun `a method the revision does not define answers 404`() = testApplication {
+        serve()
+
+        // `ping` is one of the six the revision removed, so it is absent from this lifecycle's
+        // registry even though the SDK still serves it on the other one.
+        val response = post(request(id = 1, method = "ping"), method = "ping")
+
+        response.status shouldBe HttpStatusCode.NotFound
+        response.errorCode() shouldBe RPCError.ErrorCode.METHOD_NOT_FOUND
+    }
+
+    @Test
+    fun `a protocol version this server does not serve answers 400`() = testApplication {
+        serve()
+
+        // Header and body agree; it is the revision they agree on that this server does not serve.
+        val response = post(callTool("echo", protocolVersion = "2999-01-01"), versionHeader = "2999-01-01")
+
+        response.status shouldBe HttpStatusCode.BadRequest
+        response.errorCode() shouldBe RPCError.ErrorCode.UNSUPPORTED_PROTOCOL_VERSION
+    }
+
+    @Test
+    fun `a protocol version header disagreeing with the body answers 400`() = testApplication {
+        serve()
+
+        val response = post(callTool("echo"), versionHeader = "2025-11-25")
+
+        // The two restate one another, so a disagreement means one is wrong and neither can be
+        // trusted — reported before the version gate, so a client contradicting itself is told that.
+        response.status shouldBe HttpStatusCode.BadRequest
+        response.errorCode() shouldBe RPCError.ErrorCode.HEADER_MISMATCH
+    }
+
+    @Test
+    fun `an envelope missing its client capabilities answers 400`() = testApplication {
+        serve()
+
+        val body = """
+            {"jsonrpc":"2.0","id":1,"method":"tools/list",
+             "params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"$LATEST_MODERN_VERSION"}}}
+        """.trimIndent()
+        val response = post(body, method = "tools/list")
+
+        response.status shouldBe HttpStatusCode.BadRequest
+        response.errorCode() shouldBe RPCError.ErrorCode.INVALID_PARAMS
+        response.bodyAsText() shouldContain "clientCapabilities"
+    }
+
+    @Test
+    fun `an invalid-params error from dispatch stays in band on 200`() = testApplication {
+        serve()
+
+        val body = """
+            {"jsonrpc":"2.0","id":1,"method":"resources/read",
+             "params":{"uri":"test://absent",
+                       "_meta":{"io.modelcontextprotocol/protocolVersion":"$LATEST_MODERN_VERSION",
+                                "io.modelcontextprotocol/clientCapabilities":{}}}}
+        """.trimIndent()
+        val response = post(body, method = "resources/read", name = "test://absent")
+
+        // The defining case for keying status on origin. The envelope rung is the only
+        // invalid-params rejection the revision maps to 400; one produced past the entry gate is
+        // the payload, not an HTTP failure — otherwise a bad argument would mislead every proxy,
+        // retry and metric between here and the caller.
+        response.status shouldBe HttpStatusCode.OK
+        response.errorCode() shouldBe RPCError.ErrorCode.INVALID_PARAMS
+    }
+
+    @Test
+    fun `a request-scoped notification is acknowledged with 202 and no body`() = testApplication {
+        serve()
+
+        val body = """
+            {"jsonrpc":"2.0","method":"notifications/cancelled",
+             "params":{"requestId":1,
+                       "_meta":{"io.modelcontextprotocol/protocolVersion":"$LATEST_MODERN_VERSION",
+                                "io.modelcontextprotocol/clientCapabilities":{}}}}
+        """.trimIndent()
+        val response = post(body, method = "notifications/cancelled")
+
+        response.status shouldBe HttpStatusCode.Accepted
+        response.bodyAsText() shouldBe ""
+    }
+
+    @Test
+    fun `a session id offered on a request-scoped POST is ignored`() = testApplication {
+        serve()
+
+        val response = post(callTool("echo")) { header("mcp-session-id", "not-a-session") }
+
+        // The revision has no sessions: an id is neither honoured nor echoed back.
+        response.status shouldBe HttpStatusCode.OK
+        response.headers["mcp-session-id"] shouldBe null
+    }
+
+    @Test
+    fun `a handler that emits a notification commits the response to an event stream`() = testApplication {
+        serve {
+            sendLoggingMessage(
+                LoggingMessageNotification(
+                    LoggingMessageNotificationParams(
+                        level = LoggingLevel.Warning,
+                        data = JsonPrimitive("mid-flight"),
+                    ),
+                ),
+            )
+            CallToolResult(content = listOf(TextContent("echoed")))
+        }
+
+        // The stream stays open until the handler answers, so the body is read inside `execute`;
+        // reading it afterwards would race the writer and see only what had arrived by then.
+        client.preparePost("/mcp") {
+            modernHeaders(method = "tools/call", name = "echo")
+            setBody(callTool("echo", logLevel = LoggingLevel.Warning))
+        }.execute { response ->
+            response.status shouldBe HttpStatusCode.OK
+            response.contentType()?.withoutParameters() shouldBe ContentType.Text.EventStream
+            response.headers["X-Accel-Buffering"] shouldBe "no"
+            // What arrives after the commit is asserted over a real engine, in
+            // `ModernStreamableHttpStreamTest`: this engine does not drive a streaming body
+            // concurrently with the handler that is still filling it.
+            response.bodyAsText() shouldContain "notifications/message"
+        }
+    }
+
+    /** Registers a server exposing one `echo` tool at `/mcp`. */
+    private fun ApplicationTestBuilder.serve(
+        handler: suspend ClientConnection.(io.modelcontextprotocol.kotlin.sdk.types.CallToolRequest) -> CallToolResult =
+            { CallToolResult(content = listOf(TextContent("echoed"))) },
+    ) {
+        application {
+            mcpStatelessStreamableHttp {
+                Server(
+                    Implementation("test-server", "1.0"),
+                    ServerOptions(
+                        capabilities = ServerCapabilities(
+                            tools = ServerCapabilities.Tools(null),
+                            resources = ServerCapabilities.Resources(subscribe = null, listChanged = null),
+                            logging = EmptyJsonObject,
+                        ),
+                    ),
+                ).apply {
+                    addTool(
+                        name = "echo",
+                        description = "echoes",
+                        inputSchema = ToolSchema(properties = EmptyJsonObject, required = null),
+                        handler = handler,
+                    )
+                }
+            }
+        }
+    }
+
+    private suspend fun ApplicationTestBuilder.post(
+        body: String,
+        method: String = "tools/call",
+        name: String? = "echo",
+        versionHeader: String = LATEST_MODERN_VERSION,
+        extra: HttpRequestBuilder.() -> Unit = {},
+    ): HttpResponse = client.post("/mcp") {
+        modernHeaders(method, name, versionHeader)
+        setBody(body)
+        extra()
+    }
+
+    private fun HttpRequestBuilder.modernHeaders(
+        method: String,
+        name: String?,
+        versionHeader: String = LATEST_MODERN_VERSION,
+    ) {
+        header(HttpHeaders.Host, "localhost")
+        header(HttpHeaders.Accept, "${ContentType.Application.Json}, ${ContentType.Text.EventStream}")
+        header("MCP-Protocol-Version", versionHeader)
+        header("Mcp-Method", method)
+        if (NAME_BEARING_METHODS.containsKey(method) && name != null) header("Mcp-Name", name)
+        contentType(ContentType.Application.Json)
+    }
+
+    private fun callTool(
+        name: String,
+        protocolVersion: String = LATEST_MODERN_VERSION,
+        logLevel: LoggingLevel? = null,
+    ): String {
+        val level = logLevel?.let { ""","io.modelcontextprotocol/logLevel":"${it.name.lowercase()}"""" }.orEmpty()
+        return """
+            {"jsonrpc":"2.0","id":1,"method":"tools/call",
+             "params":{"name":"$name","arguments":{},
+                       "_meta":{"io.modelcontextprotocol/protocolVersion":"$protocolVersion",
+                                "io.modelcontextprotocol/clientCapabilities":{}$level}}}
+        """.trimIndent()
+    }
+
+    private fun request(id: Int, method: String): String = """
+        {"jsonrpc":"2.0","id":$id,"method":"$method",
+         "params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"$LATEST_MODERN_VERSION",
+                            "io.modelcontextprotocol/clientCapabilities":{}}}}
+    """.trimIndent()
+
+    private suspend fun HttpResponse.errorCode(): Int = McpJson.decodeFromString<JSONRPCError>(bodyAsText()).error.code
+}

--- a/kotlin-sdk-server/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/StatelessStreamableHttpSessionLifecycleTest.kt
+++ b/kotlin-sdk-server/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/StatelessStreamableHttpSessionLifecycleTest.kt
@@ -17,7 +17,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import io.modelcontextprotocol.kotlin.sdk.types.InitializeRequest
 import io.modelcontextprotocol.kotlin.sdk.types.InitializeRequestParams
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCMessage
-import io.modelcontextprotocol.kotlin.sdk.types.LATEST_PROTOCOL_VERSION
+import io.modelcontextprotocol.kotlin.sdk.types.LATEST_HANDSHAKE_VERSION
 import io.modelcontextprotocol.kotlin.sdk.types.McpJson
 import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
 import io.modelcontextprotocol.kotlin.sdk.types.toJSON
@@ -89,7 +89,7 @@ class StatelessStreamableHttpSessionLifecycleTest {
     private fun initializeRequestBody(): String {
         val request = InitializeRequest(
             InitializeRequestParams(
-                protocolVersion = LATEST_PROTOCOL_VERSION,
+                protocolVersion = LATEST_HANDSHAKE_VERSION,
                 capabilities = ClientCapabilities(),
                 clientInfo = Implementation(name = "test-client", version = "1.0.0"),
             ),

--- a/kotlin-sdk-server/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/StreamableHttpServerTransportTest.kt
+++ b/kotlin-sdk-server/src/jvmTest/kotlin/io/modelcontextprotocol/kotlin/sdk/server/StreamableHttpServerTransportTest.kt
@@ -44,13 +44,14 @@ import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCError
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCMessage
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCRequest
 import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCResponse
-import io.modelcontextprotocol.kotlin.sdk.types.LATEST_PROTOCOL_VERSION
+import io.modelcontextprotocol.kotlin.sdk.types.LATEST_HANDSHAKE_VERSION
 import io.modelcontextprotocol.kotlin.sdk.types.ListResourcesResult
 import io.modelcontextprotocol.kotlin.sdk.types.ListToolsResult
 import io.modelcontextprotocol.kotlin.sdk.types.McpJson
 import io.modelcontextprotocol.kotlin.sdk.types.Method
 import io.modelcontextprotocol.kotlin.sdk.types.RPCError
 import io.modelcontextprotocol.kotlin.sdk.types.RequestId
+import io.modelcontextprotocol.kotlin.sdk.types.ResultMeta
 import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
 import io.modelcontextprotocol.kotlin.sdk.types.Tool
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
@@ -519,11 +520,11 @@ class StreamableHttpServerTransportTest {
             tools = listOf(
                 Tool(name = "tool-1", inputSchema = ToolSchema()),
             ),
-            meta = buildJsonObject { put("label", "first") },
+            meta = ResultMeta(buildJsonObject { put("label", "first") }),
         )
         val secondResult = ListResourcesResult(
             resources = emptyList(),
-            meta = buildJsonObject { put("label", "second") },
+            meta = ResultMeta(buildJsonObject { put("label", "second") }),
         )
 
         transport.onMessage { message ->
@@ -1040,7 +1041,7 @@ class StreamableHttpServerTransportTest {
             header(HttpHeaders.Host, "localhost")
             header(HttpHeaders.Accept, ContentType.Text.EventStream.toString())
             header(MCP_SESSION_ID_HEADER, sessionId)
-            header("mcp-protocol-version", LATEST_PROTOCOL_VERSION)
+            header("mcp-protocol-version", LATEST_HANDSHAKE_VERSION)
         }.execute { firstResponse ->
             firstResponse.status shouldBe HttpStatusCode.OK
             firstResponse.bodyAsChannel().readUTF8Line()
@@ -1051,7 +1052,7 @@ class StreamableHttpServerTransportTest {
                 header(HttpHeaders.Host, "localhost")
                 header(HttpHeaders.Accept, ContentType.Text.EventStream.toString())
                 header(MCP_SESSION_ID_HEADER, sessionId)
-                header("mcp-protocol-version", LATEST_PROTOCOL_VERSION)
+                header("mcp-protocol-version", LATEST_HANDSHAKE_VERSION)
             }.execute { secondResponse ->
                 secondResponse.status shouldBe HttpStatusCode.OK
                 secondResponse.headers[MCP_SESSION_ID_HEADER] shouldBe sessionId
@@ -1094,7 +1095,7 @@ class StreamableHttpServerTransportTest {
             header(HttpHeaders.Host, "localhost")
             header(HttpHeaders.Accept, ContentType.Text.EventStream.toString())
             header(MCP_SESSION_ID_HEADER, sessionId)
-            header("mcp-protocol-version", LATEST_PROTOCOL_VERSION)
+            header("mcp-protocol-version", LATEST_HANDSHAKE_VERSION)
         }.execute { response ->
             response.status shouldBe HttpStatusCode.OK
             response.bodyAsChannel().readLine()
@@ -1106,7 +1107,7 @@ class StreamableHttpServerTransportTest {
             header(HttpHeaders.Host, "localhost")
             header(HttpHeaders.Accept, ContentType.Text.EventStream.toString())
             header(MCP_SESSION_ID_HEADER, sessionId)
-            header("mcp-protocol-version", LATEST_PROTOCOL_VERSION)
+            header("mcp-protocol-version", LATEST_HANDSHAKE_VERSION)
         }.execute { response ->
             response.status shouldBe HttpStatusCode.OK
             response.headers[MCP_SESSION_ID_HEADER] shouldBe sessionId
@@ -1147,7 +1148,7 @@ class StreamableHttpServerTransportTest {
             header(HttpHeaders.Host, "localhost")
             header(HttpHeaders.Accept, ContentType.Text.EventStream.toString())
             header(MCP_SESSION_ID_HEADER, sessionId)
-            header("mcp-protocol-version", LATEST_PROTOCOL_VERSION)
+            header("mcp-protocol-version", LATEST_HANDSHAKE_VERSION)
         }.execute { response ->
             // Verify Mcp-Session-Id is present on the SSE response
             response.status shouldBe HttpStatusCode.OK
@@ -1184,7 +1185,7 @@ class StreamableHttpServerTransportTest {
     private fun buildInitializeRequestPayload(): JSONRPCRequest {
         val request = InitializeRequest(
             InitializeRequestParams(
-                protocolVersion = LATEST_PROTOCOL_VERSION,
+                protocolVersion = LATEST_HANDSHAKE_VERSION,
                 capabilities = ClientCapabilities(),
                 clientInfo = Implementation(name = "test-client", version = "1.0.0"),
             ),


### PR DESCRIPTION
Implements SEP-2575 alongside the legacy handshake era.
Closes #815

- Per-request `_meta` envelope; `resultType` on every result, cache hints (`ttlMs`/`cacheScope`)
- Error codes `-32020`/`-32021`/`-32022`; `-32002` no longer emitted
- `server/discover` (auto-registered); era-gated method registry
- Modern Streamable HTTP: POST-only, sessionless, deferred SSE commit
- Client version negotiation (Legacy/Auto/Pin) + opt-in response cache

## Breaking Changes
- `RequestResult.meta`: `JsonObject?` -> `ResultMeta?`; `resultType` added to result data classes
- `LATEST_PROTOCOL_VERSION` -> `2026-07-28`, `SUPPORTED_PROTOCOL_VERSIONS` deprecated
- Legacy-only methods answer `-32601` on modern connections

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
